### PR TITLE
Remove blankslate-icon

### DIFF
--- a/.changeset/warm-phones-hunt.md
+++ b/.changeset/warm-phones-hunt.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": major
+---
+
+Remove blankslate-icon

--- a/data/colors/mixins/dark_mode.scss
+++ b/data/colors/mixins/dark_mode.scss
@@ -154,10 +154,6 @@ $export: (
     row-border: $gray-6,
   ),
 
-  blankslate: (
-    icon: lighten($gray-5, 5%),
-  ),
-
   btn: (
     text: $gray-1,
     bg: $gray-7,

--- a/data/colors/mixins/light_mode.scss
+++ b/data/colors/mixins/light_mode.scss
@@ -154,10 +154,6 @@ $export: (
     row-border: lighten($gray-2, 3%),
   ),
 
-  blankslate: (
-    icon: lighten($gray-4, 5%),
-  ),
-
   btn: (
     text: $gray-9,
     bg: $gray-0,


### PR DESCRIPTION
This removes `blankslate-icon`. In Primer CSS it's replaced with `icon-secondary` https://github.com/primer/css/pull/1368/commits/87a58a940790205670428ff65f307aea140935a8.

**Note**: This is a breaking change but there is no rush to merge this and we can wait for other breaking changes.
