### PR TITLE
Add `counter-secondary-bg`

### DIFF
--- a/.changeset/moody-lobsters-roll.md
+++ b/.changeset/moody-lobsters-roll.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": minor
+---
+
+Add `counter-secondary-bg`

--- a/.changeset/sharp-suns-run.md
+++ b/.changeset/sharp-suns-run.md
@@ -1,5 +1,0 @@
----
-"@primer/primitives": patch
----
-
-Increase dark `counter-secondary-text` contrast

--- a/data/colors/mixins/dark_mode.scss
+++ b/data/colors/mixins/dark_mode.scss
@@ -270,7 +270,7 @@ $export: (
     ),
 
     secondary: (
-      text: $gray-3,
+      text: mix($gray-1, $gray-6, 66%),
     ),
   ),
 

--- a/data/colors/mixins/dark_mode.scss
+++ b/data/colors/mixins/dark_mode.scss
@@ -270,7 +270,7 @@ $export: (
     ),
 
     secondary: (
-      text: mix($gray-1, $gray-6, 66%),
+      text: $gray-3,
     ),
   ),
 

--- a/data/colors/mixins/dark_mode.scss
+++ b/data/colors/mixins/dark_mode.scss
@@ -271,6 +271,7 @@ $export: (
 
     secondary: (
       text: $gray-3,
+      bg: rgba($gray-3, 0.2),
     ),
   ),
 

--- a/data/colors/mixins/light_mode.scss
+++ b/data/colors/mixins/light_mode.scss
@@ -271,6 +271,7 @@ $export: (
 
     secondary: (
       text: $gray-5,
+      bg: rgba($gray-3, 0.5),
     ),
   ),
 


### PR DESCRIPTION
We got some feedback that the text color of `Counter--secondary` didn't have enough contrast. This PR adds `counter-secondary-bg` with opacity so it can be used for `Counter--secondary`.

Before | After
--- | ---
![Screen Shot 2021-03-29 at 16 22 00](https://user-images.githubusercontent.com/378023/112804744-b842e380-90af-11eb-8300-9153090b32e5.png) | ![image](https://user-images.githubusercontent.com/378023/112810181-be3bc300-90b5-11eb-886b-45082ec3caab.png)

The columns ☝️  above are `counter-text`, `counter-primary-text` and `counter-secondary-text`. Only the dark themes in the last column (`counter-secondary-text`) are affected.
