### PR TITLE
Build CSV output

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,3 +22,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+      
+      - uses: actions/download-artifact@master
+        with:
+          name: primitives
+          path: ./dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,8 +22,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-      
-      - uses: actions/download-artifact@master
+
+      - uses: actions/upload-artifact@v2
         with:
           name: primitives
           path: ./dist

--- a/script/build.ts
+++ b/script/build.ts
@@ -25,6 +25,7 @@ const outDir = path.join(__dirname, "..", "dist")
 const scssDir = path.join(outDir, "scss")
 const tsDir = path.join(outDir, "ts")
 const jsonDir = path.join(outDir, "json")
+const csvDir = path.join(outDir, "csv")
 
 async function build() {
   const modeTypes = fs.readdirSync(dataDir)
@@ -86,6 +87,7 @@ async function writeModeOutput(collection: ModeCollection): Promise<void> {
   writeScssOutput(collection)
   writeTsOutput(collection)
   writeJsonOutput(collection)
+  writeCsvOutput(collection)
 
   writeTsTypeIndex(collection)
 }
@@ -149,6 +151,21 @@ async function writeMainTsIndex(types: string[]) {
   const dir = path.join(tsDir)
   await mkdirp(dir)
   fs.writeFileSync(path.join(dir, `index.ts`), output)
+}
+
+async function writeCsvOutput(collection: ModeCollection): Promise<void> {
+  const data: any = {}
+  for (const [_name, vars] of collection) {
+    console.log(_name)
+    vars.flattened().forEach((value) => {
+      const key = value.path.join('/')
+      data[key] = data[key] ? {...data[key], [_name]: value.value} : {key, [_name]: value.value}
+    })
+  }
+  let output: any = Object.keys(Object.values(data)[0] as object).join('\t') + '\n'
+  output += Object.values(data).map((value: any) => Object.values(value).join('\t')).join('\n')
+  await mkdirp(csvDir)
+  fs.writeFileSync(path.join(csvDir, `${collection.type}.csv`), output)
 }
 
 if (require.main === module) {


### PR DESCRIPTION
This PR updates the build script to build CSVs. This will make it easier to import primitives into Figma.

cc @ashygee 