### PR TITLE
Add breakpoints.json; breakpoints and maxWidths theme keys

### DIFF
--- a/breakpoints.js
+++ b/breakpoints.js
@@ -1,0 +1,10 @@
+const breakpoints = require('./breakpoints.json')
+const px = n => `${n}px`
+
+module.exports = {
+  breakpoints: Object.values(breakpoints).sort().map(px),
+  maxWidths: Object.entries(breakpoints).reduce((maxWidths, [key, n]) => {
+    maxWidths[key] = px(n)
+    return maxWidths
+  }, {})
+}

--- a/breakpoints.json
+++ b/breakpoints.json
@@ -1,0 +1,6 @@
+{
+  "small": 544,
+  "medium": 768,
+  "large": 1012,
+  "xlarge": 1280
+}

--- a/index.js
+++ b/index.js
@@ -1,10 +1,13 @@
 const colors = require('./colors')
 const space = require('./spacing')
 const {fontSizes, lineHeights} = require('./typography')
+const {breakpoints, maxWidths} = require('./breakpoints')
 
 module.exports = {
   colors,
   space,
   fontSizes,
-  lineHeights
+  lineHeights,
+  breakpoints,
+  maxWidths
 }


### PR DESCRIPTION
This ports over our breakpoints from primer/components. I've made the values in the `breakpoints.json` numbers and converted them to `px` CSS strings in `breakpoints.js` because it's nice to be able to access the "raw" values without having to strip off the trailing `px`.

### TODO
- [x] Add `breakpoints.json`
- [x] Add `breakpoints.js`
- [x] Add theme `breakpoints` and `maxWidths` keys
- [ ] Change base to `master` after merging #9