### PR TITLE
Improve ANSI colors

### DIFF
--- a/.changeset/early-zoos-think.md
+++ b/.changeset/early-zoos-think.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Improve ANSI colors

--- a/data/colors/mixins/dark_mode.scss
+++ b/data/colors/mixins/dark_mode.scss
@@ -1007,7 +1007,7 @@ $export: (
     blue-bright: $blue-2,
     magenta: $purple-3,
     magenta-bright: $purple-2,
-    cyan: #76e3ea, // custom
-    cyan-bright: #b3f0ff, // custom
+    cyan: #39c5cf, // custom
+    cyan-bright: #56d4dd, // custom
   ),
 );

--- a/data/colors/mixins/dark_mode.scss
+++ b/data/colors/mixins/dark_mode.scss
@@ -992,10 +992,10 @@ $export: (
 
   // used for terminal-like enviroments
   ansi: (
-    black: $gray-9,
-    black-bright: $gray-8,
+    black: $gray-5,
+    black-bright: $gray-4,
     white: $gray-2,
-    white-bright: $gray-2,
+    white-bright: $gray-0,
     gray: $gray-4,
     red: $red-3,
     red-bright: $red-2,

--- a/data/colors/mixins/light_mode.scss
+++ b/data/colors/mixins/light_mode.scss
@@ -993,9 +993,9 @@ $export: (
   // used for terminal-like enviroments
   ansi: (
     black: $gray-9,
-    black-bright: $gray-7,
-    white: $gray-0,
-    white-bright: $white,
+    black-bright: $gray-6,
+    white: $gray-5,
+    white-bright: $gray-4,
     gray: $gray-5,
     red: $red-5,
     red-bright: $red-6,

--- a/data/colors/mixins/light_mode.scss
+++ b/data/colors/mixins/light_mode.scss
@@ -170,7 +170,7 @@ $export: (
 
     active-bg: darken(#f3f4f6, 3%),
     active-border: $black-fade-10,
-    
+
     selected-bg: darken(#f3f4f6, 2%),
 
     focus-bg: $gray-0,
@@ -1004,7 +1004,7 @@ $export: (
     yellow: $yellow-8,
     yellow-bright: $yellow-7,
     blue: $blue-5,
-    blue-bright: $blue-7,
+    blue-bright: $blue-4,
     magenta: $purple-5,
     magenta-bright: $purple-4,
     cyan: #1b7c83, // custom


### PR DESCRIPTION
This is a follow-up to #73 with some improvements to white, black and grays. It should improve https://github.com/primer/github-vscode-theme/issues/155.

Before | After
--- | ---
![Screen Shot 2021-04-22 at 19 37 00](https://user-images.githubusercontent.com/378023/115703682-62f3ac80-a3a5-11eb-8133-169392899592.png) | ![Screen Shot 2021-04-22 at 19 37 57](https://user-images.githubusercontent.com/378023/115703686-64bd7000-a3a5-11eb-9525-5c69d24a2add.png)
![Screen Shot 2021-04-22 at 19 46 50](https://user-images.githubusercontent.com/378023/115703691-65560680-a3a5-11eb-8929-6920e714128a.png) | ![Screen Shot 2021-04-22 at 19 53 09](https://user-images.githubusercontent.com/378023/115703695-65ee9d00-a3a5-11eb-97b1-0cebbd8999fc.png)
![Screen Shot 2021-04-22 at 19 55 39](https://user-images.githubusercontent.com/378023/115703697-66873380-a3a5-11eb-96a3-bb20e4574f37.png) | ![Screen Shot 2021-04-22 at 19 56 01](https://user-images.githubusercontent.com/378023/115703698-66873380-a3a5-11eb-9c39-2c64646657d7.png)
