### PR TITLE
Update bg-canvas-inset + input-contrast-bg

### DIFF
--- a/data/colors/mixins/dark_mode.scss
+++ b/data/colors/mixins/dark_mode.scss
@@ -45,7 +45,7 @@ $export: (
     canvas: $gray-9,
     canvas-mobile: $black,
     canvas-inverse: $gray-0,
-    canvas-inset: #06090F,
+    canvas-inset: darken($gray-9, 2%),
     primary: $gray-9,
     secondary: $gray-9,
     tertiary: $gray-8,
@@ -320,7 +320,7 @@ $export: (
 
   input: (
     bg: $gray-9,
-    contrast-bg: rgba(#010409, 0.3),
+    contrast-bg: rgba($black, 0.5),
     border: $gray-7,
     shadow: 0 0 transparent,
 


### PR DESCRIPTION
This updates the hex values of `bg-canvas-inset` and `input-contrast-bg`:

- `bg-canvas-inset` from `#06090F` to `darken($gray-9, 2%)`.
- `input-contrast-bg` from `rgba(#010409, 0.3)` to `rgba($black, 0.5)`.

This makes the colors "relative" and they should adapt to the lighter `bg-canvas` in the dimmed theme. For the dark theme the difference is hard to notice. So maybe fine until V2.

Theme | Before | After
--- | ---  | ---
Dark Dimmed | ![Screen Shot 2021-03-15 at 12 23 37](https://user-images.githubusercontent.com/378023/111106773-0f699400-8599-11eb-8b7d-da0975178e49.png) | ![Screen Shot 2021-03-15 at 14 00 35](https://user-images.githubusercontent.com/378023/111106777-11cbee00-8599-11eb-8a32-7d8277d5f73a.png)
Dark | ![before](https://user-images.githubusercontent.com/378023/111106779-12fd1b00-8599-11eb-806b-a0dc89af45ce.png) | ![after](https://user-images.githubusercontent.com/378023/111106778-12648480-8599-11eb-9650-daf566b21583.png)

This came up in the dimmed feedback discussion:

- https://github.com/github/github/discussions/172940#discussioncomment-465469
- https://github.com/github/github/discussions/172940#discussioncomment-466447