### PR TITLE
Remove border-overlay

### DIFF
--- a/.changeset/wild-eagles-sing.md
+++ b/.changeset/wild-eagles-sing.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": major
+---
+
+Remove border-overlay

--- a/data/colors/mixins/dark_mode.scss
+++ b/data/colors/mixins/dark_mode.scss
@@ -826,7 +826,7 @@ $export: (
 
     dropdown-text: var(--color-text-primary),
     dropdown-bg: var(--color-bg-overlay),
-    dropdown-border: var(--color-border-overlay),
+    dropdown-border: var(--color-border-primary),
     dropdown-hover-text: var(--color-state-hover-primary-text),
     dropdown-hover-bg: var(--color-state-hover-primary-bg),
     dropdown-btn-hover-text: var(--color-state-hover-primary-text),

--- a/data/colors/mixins/dark_mode.scss
+++ b/data/colors/mixins/dark_mode.scss
@@ -33,7 +33,6 @@ $export: (
     primary: $gray-6,
     secondary: $gray-7,
     tertiary: $gray-4,
-    overlay: var(--color-border-primary),
     inverse: $white,
     info: rgba($blue-4, 0.4),
     danger: rgba($red-4, 0.4),

--- a/data/colors/mixins/dark_mode.scss
+++ b/data/colors/mixins/dark_mode.scss
@@ -33,7 +33,7 @@ $export: (
     primary: $gray-6,
     secondary: $gray-7,
     tertiary: $gray-4,
-    overlay: $gray-6,
+    overlay: var(--color-border-primary),
     inverse: $white,
     info: rgba($blue-4, 0.4),
     danger: rgba($red-4, 0.4),

--- a/data/colors/mixins/light_mode.scss
+++ b/data/colors/mixins/light_mode.scss
@@ -33,7 +33,7 @@ $export: (
     primary: $gray-2,
     secondary: lighten($gray-2, 3%),
     tertiary: $gray-3,
-    overlay: $gray-2,
+    overlay: var(--color-border-primary),
     inverse: $white,
     info: $blue-5,
     danger: $red-5,

--- a/data/colors/mixins/light_mode.scss
+++ b/data/colors/mixins/light_mode.scss
@@ -33,7 +33,6 @@ $export: (
     primary: $gray-2,
     secondary: lighten($gray-2, 3%),
     tertiary: $gray-3,
-    overlay: var(--color-border-primary),
     inverse: $white,
     info: $blue-5,
     danger: $red-5,


### PR DESCRIPTION
Closes https://github.com/github/design-systems/issues/1393.

- 🔥  Remove `border-overlay`.

⚠️ **Note**: This is a breaking change. It's not too urgent to be released. Most Primer repos already have migration PRs ready. See below.

## Migration guide

The `border-overlay` can be replaced with `border-primary`. There should be no visual difference since both variables use the same color.

- [x] Figma
- [x] https://github.com/primer/github-vscode-theme/pull/168
- [ ] https://github.com/primer/components/pull/1183
- [x] https://github.com/primer/css/pull/1370
- [x] https://github.com/primer/view_components/pull/497
- [x] https://github.com/github/github/pull/178083
