### PR TITLE
Underlinenav-counter-bg

### DIFF
--- a/.changeset/quiet-trainers-dance.md
+++ b/.changeset/quiet-trainers-dance.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Adding variable for Underlinenav-counter-bg

--- a/data/colors/mixins/dark_mode.scss
+++ b/data/colors/mixins/dark_mode.scss
@@ -500,6 +500,7 @@ $export: (
     icon-hover: $gray-1,
     icon-active: $gray-1,
     counter-text: $gray-3,
+    counter-bg: rgba($gray-3, 0.2),
   ),
 
   verified-badge: (

--- a/data/colors/mixins/light_mode.scss
+++ b/data/colors/mixins/light_mode.scss
@@ -500,6 +500,7 @@ $export: (
     icon-hover: $gray-4,
     icon-active: $gray-9,
     counter-text: $gray-9,
+    counter-bg: var(--color-counter-bg),
   ),
 
   verified-badge: (


### PR DESCRIPTION
This adds a `underlinenav-counter-bg` variable to increase contrast in dark mode:

Before `$gray-6` | After `rgba($gray-3, 0.2)`
--- | ---
![Screen Shot 2021-03-25 at 17 36 56](https://user-images.githubusercontent.com/378023/112444666-a3a1db00-8d91-11eb-8ab2-2b5e9b7926c8.png) | ![Screen Shot 2021-03-25 at 17 37 29](https://user-images.githubusercontent.com/378023/112444673-a56b9e80-8d91-11eb-96a3-44c45e81d32c.png)
![Screen Shot 2021-03-25 at 17 40 16](https://user-images.githubusercontent.com/378023/112444674-a6043500-8d91-11eb-85f0-170e0da67913.png) | ![Screen Shot 2021-03-25 at 17 40 35](https://user-images.githubusercontent.com/378023/112444677-a69ccb80-8d91-11eb-998b-8cfe187a2fd0.png)

It's based on this test https://github.com/github/design-systems/issues/1353#issuecomment-806472790.