### PR TITLE
Add colors for unverified-badge

### DIFF
--- a/data/colors/mixins/dark_mode.scss
+++ b/data/colors/mixins/dark_mode.scss
@@ -507,6 +507,12 @@ $export: (
     border: rgba($green-3, 0.4),
   ),
 
+  unverified-badge: (
+    text: $yellow-2,
+    bg: rgba($yellow-2, 0.1),
+    border: rgba($yellow-2, 0.4),
+  ),
+
   social-count: (
     bg: $gray-7,
   ),

--- a/data/colors/mixins/light_mode.scss
+++ b/data/colors/mixins/light_mode.scss
@@ -507,6 +507,12 @@ $export: (
     border: $gray-2,
   ),
 
+  unverified-badge: (
+    text: $yellow-8,
+    bg: $white,
+    border: $gray-2,
+  ),
+
   social-count: (
     bg: $white,
   ),


### PR DESCRIPTION
This Pull request is to add colors to the `unverified-badge` associated with commits

This corresponds with https://github.com/github/coding/issues/534

See https://github.com/github/coding/issues/513 for full details