### PR TITLE
Rename calendar-day variable names

### DIFF
--- a/.changeset/real-bottles-sniff.md
+++ b/.changeset/real-bottles-sniff.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Rename calendar-day variable names

--- a/data/colors/dark.ts
+++ b/data/colors/dark.ts
@@ -784,14 +784,14 @@ export default {
   calendarGraph: {
     dayBg: get('scale.gray.8'),
     dayBorder: 'rgba(27,31,35,0.06)',
-    dayL1Bg: '#0e4429',
-    dayL2Bg: '#006d32',
-    dayL3Bg: '#26a641',
-    dayL4Bg: '#39d353',
-    dayL4Border: 'rgba(255,255,255,0.05)',
-    dayL3Border: 'rgba(255,255,255,0.05)',
-    dayL2Border: 'rgba(255,255,255,0.05)',
-    dayL1Border: 'rgba(255,255,255,0.05)'
+    day1Bg: '#0e4429',
+    day2Bg: '#006d32',
+    day3Bg: '#26a641',
+    day4Bg: '#39d353',
+    day4Border: 'rgba(255,255,255,0.05)',
+    day3Border: 'rgba(255,255,255,0.05)',
+    day2Border: 'rgba(255,255,255,0.05)',
+    day1Border: 'rgba(255,255,255,0.05)'
   },
   footerInvertocat: {
     octicon: get('scale.gray.6'),

--- a/data/colors/light.ts
+++ b/data/colors/light.ts
@@ -784,14 +784,14 @@ export default {
   calendarGraph: {
     dayBg: '#ebedf0',
     dayBorder: 'rgba(27,31,35,0.06)',
-    dayL1Bg: '#9be9a8',
-    dayL2Bg: '#40c463',
-    dayL3Bg: '#30a14e',
-    dayL4Bg: '#216e39',
-    dayL4Border: 'rgba(27,31,35,0.06)',
-    dayL3Border: 'rgba(27,31,35,0.06)',
-    dayL2Border: 'rgba(27,31,35,0.06)',
-    dayL1Border: 'rgba(27,31,35,0.06)'
+    day1Bg: '#9be9a8',
+    day2Bg: '#40c463',
+    day3Bg: '#30a14e',
+    day4Bg: '#216e39',
+    day4Border: 'rgba(27,31,35,0.06)',
+    day3Border: 'rgba(27,31,35,0.06)',
+    day2Border: 'rgba(27,31,35,0.06)',
+    day1Border: 'rgba(27,31,35,0.06)'
   },
   footerInvertocat: {
     octicon: get('scale.gray.3'),

--- a/data/colors_v2/vars/product_dark.ts
+++ b/data/colors_v2/vars/product_dark.ts
@@ -6,14 +6,14 @@ export default {
   calendarGraph: {
     dayBg: get('scale.gray.8'),
     dayBorder: 'rgba(27, 31, 35, 0.06)',
-    dayL1Bg: '#0E4429',
-    dayL2Bg: '#006D32',
-    dayL3Bg: '#26A641',
-    dayL4Bg: '#39D353',
-    dayL4Border: 'rgba(255, 255, 255, 0.05)',
-    dayL3Border: 'rgba(255, 255, 255, 0.05)',
-    dayL2Border: 'rgba(255, 255, 255, 0.05)',
-    dayL1Border: 'rgba(255, 255, 255, 0.05)'
+    day1Bg: '#0E4429',
+    day2Bg: '#006D32',
+    day3Bg: '#26A641',
+    day4Bg: '#39D353',
+    day4Border: 'rgba(255, 255, 255, 0.05)',
+    day3Border: 'rgba(255, 255, 255, 0.05)',
+    day2Border: 'rgba(255, 255, 255, 0.05)',
+    day1Border: 'rgba(255, 255, 255, 0.05)'
   },
   marketingIcon: {
     primary: get('scale.blue.2'),

--- a/data/colors_v2/vars/product_light.ts
+++ b/data/colors_v2/vars/product_light.ts
@@ -6,14 +6,14 @@ export default {
   calendarGraph: {
     dayBg: '#EBEDF0',
     dayBorder: 'rgba(27, 31, 35, 0.06)',
-    dayL1Bg: '#9BE9A8',
-    dayL2Bg: '#40C463',
-    dayL3Bg: '#30A14E',
-    dayL4Bg: '#216E39',
-    dayL4Border: 'rgba(27, 31, 35, 0.06)',
-    dayL3Border: 'rgba(27, 31, 35, 0.06)',
-    dayL2Border: 'rgba(27, 31, 35, 0.06)',
-    dayL1Border: 'rgba(27, 31, 35, 0.06)'
+    day1Bg: '#9BE9A8',
+    day2Bg: '#40C463',
+    day3Bg: '#30A14E',
+    day4Bg: '#216E39',
+    day4Border: 'rgba(27, 31, 35, 0.06)',
+    day3Border: 'rgba(27, 31, 35, 0.06)',
+    day2Border: 'rgba(27, 31, 35, 0.06)',
+    day1Border: 'rgba(27, 31, 35, 0.06)'
   },
   marketingIcon: {
     primary: get('scale.blue.4'),


### PR DESCRIPTION
This renames the calendarGraph names from `calendar-graph-day-L1-bg` to `calendar-graph-day-1-bg`. With the new output process these were outputting as `calendar-graph-day-l-1-bg`