### PR TITLE
Track v2 color system coverage

### DIFF
--- a/.github/v2-coverage.js
+++ b/.github/v2-coverage.js
@@ -3,8 +3,8 @@ const { default: colorsV2 } = require("../dist/js/colors_v2");
 const flatten = require("flat");
 const github = require("@actions/github");
 
-const [repoOwner, repoName] = process.env.GITHUB_REPOSITORY.split("/");
-const octokit = new github.GitHub(process.env.GITHUB_TOKEN);
+// const [repoOwner, repoName] = process.env.GITHUB_REPOSITORY.split("/");
+// const octokit = new github.GitHub(process.env.GITHUB_TOKEN);
 
 async function run() {
   const variablesV1 = Object.keys(flatten(colors.light));
@@ -24,18 +24,20 @@ async function run() {
   const coverage =
     ((variablesV1.length - diff.length) / variablesV1.length) * 100;
 
-  if (octokit) {
-    await octokit.repos.createStatus({
-      owner: repoOwner,
-      repo: repoName,
-      sha: process.env.GITHUB_SHA,
-      context: "v2 coverage",
-      state: "success",
-      description: `${variablesV1.length - diff.length}/${
-        variablesV1.length
-      } (${coverage.toFixed(2)}%)`,
-    });
-  }
+  console.log(process.env.GITHUB_REPOSITORY);
+
+  // if (octokit) {
+  //   await octokit.repos.createStatus({
+  //     owner: repoOwner,
+  //     repo: repoName,
+  //     sha: process.env.GITHUB_SHA,
+  //     context: "v2 coverage",
+  //     state: "success",
+  //     description: `${variablesV1.length - diff.length}/${
+  //       variablesV1.length
+  //     } (${coverage.toFixed(2)}%)`,
+  //   });
+  // }
 }
 
 run();

--- a/.github/v2-coverage.js
+++ b/.github/v2-coverage.js
@@ -25,6 +25,7 @@ async function run() {
     ((variablesV1.length - diff.length) / variablesV1.length) * 100;
 
   console.log(process.env.GITHUB_REPOSITORY);
+  console.log(process.env.GITHUB_SHA);
 
   // if (octokit) {
   //   await octokit.repos.createStatus({

--- a/.github/v2-coverage.js
+++ b/.github/v2-coverage.js
@@ -1,26 +1,41 @@
 const { default: colors } = require("../dist/js/colors");
 const { default: colorsV2 } = require("../dist/js/colors_v2");
 const flatten = require("flat");
+const github = require("@actions/github");
 
-const variablesV1 = Object.keys(flatten(colors.light));
-const variablesV2 = Object.keys(flatten(colorsV2.light));
+const [repoOwner, repoName] = process.env.GITHUB_REPOSITORY.split("/");
+const octokit = new github.GitHub(process.env.GITHUB_TOKEN);
 
-// V1 - V2
-const diff = variablesV1.filter(v => variablesV2.indexOf(v) === -1);
+async function run() {
+  const variablesV1 = Object.keys(flatten(colors.light));
+  const variablesV2 = Object.keys(flatten(colorsV2.light));
 
-console.log(
-  "The following v1 variables do not have a corresponding v2 variable:"
-);
+  // V1 - V2
+  const diff = variablesV1.filter(v => variablesV2.indexOf(v) === -1);
 
-for (const variable of diff) {
-  console.log(variable);
+  console.log(
+    "The following v1 variables do not have a corresponding v2 variable:"
+  );
+
+  for (const variable of diff) {
+    console.log(variable);
+  }
+
+  const coverage =
+    ((variablesV1.length - diff.length) / variablesV1.length) * 100;
+
+  if (octokit) {
+    await octokit.repos.createStatus({
+      owner: repoOwner,
+      repo: repoName,
+      sha: process.env.GITHUB_SHA,
+      context: "v2 coverage",
+      state: "success",
+      description: `${variablesV1.length - diff.length}/${
+        variablesV1.length
+      } (${coverage.toFixed(2)}%)`,
+    });
+  }
 }
 
-const coverage =
-  ((variablesV1.length - diff.length) / variablesV1.length) * 100;
-
-console.log(
-  `v2 coverage: ${variablesV1.length - diff.length}/${
-    variablesV1.length
-  } (${coverage.toFixed(2)}%)`
-);
+run();

--- a/.github/v2-coverage.js
+++ b/.github/v2-coverage.js
@@ -1,10 +1,13 @@
 const { default: colors } = require("../dist/js/colors");
 const { default: colorsV2 } = require("../dist/js/colors_v2");
 const flatten = require("flat");
-const github = require("@actions/github");
+const { Octokit } = require("@octokit/rest");
 
-// const [repoOwner, repoName] = process.env.GITHUB_REPOSITORY.split("/");
-// const octokit = new github.GitHub(process.env.GITHUB_TOKEN);
+// This is a temporary script for tracking the coverage of the v2 functional color system.
+// Delete this file when the v2 system is fully implemented.
+
+const [repoOwner, repoName] = process.env.GITHUB_REPOSITORY.split("/");
+const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
 
 async function run() {
   const variablesV1 = Object.keys(flatten(colors.light));
@@ -24,21 +27,18 @@ async function run() {
   const coverage =
     ((variablesV1.length - diff.length) / variablesV1.length) * 100;
 
-  console.log(process.env.GITHUB_REPOSITORY);
-  console.log(process.env.GITHUB_SHA);
-
-  // if (octokit) {
-  //   await octokit.repos.createStatus({
-  //     owner: repoOwner,
-  //     repo: repoName,
-  //     sha: process.env.GITHUB_SHA,
-  //     context: "v2 coverage",
-  //     state: "success",
-  //     description: `${variablesV1.length - diff.length}/${
-  //       variablesV1.length
-  //     } (${coverage.toFixed(2)}%)`,
-  //   });
-  // }
+  if (octokit) {
+    await octokit.repos.createCommitStatus({
+      owner: repoOwner,
+      repo: repoName,
+      sha: process.env.GITHUB_SHA,
+      context: "v2 coverage",
+      state: "success",
+      description: `${variablesV1.length - diff.length}/${
+        variablesV1.length
+      } (${coverage.toFixed(2)}%)`,
+    });
+  }
 }
 
 run();

--- a/.github/v2-coverage.js
+++ b/.github/v2-coverage.js
@@ -1,0 +1,26 @@
+const { default: colors } = require("../dist/js/colors");
+const { default: colorsV2 } = require("../dist/js/colors_v2");
+const flatten = require("flat");
+
+const variablesV1 = Object.keys(flatten(colors.light));
+const variablesV2 = Object.keys(flatten(colorsV2.light));
+
+// V1 - V2
+const diff = variablesV1.filter(v => variablesV2.indexOf(v) === -1);
+
+console.log(
+  "The following v1 variables do not have a corresponding v2 variable:"
+);
+
+for (const variable of diff) {
+  console.log(variable);
+}
+
+const coverage =
+  ((variablesV1.length - diff.length) / variablesV1.length) * 100;
+
+console.log(
+  `v2 coverage: ${variablesV1.length - diff.length}/${
+    variablesV1.length
+  } (${coverage.toFixed(2)}%)`
+);

--- a/.github/workflows/v2-coverage.yml
+++ b/.github/workflows/v2-coverage.yml
@@ -2,7 +2,6 @@ name: v2 coverage
 on: [push]
 jobs:
   coverage:
-    name: v2 coverage
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/v2-coverage.yml
+++ b/.github/workflows/v2-coverage.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Build
         run: yarn build
 
-      - run: node .github/v2-coverage.js
+      - name: Compute coverage
+        run: node .github/v2-coverage.js
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/v2-coverage.yml
+++ b/.github/workflows/v2-coverage.yml
@@ -1,0 +1,22 @@
+name: v2 coverage
+on: [push]
+jobs:
+  coverage:
+    name: v2 coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@master
+
+      - name: Set up Node.js
+        uses: actions/setup-node@master
+        with:
+          node-version: 12
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Build
+        run: yarn build
+
+      - run: node .github/v2-coverage.js

--- a/.github/workflows/v2-coverage.yml
+++ b/.github/workflows/v2-coverage.yml
@@ -19,3 +19,5 @@ jobs:
         run: yarn build
 
       - run: node .github/v2-coverage.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }

--- a/.github/workflows/v2-coverage.yml
+++ b/.github/workflows/v2-coverage.yml
@@ -1,3 +1,6 @@
+# This is a temporary workflow for tracking the coverage of the v2 functional color system.
+# Delete this file when the v2 system is fully implemented.
+
 name: v2 coverage
 on: [push]
 jobs:
@@ -20,4 +23,4 @@ jobs:
 
       - run: node .github/v2-coverage.js
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "release": "yarn build && changeset publish"
   },
   "devDependencies": {
+    "@actions/core": "^1.2.7",
+    "@actions/github": "^4.0.0",
     "@changesets/changelog-github": "^0.3.0",
     "@changesets/cli": "^2.11.2",
     "@types/chalk": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "@primer/primitives",
   "version": "4.3.2",
   "description": "Typography, spacing, and color primitives for Primer design system",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",
   "repository": "https://github.com/primer/primitives",
@@ -37,6 +39,7 @@
     "camelcase-keys": "^6.2.2",
     "chalk": "^4.1.0",
     "deep-shape-equals": "^0.1.2",
+    "flat": "^5.0.2",
     "lodash": "^4.17.20",
     "mkdirp": "^1.0.4",
     "node-sass": "^4.14.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@actions/github": "^4.0.0",
     "@changesets/changelog-github": "^0.3.0",
     "@changesets/cli": "^2.11.2",
+    "@octokit/rest": "^18.5.3",
     "@types/chalk": "^2.2.0",
     "@types/lodash": "^4.14.163",
     "@types/mkdirp": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -982,6 +982,11 @@ find-yarn-workspace-root2@1.2.16:
     micromatch "^4.0.2"
     pkg-dir "^4.2.0"
 
+flat@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
+  integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"

--- a/yarn.lock
+++ b/yarn.lock
@@ -301,7 +301,7 @@
   dependencies:
     "@octokit/types" "^6.0.3"
 
-"@octokit/core@^3.0.0":
+"@octokit/core@^3.0.0", "@octokit/core@^3.2.3":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.4.0.tgz#b48aa27d755b339fe7550548b340dcc2b513b742"
   integrity sha512-6/vlKPP8NF17cgYXqucdshWqmMZGXkuvtcrWCgU5NOI0Pl2GjlmZyWgBMrU8zJ3v2MJlM6++CiB45VKYmhiWWg==
@@ -337,12 +337,25 @@
   resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-7.0.0.tgz#0f6992db9854af15eca77d71ab0ec7fad2f20411"
   integrity sha512-gV/8DJhAL/04zjTI95a7FhQwS6jlEE0W/7xeYAzuArD0KVAVWDLP2f3vi98hs3HLTczxXdRK/mF0tRoQPpolEw==
 
-"@octokit/plugin-paginate-rest@^2.2.3":
+"@octokit/plugin-paginate-rest@^2.2.3", "@octokit/plugin-paginate-rest@^2.6.2":
   version "2.13.3"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.13.3.tgz#f0f1792230805108762d87906fb02d573b9e070a"
   integrity sha512-46lptzM9lTeSmIBt/sVP/FLSTPGx6DCzAdSX3PfeJ3mTf4h9sGC26WpaQzMEq/Z44cOcmx8VsOhO+uEgE3cjYg==
   dependencies:
     "@octokit/types" "^6.11.0"
+
+"@octokit/plugin-request-log@^1.0.2":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.3.tgz#70a62be213e1edc04bb8897ee48c311482f9700d"
+  integrity sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ==
+
+"@octokit/plugin-rest-endpoint-methods@5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.0.1.tgz#631b8d4edc6798b03489911252a25f2a4e58c594"
+  integrity sha512-vvWbPtPqLyIzJ7A4IPdTl+8IeuKAwMJ4LjvmqWOOdfSuqWQYZXq2CEd0hsnkidff2YfKlguzujHs/reBdAx8Sg==
+  dependencies:
+    "@octokit/types" "^6.13.1"
+    deprecation "^2.3.1"
 
 "@octokit/plugin-rest-endpoint-methods@^4.0.0":
   version "4.15.1"
@@ -373,7 +386,17 @@
     node-fetch "^2.6.1"
     universal-user-agent "^6.0.0"
 
-"@octokit/types@^6.0.3", "@octokit/types@^6.11.0", "@octokit/types@^6.13.0", "@octokit/types@^6.7.1":
+"@octokit/rest@^18.5.3":
+  version "18.5.3"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.5.3.tgz#6a2e6006a87ebbc34079c419258dd29ec9ff659d"
+  integrity sha512-KPAsUCr1DOdLVbZJgGNuE/QVLWEaVBpFQwDAz/2Cnya6uW2wJ/P5RVGk0itx7yyN1aGa8uXm2pri4umEqG1JBA==
+  dependencies:
+    "@octokit/core" "^3.2.3"
+    "@octokit/plugin-paginate-rest" "^2.6.2"
+    "@octokit/plugin-request-log" "^1.0.2"
+    "@octokit/plugin-rest-endpoint-methods" "5.0.1"
+
+"@octokit/types@^6.0.3", "@octokit/types@^6.11.0", "@octokit/types@^6.13.0", "@octokit/types@^6.13.1", "@octokit/types@^6.7.1":
   version "6.14.2"
   resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.14.2.tgz#64c9457f38fb8522bdbba3c8cc814590a2d61bf5"
   integrity sha512-wiQtW9ZSy4OvgQ09iQOdyXYNN60GqjCL/UdMsepDr1Gr0QzpW6irIKbH3REuAHXAhxkEk9/F2a3Gcs1P6kW5jA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,28 @@
 # yarn lockfile v1
 
 
+"@actions/core@^1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.2.7.tgz#594f8c45b213f0146e4be7eda8ae5cf4e198e5ab"
+  integrity sha512-kzLFD5BgEvq6ubcxdgPbRKGD2Qrgya/5j+wh4LZzqT915I0V3rED+MvjH6NXghbvk1MXknpNNQ3uKjXSEN00Ig==
+
+"@actions/github@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@actions/github/-/github-4.0.0.tgz#d520483151a2bf5d2dc9cd0f20f9ac3a2e458816"
+  integrity sha512-Ej/Y2E+VV6sR9X7pWL5F3VgEWrABaT292DRqRU6R4hnQjPtC/zD3nagxVdXWiRQvYDh8kHXo7IDmG42eJ/dOMA==
+  dependencies:
+    "@actions/http-client" "^1.0.8"
+    "@octokit/core" "^3.0.0"
+    "@octokit/plugin-paginate-rest" "^2.2.3"
+    "@octokit/plugin-rest-endpoint-methods" "^4.0.0"
+
+"@actions/http-client@^1.0.8":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@actions/http-client/-/http-client-1.0.11.tgz#c58b12e9aa8b159ee39e7dd6cbd0e91d905633c0"
+  integrity sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==
+  dependencies:
+    tunnel "0.0.6"
+
 "@babel/code-frame@^7.0.0":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
@@ -272,6 +294,92 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@octokit/auth-token@^2.4.4":
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-2.4.5.tgz#568ccfb8cb46f36441fac094ce34f7a875b197f3"
+  integrity sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+
+"@octokit/core@^3.0.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.4.0.tgz#b48aa27d755b339fe7550548b340dcc2b513b742"
+  integrity sha512-6/vlKPP8NF17cgYXqucdshWqmMZGXkuvtcrWCgU5NOI0Pl2GjlmZyWgBMrU8zJ3v2MJlM6++CiB45VKYmhiWWg==
+  dependencies:
+    "@octokit/auth-token" "^2.4.4"
+    "@octokit/graphql" "^4.5.8"
+    "@octokit/request" "^5.4.12"
+    "@octokit/request-error" "^2.0.5"
+    "@octokit/types" "^6.0.3"
+    before-after-hook "^2.2.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/endpoint@^6.0.1":
+  version "6.0.11"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-6.0.11.tgz#082adc2aebca6dcefa1fb383f5efb3ed081949d1"
+  integrity sha512-fUIPpx+pZyoLW4GCs3yMnlj2LfoXTWDUVPTC4V3MUEKZm48W+XYpeWSZCv+vYF1ZABUm2CqnDVf1sFtIYrj7KQ==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+    is-plain-object "^5.0.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/graphql@^4.5.8":
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.6.1.tgz#f975486a46c94b7dbe58a0ca751935edc7e32cc9"
+  integrity sha512-2lYlvf4YTDgZCTXTW4+OX+9WTLFtEUc6hGm4qM1nlZjzxj+arizM4aHWzBVBCxY9glh7GIs0WEuiSgbVzv8cmA==
+  dependencies:
+    "@octokit/request" "^5.3.0"
+    "@octokit/types" "^6.0.3"
+    universal-user-agent "^6.0.0"
+
+"@octokit/openapi-types@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-7.0.0.tgz#0f6992db9854af15eca77d71ab0ec7fad2f20411"
+  integrity sha512-gV/8DJhAL/04zjTI95a7FhQwS6jlEE0W/7xeYAzuArD0KVAVWDLP2f3vi98hs3HLTczxXdRK/mF0tRoQPpolEw==
+
+"@octokit/plugin-paginate-rest@^2.2.3":
+  version "2.13.3"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.13.3.tgz#f0f1792230805108762d87906fb02d573b9e070a"
+  integrity sha512-46lptzM9lTeSmIBt/sVP/FLSTPGx6DCzAdSX3PfeJ3mTf4h9sGC26WpaQzMEq/Z44cOcmx8VsOhO+uEgE3cjYg==
+  dependencies:
+    "@octokit/types" "^6.11.0"
+
+"@octokit/plugin-rest-endpoint-methods@^4.0.0":
+  version "4.15.1"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.15.1.tgz#91a064bee99d0ffcef74a04357e1cf15c27d1cd0"
+  integrity sha512-4gQg4ySoW7ktKB0Mf38fHzcSffVZd6mT5deJQtpqkuPuAqzlED5AJTeW8Uk7dPRn7KaOlWcXB0MedTFJU1j4qA==
+  dependencies:
+    "@octokit/types" "^6.13.0"
+    deprecation "^2.3.1"
+
+"@octokit/request-error@^2.0.0", "@octokit/request-error@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.0.5.tgz#72cc91edc870281ad583a42619256b380c600143"
+  integrity sha512-T/2wcCFyM7SkXzNoyVNWjyVlUwBvW3igM3Btr/eKYiPmucXTtkxt2RBsf6gn3LTzaLSLTQtNmvg+dGsOxQrjZg==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+    deprecation "^2.0.0"
+    once "^1.4.0"
+
+"@octokit/request@^5.3.0", "@octokit/request@^5.4.12":
+  version "5.4.15"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.15.tgz#829da413dc7dd3aa5e2cdbb1c7d0ebe1f146a128"
+  integrity sha512-6UnZfZzLwNhdLRreOtTkT9n57ZwulCve8q3IT/Z477vThu6snfdkBuhxnChpOKNGxcQ71ow561Qoa6uqLdPtag==
+  dependencies:
+    "@octokit/endpoint" "^6.0.1"
+    "@octokit/request-error" "^2.0.0"
+    "@octokit/types" "^6.7.1"
+    is-plain-object "^5.0.0"
+    node-fetch "^2.6.1"
+    universal-user-agent "^6.0.0"
+
+"@octokit/types@^6.0.3", "@octokit/types@^6.11.0", "@octokit/types@^6.13.0", "@octokit/types@^6.7.1":
+  version "6.14.2"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.14.2.tgz#64c9457f38fb8522bdbba3c8cc814590a2d61bf5"
+  integrity sha512-wiQtW9ZSy4OvgQ09iQOdyXYNN60GqjCL/UdMsepDr1Gr0QzpW6irIKbH3REuAHXAhxkEk9/F2a3Gcs1P6kW5jA==
+  dependencies:
+    "@octokit/openapi-types" "^7.0.0"
+
 "@types/chalk@^2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@types/chalk/-/chalk-2.2.0.tgz#b7f6e446f4511029ee8e3f43075fb5b73fbaa0ba"
@@ -483,6 +591,11 @@ bcrypt-pbkdf@^1.0.0:
   integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
+
+before-after-hook@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.1.tgz#73540563558687586b52ed217dad6a802ab1549c"
+  integrity sha512-/6FKxSTWoJdbsLDF8tdIjaRiFXiE6UHsEHE3OPI/cwPURCVi1ukP0gmLn7XWEiFk5TcwQjjY5PWsU+j+tgXgmw==
 
 better-path-resolve@1.0.0:
   version "1.0.0"
@@ -805,6 +918,11 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
+
+deprecation@^2.0.0, deprecation@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
+  integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
 
 diff@^4.0.1:
   version "4.0.2"
@@ -1298,6 +1416,11 @@ is-plain-obj@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
+is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
+
 is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
@@ -1607,7 +1730,7 @@ nan@^2.13.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
   integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
 
-node-fetch@^2.5.0:
+node-fetch@^2.5.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -1702,7 +1825,7 @@ object-assign@^4.0.1, object-assign@^4.1.0:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
-once@^1.3.0:
+once@^1.3.0, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
@@ -2492,6 +2615,11 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+tunnel@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
+  integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
@@ -2516,6 +2644,11 @@ typescript@^3.7.2:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+
+universal-user-agent@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"
+  integrity sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==
 
 universalify@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
## Context

We will know that the [v2 color system](https://github.com/github/design-systems/issues/1388) has full coverage of the existing color system when every v1 variable can be either mapped to a v2 variable or moved into dotcom as an app-level variable.

## Summary

This PR helps us track the coverage of the v2 color system using GitHub Actions. The coverage of the v2 system will now be included as a commit status for every commit:

![CleanShot 2021-05-14 at 05 39 13@2x](https://user-images.githubusercontent.com/4608155/118271972-ce95da80-b476-11eb-9e31-1354779b264a.png)

When this commit status reads 100%, we can be confident that the v2 system is complete.

To see a list of all the v1 variables that still need to be mapped to a v2 variable. check the actions log:

<img width="757" alt="CleanShot 2021-05-14 at 05 44 19@2x" src="https://user-images.githubusercontent.com/4608155/118272435-7ad7c100-b477-11eb-9f04-a3331c716c11.png">



