### PR TITLE
Fix upload focused border color

### DIFF
--- a/.changeset/chilled-falcons-rhyme.md
+++ b/.changeset/chilled-falcons-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Fix `--color-upload-enabled-border-focused`

--- a/data/colors/dark.ts
+++ b/data/colors/dark.ts
@@ -590,7 +590,7 @@ export default {
   },
   uploadEnabled: {
     border: lighten(get('scale.gray.6'), 0.05),
-    borderFocused: lighten(get('scale.blue.5'), 0.8)
+    borderFocused: lighten(get('scale.blue.5'), 0.08)
   },
   previewableCommentForm: {
     border: darken(get('scale.gray.6'), 0.05)


### PR DESCRIPTION
This fixes the border color of the focused upload box in comment inputs.

**Before:**

![image (20)](https://user-images.githubusercontent.com/4608155/120033382-523fe300-bfb0-11eb-9235-b840287e51c2.png)


**After:**

![image](https://user-images.githubusercontent.com/4608155/120033885-13f6f380-bfb1-11eb-8df8-cc2d068d012f.png)

