### PR TITLE
Update bg-overlay (mix)

### DIFF
--- a/.changeset/beige-insects-know.md
+++ b/.changeset/beige-insects-know.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Update bg-overlay (mix)

--- a/data/colors/mixins/dark_mode.scss
+++ b/data/colors/mixins/dark_mode.scss
@@ -49,7 +49,7 @@ $export: (
     primary: $gray-9,
     secondary: $gray-9,
     tertiary: $gray-8,
-    overlay: $gray-7,
+    overlay: mix($gray-7, $gray-8),
     backdrop: rgba($black, 0.8),
     info: rgba($blue-4, 0.1),
     info-inverse: $blue-4,


### PR DESCRIPTION
This is a follow-up to https://github.com/primer/primitives/pull/50 that got reverted with https://github.com/primer/primitives/pull/60.

This time, instead of changing the `bg-overlay` from `$gray-7` to `$gray-8`, the two colors get mixed to use something like `$gray-7.5`. This makes the background a bit darker to increase the text contrast...

Theme | Before | After
--- | ---  | ---
`dark_dimmed` | ![Screen Shot 2021-04-01 at 22 55 50](https://user-images.githubusercontent.com/378023/113306575-3537bc80-933f-11eb-9d35-d46675cd820a.png) | ![Screen Shot 2021-04-01 at 22 56 08](https://user-images.githubusercontent.com/378023/113306585-379a1680-933f-11eb-9762-a57865926bb8.png)
`dark` | ![Screen Shot 2021-04-01 at 22 57 39](https://user-images.githubusercontent.com/378023/113306709-56001200-933f-11eb-97a6-3a206514afd0.png) | ![Screen Shot 2021-04-01 at 22 58 00](https://user-images.githubusercontent.com/378023/113306720-58fb0280-933f-11eb-908c-64c277184180.png)

... and at the same time it keeps the hover color still visible:

![hover](https://user-images.githubusercontent.com/378023/113307087-ba22d600-933f-11eb-91ef-56914348682a.gif)

@auareyou @juliusschaeper @vdepizzol 