### PR TITLE
Update dark `bg-overlay`

### DIFF
--- a/data/colors/mixins/dark_mode.scss
+++ b/data/colors/mixins/dark_mode.scss
@@ -49,7 +49,7 @@ $export: (
     primary: $gray-9,
     secondary: $gray-9,
     tertiary: $gray-8,
-    overlay: $gray-7,
+    overlay: $gray-8,
     backdrop: rgba($black, 0.8),
     info: rgba($blue-4, 0.1),
     info-inverse: $blue-4,


### PR DESCRIPTION
This is part of https://github.com/github/design-systems/issues/1353 and update the [`bg-overlay`](https://github.com/primer/primitives/blob/7d9fc7d7e2eb4a673797ff88f28a18fda93e6aac/data/colors/mixins/dark_mode.scss#L52) from `$gray-7` to `$gray-8`. This change should make the text color have more contrast:

`$gray-7` | `$gray-8`
--- | ---
![Screen Shot 2021-03-24 at 19 28 36](https://user-images.githubusercontent.com/378023/112297866-ba84f680-8cd9-11eb-970f-86d2000172c3.png) | ![Screen Shot 2021-03-24 at 19 28 52](https://user-images.githubusercontent.com/378023/112297878-bc4eba00-8cd9-11eb-83d0-1fd7b5d0cbc7.png)
![Screen Shot 2021-03-24 at 19 29 21](https://user-images.githubusercontent.com/378023/112297879-bce75080-8cd9-11eb-9b21-adc7467699c3.png) | ![Screen Shot 2021-03-24 at 19 29 42](https://user-images.githubusercontent.com/378023/112297883-bd7fe700-8cd9-11eb-8c73-832c4498981e.png)

We might can revisit this in v2, but maybe fine as a quick fix.