### PR TITLE
Refactor build script

### DIFF
--- a/data/colors/dark.scss
+++ b/data/colors/dark.scss
@@ -448,23 +448,19 @@ $export: (
   ),
 
   fade: (
-    black: (
-      10: $black-fade-10,
-      15: $black-fade-15,
-      30: $black-fade-30,
-      50: $black-fade-50,
-      70: $black-fade-70,
-      85: $black-fade-85,
-    ),
+    black-10: $black-fade-10,
+    black-15: $black-fade-15,
+    black-30: $black-fade-30,
+    black-50: $black-fade-50,
+    black-70: $black-fade-70,
+    black-85: $black-fade-85,
 
-    white: (
-      10: $white-fade-10,
-      15: $white-fade-15,
-      30: $white-fade-30,
-      50: $white-fade-50,
-      70: $white-fade-70,
-      85: $white-fade-85,
-    ),
+    white-10: $white-fade-10,
+    white-15: $white-fade-15,
+    white-30: $white-fade-30,
+    white-50: $white-fade-50,
+    white-70: $white-fade-70,
+    white-85: $white-fade-85,
   ),
 
   // Components

--- a/data/colors/light.scss
+++ b/data/colors/light.scss
@@ -448,23 +448,19 @@ $export: (
   ),
 
   fade: (
-    black: (
-      10: $black-fade-10,
-      15: $black-fade-15,
-      30: $black-fade-30,
-      50: $black-fade-50,
-      70: $black-fade-70,
-      85: $black-fade-85,
-    ),
+    black-10: $black-fade-10,
+    black-15: $black-fade-15,
+    black-30: $black-fade-30,
+    black-50: $black-fade-50,
+    black-70: $black-fade-70,
+    black-85: $black-fade-85,
 
-    white: (
-      10: $white-fade-10,
-      15: $white-fade-15,
-      30: $white-fade-30,
-      50: $white-fade-50,
-      70: $white-fade-70,
-      85: $white-fade-85,
-    ),
+    white-10: $white-fade-10,
+    white-15: $white-fade-15,
+    white-30: $white-fade-30,
+    white-50: $white-fade-50,
+    white-70: $white-fade-70,
+    white-85: $white-fade-85,
   ),
 
   // Components

--- a/package.json
+++ b/package.json
@@ -31,11 +31,13 @@
   "dependencies": {},
   "devDependencies": {
     "@types/chalk": "^2.2.0",
+    "@types/lodash": "^4.14.163",
     "@types/mkdirp": "^1.0.1",
     "@types/node": "^14.0.26",
     "camelcase-keys": "^6.2.2",
     "chalk": "^4.1.0",
     "deep-shape-equals": "^0.1.2",
+    "lodash": "^4.17.20",
     "mkdirp": "^1.0.4",
     "node-sass": "^4.14.1",
     "sass-extract": "^2.1.0",

--- a/script/build.ts
+++ b/script/build.ts
@@ -2,32 +2,22 @@ import fs from 'fs'
 import path from 'path'
 import mkdirp from 'mkdirp'
 import camelcaseKeys from 'camelcase-keys'
+import { Document } from 'sass-extract'
 import chalk from 'chalk'
-import { parseScssFile, collectVars, VariableCollection, ModeVariable } from './lib/scss'
+import { parseScssFile  } from './lib/scss'
+import ModeCollection from './lib/mode-collection'
 
-let SKIP: string[] = (process.env['PRIMER_SKIP'] || "").split(',')
-
-function flatMap<T, R>(array: T[], iter: (value: T, index: number, arr: T[]) => R[]): R[] {
-  var results: R[] = []
-
-  array.forEach((value, index, list) => {
-    var res = iter.call(null, value, index, list)
-    if (Array.isArray(res)) {
-      results.push.apply(results, res)
-    } else if (res != null) {
-      results.push(res)
-    }
-  })
-
-  return results;
-}
-
-interface ModeData {
+interface Skip {
   type: string
   name: string
-  vars: VariableCollection
-  prefix: string
 }
+
+let SKIP: Skip[] = (process.env['PRIMER_SKIP'] || "")
+  .split(',')
+  .map(skip => {
+    const [type, name] = skip.split('/')
+    return {type, name}
+  })
 
 const dataDir = path.join(__dirname, "..", "data")
 const outDir = path.join(__dirname, "..", "dist")
@@ -40,128 +30,111 @@ async function build() {
   const modeTypes = fs.readdirSync(dataDir)
 
   for (const type of modeTypes) {
-    let modes = await getModesForType(type)
-    modes = modes.filter(mode => !SKIP.includes(`${mode.type}/${mode.name}`))
+    const toSkip = SKIP.filter(skip => skip.type === type).map(skip => skip.name)
+    let collection = await getModeCollectionForType(type, toSkip)
 
-    const missingVars = getMissingVars(modes)
-    if (missingVars.length > 0) {
-      console.log(`\nInvalid modes for type '${type}'. The following variables are missing in one or more modes:\n`)
-      missingVars.forEach(v => console.log(v))
+    const {isValid, errors} = collection.validate()
+    if (!isValid) {
+      console.log(chalk.red`\n===============================================`)
+      console.log(chalk`{red [FATAL]} The build failed due to the following errors:`)
+      for (const err of errors) {
+        console.log(err)
+      }
+      console.log(chalk.red`===============================================`)
       console.log("")
       process.exit(1)
     }
 
-    for (const mode of modes) {
-      const cssVarValues = mode.vars.flattened().filter(v => typeof v.value === 'string' && v.value.startsWith('var(--'))
-      if (cssVarValues.length > 0) {
-        const missingCssRefs = cssVarValues.map(v => ` - ${v.name} -> ${v.value}`).join('\n')
-        console.log(`\nMode ${type}.${mode.name} has unresolved CSS variable references:\n${missingCssRefs}`)
-        console.log('Check to make sure your CSS variable references do not form an infinite loop')
-        process.exit(1)
-      }
-    }
-
-    await writeModeOutput(type, modes)
+    await writeModeOutput(collection)
   }
 
   await writeMainTsIndex(modeTypes)
 }
 
-async function getModesForType(type: string): Promise<ReadonlyArray<ModeData>> {
+async function getModeCollectionForType(type: string, toSkip: string[]): Promise<ModeCollection> {
   const filenames = fs.readdirSync(path.join(dataDir, type))
     .map(file => path.join(dataDir, type, file))
     .filter(file => file.endsWith('.scss'))
 
-  return Promise.all(filenames.map(async (file) => {
+  let prefix = type
+  const prefixFile = path.join(dataDir, type, "prefix")
+  if (fs.existsSync(prefixFile)) {
+    prefix = fs.readFileSync(prefixFile, "utf8").trim()
+  }
+
+  const collection = new ModeCollection(type, prefix)
+
+  const renderedScss: [string, Document][] = await Promise.all(filenames.map(async (file) => {
     const name = path.basename(file, ".scss")
     const rendered = await parseScssFile(file)
-    let prefix = `${type}`
-    const prefixFile = path.join(dataDir, type, "prefix")
-    if (fs.existsSync(prefixFile)) {
-      prefix = fs.readFileSync(prefixFile, "utf8").trim()
-    }
-    const vars = collectVars(prefix, rendered.vars.global.$export)
-    return { type, name, vars, prefix }
+
+    return [name, rendered] as [string, Document]
   }))
-}
 
-function getMissingVars(modes: ReadonlyArray<ModeData>): Array<string> {
-  if (modes.length === 1) {
-    return []
-  }
-
-  const missingVars = []
-
-  const allVarsPerMode = modes.reduce((acc, mode) => {
-    const allVars = mode.vars.flattened()
-    acc[mode.name] = allVars
-    return acc
-  }, {} as Record<string, ReadonlyArray<ModeVariable>>)
-
-  const allVarNames = flatMap((modes as Array<ModeData>), mode => {
-    return mode.vars.flattened().map(v => v.name)
-  })
-  const uniqueVarNames = [...new Set(allVarNames)].sort()
-
-  for (const v of uniqueVarNames.values()) {
-    const missingModes = modes.filter(mode => !(allVarsPerMode[mode.name].find(item => item.name === v))).map(mode => mode.name)
-    if (missingModes.length > 0) {
-      const msg = chalk`Variable {bold ${v}} is missing in modes: ${missingModes.map(str => chalk.bold(str)).join(', ')}`
-      missingVars.push(msg)
+  for (const [name, rendered] of renderedScss) {
+    if (toSkip.includes(name)) {
+      continue
     }
+
+    collection.addFromSassExports(name, rendered.vars.global.$export)
   }
 
-  return missingVars
+  return collection
 }
 
-async function writeModeOutput(type: string, modes: ReadonlyArray<ModeData>): Promise<void> {
-  for (const mode of modes) {
-    writeScssOutput(mode)
-    writeTsOutput(mode)
-    writeJsonOutput(mode)
+async function writeModeOutput(collection: ModeCollection): Promise<void> {
+  writeScssOutput(collection)
+  writeTsOutput(collection)
+  writeJsonOutput(collection)
+
+  writeTsTypeIndex(collection)
+}
+
+async function writeScssOutput(collection: ModeCollection): Promise<void> {
+  for (const [_name, vars] of collection) {
+    let output = `@mixin primer-${collection.type}-${vars.name} {\n`
+    output += "  & {\n"
+    for (const variable of vars) {
+      output += `    --${variable.name}: ${variable.value};\n`
+    }
+    output += '  }\n}\n'
+
+    const dir = path.join(scssDir, collection.type)
+    await mkdirp(dir)
+    fs.writeFileSync(path.join(dir, `_${vars.name}.scss`), output)
   }
-
-  writeTsTypeIndex(type, modes.map(m => m.name))
 }
 
-async function writeScssOutput(mode: ModeData): Promise<void> {
-  let output = `@mixin primer-${mode.type}-${mode.name} {\n`
-  output += "  & {\n"
-  for (const variable of mode.vars) {
-    output += `    --${variable.name}: ${variable.value};\n`
+async function writeTsOutput(collection: ModeCollection): Promise<void> {
+  for (const [_name, vars] of collection) {
+    let output = JSON.stringify(camelcaseKeys(vars.tree(), {deep: true}), null, '  ')
+    output = `export default ${output}`
+
+    const dir = path.join(tsDir, collection.type)
+    await mkdirp(dir)
+    fs.writeFileSync(path.join(dir, `${vars.name}.ts`), output)
   }
-  output += '  }\n}\n'
-
-  const dir = path.join(scssDir, mode.type)
-  await mkdirp(dir)
-  fs.writeFileSync(path.join(dir, `_${mode.name}.scss`), output)
 }
 
-async function writeTsOutput(mode: ModeData): Promise<void> {
-  let output = JSON.stringify(camelcaseKeys(mode.vars.tree(), {deep: true}), null, '  ')
-  output = `export default ${output}`
+async function writeJsonOutput(collection: ModeCollection): Promise<void> {
+  for (const [_name, vars] of collection) {
+    let output = JSON.stringify(camelcaseKeys(vars.tree(), {deep: true}), null, '  ')
 
-  const dir = path.join(tsDir, mode.type)
-  await mkdirp(dir)
-  fs.writeFileSync(path.join(dir, `${mode.name}.ts`), output)
+    const dir = path.join(jsonDir, collection.type)
+    await mkdirp(dir)
+    fs.writeFileSync(path.join(dir, `${vars.name}.json`), output)
+  }
 }
 
-async function writeJsonOutput(mode: ModeData): Promise<void> {
-  let output = JSON.stringify(camelcaseKeys(mode.vars.tree(), {deep: true}), null, '  ')
-
-  const dir = path.join(jsonDir, mode.type)
-  await mkdirp(dir)
-  fs.writeFileSync(path.join(dir, `${mode.name}.json`), output)
-}
-
-async function writeTsTypeIndex(type: string, modules: string[]) {
+async function writeTsTypeIndex(collection: ModeCollection) {
   let output = ''
+  const modules = [...collection.modes.keys()]
   for (const mod of modules) {
     output += `import ${mod} from './${mod}'\n`
   }
   output += `export default { ${modules.join(', ')} }`
 
-  const dir = path.join(tsDir, type)
+  const dir = path.join(tsDir, collection.type)
   await mkdirp(dir)
   fs.writeFileSync(path.join(dir, `index.ts`), output)
 }
@@ -180,6 +153,6 @@ async function writeMainTsIndex(types: string[]) {
 
 if (require.main === module) {
   build()
-    .then(() => console.log("Built mode data"))
+    .then(() => console.log("✨ Built mode data 🎉"))
     .catch(err => console.error(err))
 }

--- a/script/lib/mode-collection.ts
+++ b/script/lib/mode-collection.ts
@@ -1,0 +1,95 @@
+import flatMap from "lodash/flatMap";
+import chalk from "chalk";
+import VariableCollection from "./variable-collection";
+import { SassMap } from "./scss";
+
+export default class ModeCollection {
+  public readonly type: string
+  public readonly prefix: string
+  public readonly modes: Map<string, VariableCollection> = new Map()
+
+  constructor(type: string, prefix: string) {
+    this.type = type
+    this.prefix = prefix
+  }
+
+  public addFromSassExports(name: string, data: SassMap) {
+    const vars = new VariableCollection(name, this.prefix)
+    vars.addFromSassExports(data)
+    this.add(name, vars)
+  }
+
+  public add(modeName: string, vars: VariableCollection) {
+    this.modes.set(modeName, vars)
+  }
+
+  public validate(): {isValid: boolean, errors: string[]} {
+    const errors = []
+
+    // Ensure that every mode in this collection has the same variables defined
+    const missingVarsPerMode = this.getMissingVarsPerMode()
+    if (missingVarsPerMode.length > 0) {
+      errors.push(`\n> The following variables are missing in one or more modes:\n`)
+      for (const {modes, variableName} of missingVarsPerMode) {
+        const msg = chalk`* Variable {bold.red ${variableName}} is missing in modes: ${modes.map(mode => chalk.bold.bgBlack.white(mode.name)).join(', ')}`
+        errors.push(msg)
+      }
+    }
+
+    // Ensure that any variables with late-binding to
+    // other CSS variables defined inside the same file can be resolved
+    const unresolvableBindings = this.getUnresolvableLateBindings()
+    if (unresolvableBindings.length > 0) {
+      errors.push(`\n> The following CSS variables were referenced as values but could not be resolved at build-time:\n`)
+      for (const {ref, from, mode} of unresolvableBindings) {
+        const msg = chalk`* Variable {bold.red var(--${ref})} referenced by {bold.bgBlack.white ${from}} in mode {bold.bgBlack.white ${mode.name}}`
+        errors.push(msg)
+      }
+      errors.push(`Check to make sure CSS variable references do not create an infinite loop.`)
+    }
+
+    return {isValid: errors.length === 0, errors}
+  }
+
+  public [Symbol.iterator]() {
+    return this.modes[Symbol.iterator]()
+  }
+
+  private getMissingVarsPerMode(): {modes: VariableCollection[], variableName: string}[] {
+    if (this.modes.size === 1) {
+      return []
+    }
+
+    const result: {modes: VariableCollection[], variableName: string}[] = []
+    const modes = [...this.modes.values()]
+
+    const allVarNames = flatMap(modes, mode => {
+      return mode.flattened().map(v => v.name)
+    })
+    const uniqueVarNames = [...new Set(allVarNames)].sort()
+
+    for (const v of uniqueVarNames.values()) {
+      const missingModes = modes.filter(mode => mode.getByName(v) === undefined)
+      if (missingModes.length > 0) {
+        result.push({modes: missingModes, variableName: v})
+      }
+    }
+
+    return result
+  }
+
+  private getUnresolvableLateBindings(): {mode: VariableCollection, from: string, ref: string}[] {
+    const result: {mode: VariableCollection, from: string, ref: string}[] = []
+
+    for (const [_name, mode] of this.modes) {
+      const lateBindings = mode.flattened().filter(v => !!v.ref)
+      for (const v of lateBindings) {
+        if (!mode.resolveRef(v.ref!)) {
+          result.push({mode, from: v.name, ref: v.ref!})
+        }
+      }
+    }
+
+    return result
+  }
+}

--- a/script/lib/scss.ts
+++ b/script/lib/scss.ts
@@ -40,162 +40,12 @@ export interface SassMapValue {
   [key: string]: SassValue
 }
 
-export interface ModeVariable {
-  name: string
-  path: string[]
-  value: any
-}
-
-type PendingVar = {name: string, fullName: string, context: Record<string, any>}
-
-export class VariableCollection {
-  private _type: string
-  private _prefix: string[]
-  private _pending: Map<string, PendingVar[]> = new Map()
-  private _data: Record<string, any> = {}
-  private _flat: ModeVariable[] = []
-
-  constructor(type: string, prefix: string[] = []) {
-    this._type = type
-    this._prefix = prefix
-  }
-
-  public add(name: string, value: any) {
-    const fullPath = [this._type, ...this._prefix, name]
-    const fullName = fullPath.join('-')
-
-    this._data[name] = value
-
-    // If the value is a CSS variable, we need to resolve it to
-    // its value for non-CSS clients. If we've already set it, just
-    // get it from the flat cache. Otherwise set a pending flag
-    // and wait until we see it.
-    if (typeof value === 'string' && value.startsWith('var(--')) {
-      const [_, match] = value.match(/var\(--(.*)\)/)!
-      const found = this._flat.find(item => item.name === match)
-      if (found) {
-        this._data[name] = found.value
-      } else {
-        this.addPending(name, fullName, this._data, match)
-      }
-    }
-
-    if (value instanceof VariableCollection) {
-      this.mergeChildCollection(value)
-    } else if (Array.isArray(value)) {
-      for (const i in value) {
-        const item = {name: `${fullName}-${i}`, path: [...fullPath, i], value: value[i]}
-        this._flat.push(item)
-        this.resolvePending(item)
-      }
-    } else {
-      const item = {name: fullName, path: fullPath, value}
-      this._flat.push(item)
-      this.resolvePending(item)
-    }
-  }
-
-  public flattened(): ReadonlyArray<ModeVariable> {
-    return this._flat
-  }
-
-  public tree(): Readonly<Record<string, any>> {
-    let output = {} as Record<string, any>
-
-    for (const key of Object.keys(this._data)) {
-      const val = this._data[key]
-      if (this._data[key] instanceof VariableCollection) {
-        output[key] = val.tree()
-      } else {
-        output[key] = val
-      }
-    }
-
-    return output
-  }
-
-  public get pending() {
-    return this._pending
-  }
-
-  public [Symbol.iterator]() {
-    return this.flattened()[Symbol.iterator]()
-  }
-
-  private mergeChildCollection(other: VariableCollection) {
-    this.mergePending(other.pending)
-    this._flat = this._flat.concat(other.flattened())
-    this._flat.forEach(this.resolvePending.bind(this))
-  }
-
-  private mergePending(otherPending: Map<string, PendingVar[]>) {
-    for (const [key, arr] of otherPending.entries()) {
-      for (const item of arr) {
-        this.addPending(item.name, item.fullName, item.context, key)
-      }
-    }
-  }
-
-  private addPending(name: string, fullName: string, context: Record<string, any>, search: string) {
-    const val = {name, fullName, context}
-
-    if (this._pending.has(search)) {
-      const arr = this._pending.get(search)!
-      arr.push(val)
-    } else {
-      this._pending.set(search, [val])
-    }
-  }
-
-  private resolvePending(variable: ModeVariable) {
-    const item = this._pending.get(variable.name)
-    if (item) {
-      const val = variable.value
-      item.forEach(({name, fullName, context}) => {
-        context[name] = val
-        const flatItem = this._flat.find(item => item.name === fullName)
-        if (flatItem) {
-          flatItem.value = val
-        }
-      })
-
-      this._pending.delete(variable.name)
-    }
-  }
-}
-
 export async function parseScssFile(file: string): Promise<Document> {
   const { vars } = await renderSass({ file })
   return { vars }
 }
 
-export function collectVars(type: string, data: SassMap, prefix: string[] = []): VariableCollection {
-  let output = new VariableCollection(type, prefix)
-
-  for (let key of Object.keys(data.value)) {
-    if (key === 'grey') {
-      // [MKT] SCSS seems to automatically change `gray` to `grey` during parsing ???
-      data.value['gray'] = data.value['grey']
-      delete data.value['grey']
-      key = 'gray'
-    }
-    const val = data.value[key]
-    if (val.type === 'SassColor' || val.type === 'SassNumber' || val.type === 'SassString') {
-      output.add(key, stringifySassPrimitive(val))
-    } else if (val.type === 'SassList' && isSassListHomogeneous(val)) {
-      output.add(key, val.value.map(stringifySassPrimitive))
-    } else if (val.type === 'SassList') {
-      output.add(key, val.value.map(stringifySassPrimitive).join(" "))
-    } else if (val.type === 'SassMap') {
-      const obj = collectVars(type, val, [...prefix, key])
-      output.add(key, obj)
-    }
-  }
-
-  return output
-}
-
-function stringifySassPrimitive(val: SassValue): string {
+export function stringifySassPrimitive(val: SassValue): string {
   switch (val.type) {
     case 'SassColor': return sassColorToString(val.value)
     case 'SassNumber': return `${val.value}${val.unit}`
@@ -208,8 +58,19 @@ function sassColorToString({r, g, b, a, hex}: SassColorValue): string {
   return a === 1 ? hex : `rgba(${r},${g},${b},${a})`
 }
 
-function isSassListHomogeneous(val: SassList) {
-  const firstType = val.value[0].type
+export function renderSassList(val: SassList): string | string[] {
+  // A homogeneous Sass list means the list is probably a list of values,
+  // e.g. a list of colors in a scale. Otherwise, it is likely a list
+  // of CSS primitives, like `inset 0 1px 0 black`, and should be
+  // joined into a single string value.
+  if (isSassListHomogeneous(val)) {
+    return val.value.map(stringifySassPrimitive)
+  } else {
+    return val.value.map(stringifySassPrimitive).join(" ")
+  }
+}
 
+export function isSassListHomogeneous(val: SassList) {
+  const firstType = val.value[0].type
   return val.value.every(item => item.type === firstType)
 }

--- a/script/lib/variable-collection.ts
+++ b/script/lib/variable-collection.ts
@@ -1,0 +1,141 @@
+import set from 'lodash/set'
+import chalk from 'chalk'
+import { SassMap, stringifySassPrimitive, renderSassList } from "./scss"
+
+function exhaustiveCheck(anything: never) {}
+
+type PathItem = string | number
+
+export interface ModeVariable {
+  name: string
+  path: PathItem[]
+  value: any
+  ref: string | null
+}
+
+const CSS_VAR_REGEX = /var\(--(.*)\)/
+
+export default class VariableCollection {
+  public readonly name: string
+  public readonly prefix: string
+  private data: Map<string, ModeVariable> = new Map()
+
+  constructor(name: string, prefix: string) {
+    this.name = name
+    this.prefix = prefix
+  }
+
+  public addFromSassExports(data: SassMap) {
+    this.iterateVarsFromSassExports(data, (path: PathItem[], value: any) => {
+      this.add(path, value)
+    })
+  }
+
+  private iterateVarsFromSassExports(data: SassMap, callback: (path: PathItem[], value: any) => void, path: string[] = []) {
+    for (let key of Object.keys(data.value)) {
+      // [MKT] Numeric keys for Sass maps are not supported due to
+      // lookup semantics in non-CSS projects (like Primer React)
+      if (!isNaN(Number(key))) {
+        console.log(chalk`{bold.red [FATAL]} Map keys cannot be numeric; found numeric key {bold.red ${key}} in ${path.join('-')}-${key} in mode ${this.name}`)
+        process.exit(1)
+      }
+
+      if (key === 'grey') {
+        // [MKT] The Sass parser seems to automatically change `gray` to `grey` during parsing???
+        // Thanks Sass, but we'll keep our original spelling.
+        data.value['gray'] = data.value['grey']
+        delete data.value['grey']
+        key = 'gray'
+      }
+
+      const newPath = [...path, key]
+      const val = data.value[key]
+      switch (val.type) {
+        case 'SassColor':
+        case 'SassNumber':
+        case 'SassString':
+          callback(newPath, stringifySassPrimitive(val))
+          break
+        case 'SassList':
+          callback(newPath, renderSassList(val))
+          break
+        case 'SassMap':
+          this.iterateVarsFromSassExports(val, callback, newPath)
+          break
+        default:
+          exhaustiveCheck(val)
+      }
+    }
+  }
+
+  public add(path: PathItem[], value: any) {
+    if (Array.isArray(value)) {
+      for (const idx in value) {
+        const newPath = [...path, idx]
+        this.add(newPath, value[idx])
+      }
+
+      return
+    }
+
+    const fullName = [this.prefix, ...path].join('-')
+    const variable: ModeVariable = {name: fullName, path, value, ref: null}
+
+    // If the value is a CSS variable, we need to set a ref
+    // so that it gets lazy-evaluated during validation and compilation.
+    if (typeof value === 'string' && value.match(CSS_VAR_REGEX)) {
+      const [_, needle] = value.match(CSS_VAR_REGEX)!
+      variable.ref = needle!
+    }
+
+    this.data.set(fullName, variable)
+  }
+
+  public flattened(): ReadonlyArray<ModeVariable> {
+    return [...this.data.values()].map((variable) => {
+      return {
+        ...variable,
+        value: variable.ref ? this.resolveRef(variable.ref) : variable.value
+      }
+    })
+  }
+
+  public getByName(fullName: string): ModeVariable | undefined {
+    return this.data.get(fullName)
+  }
+
+  public resolveRef(fullName: string, checked = new Set<string>()): any {
+    // Prevent blowing the stack from reference loops
+    if (checked.has(fullName)) {
+      return undefined
+    }
+    checked.add(fullName)
+
+    const mappedVariable = this.data.get(fullName)
+
+    if (!mappedVariable) {
+      return undefined
+    }
+
+    if (mappedVariable.ref) {
+      return this.resolveRef(mappedVariable.ref, checked)
+    } else {
+      return mappedVariable.value
+    }
+  }
+
+  public tree(): Readonly<Record<string, any>> {
+    let output = {} as Record<string, any>
+
+    for (const variable of this.data.values()) {
+      const value = variable.ref ? this.resolveRef(variable.ref) : variable.value
+      set(output, variable.path, value)
+    }
+
+    return output
+  }
+
+  public [Symbol.iterator]() {
+    return this.flattened()[Symbol.iterator]()
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,6 +14,11 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/lodash@^4.14.163":
+  version "4.14.163"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.163.tgz#6026f73c8267a0b7d41c7c8aadacfa2a5255774f"
+  integrity sha512-BeZM/FZaV53emqyHxn9L39Oz6XbHMBRLA1b1quROku48J/1kYYxPmVOJ/qSQheb81on4BI7H6QDo6bkUuRaDNQ==
+
 "@types/mkdirp@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-1.0.1.tgz#0930b948914a78587de35458b86c907b6e98bbf6"
@@ -683,7 +688,7 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash@^4.0.0, lodash@^4.17.15, lodash@~4.17.10:
+lodash@^4.0.0, lodash@^4.17.15, lodash@^4.17.20, lodash@~4.17.10:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==


### PR DESCRIPTION
This PR significantly refactors the build script so that it is much easier to work with and understand. It also improves error output in the case something goes wrong:

<img width="772" alt="image" src="https://user-images.githubusercontent.com/189606/97487199-c54d8200-1919-11eb-8114-b88eb839bc92.png">

Finally, I realized that having numeric keys like the ones in the fades:

```sass
  fade: (
    black: (
      10: $black-fade-10,
      15: $black-fade-15,
      30: $black-fade-30,
      50: $black-fade-50,
      70: $black-fade-70,
      85: $black-fade-85,
    ),

    white: (
      10: $white-fade-10,
      15: $white-fade-15,
      30: $white-fade-30,
      50: $white-fade-50,
      70: $white-fade-70,
      85: $white-fade-85,
    ),
  ),
```

can't be supported as referencing a value with a number in non-CSS clients (like Primer React) treats the value like an array. To fix this, I've updated the styles to include the number as part of the name:

```scss
  fade: (
    black-10: $black-fade-10,
    black-15: $black-fade-15,
    black-30: $black-fade-30,
    black-50: $black-fade-50,
    black-70: $black-fade-70,
    black-85: $black-fade-85,

    white-10: $white-fade-10,
    white-15: $white-fade-15,
    white-30: $white-fade-30,
    white-50: $white-fade-50,
    white-70: $white-fade-70,
    white-85: $white-fade-85,
  ),
```

The variable names will be the same in CSS, and in JS they can be referenced as `fade.black10` etc.