### PR TITLE
Move primer variables to components

### DIFF
--- a/.changeset/breezy-chicken-turn.md
+++ b/.changeset/breezy-chicken-turn.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Move primer variables to components

--- a/data/colors_v2/vars/component_dark.ts
+++ b/data/colors_v2/vars/component_dark.ts
@@ -1,6 +1,22 @@
 import {alpha, darken, get} from '../../../src/utils'
 
 export default {
+  primer: {
+    // These variables are shared across multiple components
+    canvas: {
+      backdrop: alpha(get('scale.black'), 0.8), // use for modal/dialogs
+      sticky: alpha(get('scale.gray.9'), 0.95) // use for sticky headers
+    },
+    border: {
+      active: '#F78166', // coral
+      contrast: alpha(get('scale.white'), 0.2) // use to increase contrast
+    },
+    shadow: {
+      highlight: '0 0 transparent', // top highlight
+      inset: '0 0 transparent', // top inner shadow
+      focus: (theme: any) => `0 0 0 3px ${get('scale.blue.8')(theme)}` // blue focus ring
+    }
+  },
   avatar: {
     bg: alpha(get('scale.white'), 0.1),
     border: alpha(get('scale.white'), 0.1),

--- a/data/colors_v2/vars/component_light.ts
+++ b/data/colors_v2/vars/component_light.ts
@@ -1,6 +1,22 @@
 import {alpha, darken, get} from '../../../src/utils'
 
 export default {
+  primer: {
+    // These variables are shared across multiple components
+    canvas: {
+      backdrop: alpha(get('scale.black'), 0.5), // use for modal/dialogs
+      sticky: alpha(get('scale.white'), 0.95) // use for sticky headers
+    },
+    border: {
+      active: '#f9826c', // coral
+      contrast: alpha(get('scale.black'), 0.1) // use to increase contrast
+    },
+    shadow: {
+      highlight: (theme: any) => `inset 0 1px 0 ${alpha(get('scale.white'), 0.25)(theme)}`, // top highlight
+      inset: (theme: any) => `inset 0 1px 0 ${alpha(get('scale.gray.2'), 0.2)(theme)}`, // top inner shadow
+      focus: (theme: any) => `0 0 0 3px ${alpha(get('scale.blue.5'), 0.3)(theme)}` // blue focus ring
+    }
+  },
   avatar: {
     bg: get('scale.white'),
     border: 'transparent',

--- a/data/colors_v2/vars/global_dark.ts
+++ b/data/colors_v2/vars/global_dark.ts
@@ -72,21 +72,4 @@ export default {
     muted: alpha(get('scale.pink.4'), 0.4),
     subtle: alpha(get('scale.pink.4'), 0.1)
   },
-
-  // Only meant for Primer components
-  primer: {
-    canvas: {
-      backdrop: alpha(get('scale.black'), 0.8), // use for modal/dialogs
-      sticky: alpha(get('scale.gray.9'), 0.95) // use for sticky headers
-    },
-    border: {
-      active: '#F78166', // coral
-      contrast: alpha(get('scale.white'), 0.2) // use to increase contrast
-    },
-    shadow: {
-      highlight: '0 0 transparent', // top highlight
-      inset: '0 0 transparent', // top inner shadow
-      focus: (theme: any) => `0 0 0 3px ${get('scale.blue.8')(theme)}` // blue focus ring
-    }
-  }
 }

--- a/data/colors_v2/vars/global_light.ts
+++ b/data/colors_v2/vars/global_light.ts
@@ -72,21 +72,4 @@ export default {
     muted: alpha(get('scale.pink.3'), 0.4),
     subtle: get('scale.pink.0')
   },
-
-  // Only meant to be used by Primer components
-  primer: {
-    canvas: {
-      backdrop: alpha(get('scale.black'), 0.5), // use for modal/dialogs
-      sticky: alpha(get('scale.white'), 0.95) // use for sticky headers
-    },
-    border: {
-      active: '#f9826c', // coral
-      contrast: alpha(get('scale.black'), 0.1) // use to increase contrast
-    },
-    shadow: {
-      highlight: (theme: any) => `inset 0 1px 0 ${alpha(get('scale.white'), 0.25)(theme)}`, // top highlight
-      inset: (theme: any) => `inset 0 1px 0 ${alpha(get('scale.gray.2'), 0.2)(theme)}`, // top inner shadow
-      focus: (theme: any) => `0 0 0 3px ${alpha(get('scale.blue.5'), 0.3)(theme)}` // blue focus ring
-    }
-  }
 }


### PR DESCRIPTION
This moves the `primer` variables from `global` to `component`. See https://github.com/github/design-systems/discussions/1429#discussioncomment-789917 for more details.

It makes them a bit more private and we don't have to document them and they also will not available as utility classes or props in PVC/PRC.