### PR TITLE
Revert "Update bg-overlay"

### DIFF
--- a/.changeset/pink-insects-drum.md
+++ b/.changeset/pink-insects-drum.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Revert "Update bg-overlay"

--- a/data/colors/mixins/dark_mode.scss
+++ b/data/colors/mixins/dark_mode.scss
@@ -49,7 +49,7 @@ $export: (
     primary: $gray-9,
     secondary: $gray-9,
     tertiary: $gray-8,
-    overlay: $gray-8,
+    overlay: $gray-7,
     backdrop: rgba($black, 0.8),
     info: rgba($blue-4, 0.1),
     info-inverse: $blue-4,


### PR DESCRIPTION
This reverts https://github.com/primer/primitives/pull/50 again.

Changing the `bg-overlay` from `$gray-7` to `$gray-8` has the unintended side effect of clashing with `state-hover-secondary-bg` that also uses [`$gray-8`](https://github.com/primer/primitives/blob/7d9fc7d7e2eb4a673797ff88f28a18fda93e6aac/data/colors/mixins/dark_mode.scss#L80) and makes it invisible in overlays:

![hover](https://user-images.githubusercontent.com/378023/112597593-a6afd080-8e50-11eb-9a71-f021a242ea59.gif)

I guess we could add another variable like `state-overlay-hover-bg`, but there is also the suggestion to keep `$gray-7`:  https://github.com/github/github/discussions/172940#discussioncomment-530538. So this is just a quick fix.