### PR TITLE
Invert tooltips in dark mode

### DIFF
--- a/data/colors/mixins/dark_mode.scss
+++ b/data/colors/mixins/dark_mode.scss
@@ -512,8 +512,8 @@ $export: (
   ),
 
   tooltip: (
-    text: $gray-9,
-    bg: $gray-0,
+    text: $white,
+    bg: $gray-4,
   ),
 
   header-search: (

--- a/data/colors/mixins/dark_mode.scss
+++ b/data/colors/mixins/dark_mode.scss
@@ -512,8 +512,8 @@ $export: (
   ),
 
   tooltip: (
-    text: $white,
-    bg: $gray-7,
+    text: $gray-9,
+    bg: $gray-0,
   ),
 
   header-search: (


### PR DESCRIPTION
This changes the tooltips to be inverted in dark mode.

Before | After
--- | ---
![Screen Shot 2021-03-17 at 11 08 13](https://user-images.githubusercontent.com/378023/111404540-431bf980-8712-11eb-8a20-bc93d4c4b46b.png) | ![Screen Shot 2021-03-17 at 11 00 04](https://user-images.githubusercontent.com/378023/111404536-41523600-8712-11eb-904f-fb38b231522b.png)

It solves the problem where a tooltip is used on top of another "overlay" and becomes invisible. Using a light background might be fine since tooltips are small and only visible on hover.