### PR TITLE
Add colors.pink 💕

### DIFF
--- a/primitives/colors.json
+++ b/primitives/colors.json
@@ -7,5 +7,6 @@
   "yellow": ["#fffdef", "#fffbdd", "#fff5b1", "#ffea7f", "#ffdf5d", "#ffd33d", "#f9c513", "#dbab09", "#b08800", "#735c0f"],
   "orange": ["#fff8f2", "#ffebda", "#ffd1ac", "#ffab70", "#fb8532", "#f66a0a", "#e36209", "#d15704", "#c24e00", "#a04100"],
   "red": ["#ffeef0", "#ffdce0", "#fdaeb7", "#f97583", "#ea4a5a", "#d73a49", "#cb2431", "#b31d28", "#9e1c23", "#86181d"],
-  "purple": ["#f5f0ff", "#e6dcfd", "#d1bcf9", "#b392f0", "#8a63d2", "#6f42c1", "#5a32a3", "#4c2889", "#3a1d6e", "#29134e"]
+  "purple": ["#f5f0ff", "#e6dcfd", "#d1bcf9", "#b392f0", "#8a63d2", "#6f42c1", "#5a32a3", "#4c2889", "#3a1d6e", "#29134e"],
+  "pink": ["#ffeef8", "#fedbf0", "#f9b3dd", "#f692ce", "#ec6cb9", "#ea4aaa", "#d03592", "#b93a86", "#99306f", "#6d224f]
 }


### PR DESCRIPTION
As defined in [Primer CSS](https://primer.style/css/support/color-system#pink):


name | value
--- | ---
$pink-000 | `#ffeef8`
$pink-100 | `#fedbf0`
$pink-200 | `#f9b3dd`
$pink-300 | `#f692ce`
$pink-400 | `#ec6cb9`
$pink-500 | `#ea4aaa`
$pink-600 | `#d03592`
$pink-700 | `#b93a86`
$pink-800 | `#99306f`
$pink-900 | `#6d224f`

