### PR TITLE
Deprecate auto variables

### DIFF
--- a/.changeset/rude-experts-marry.md
+++ b/.changeset/rude-experts-marry.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Deprecate auto variables

--- a/data/colors_v2/vars/deprecated.ts
+++ b/data/colors_v2/vars/deprecated.ts
@@ -9,6 +9,106 @@ const deprecated = '#ff0000'
 const unset = 'transparent'
 
 export default {
+  auto: {
+    black: deprecated,
+    white: deprecated,
+    gray: [
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated
+    ],
+    blue: [
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated
+    ],
+    green: [
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated
+    ],
+    yellow: [
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated
+    ],
+    orange: [
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated
+    ],
+    red: [
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated
+    ],
+    purple: [
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated
+    ],
+    pink: [
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated,
+      deprecated
+    ]
+  },
   text: {
     primary: get('fg.default'),
     secondary: get('fg.muted'),


### PR DESCRIPTION
This deprecates the `auto` variables. They will be `red`. E.g. `--color-auto-purple-6: #ff0000;`. This should prevent further uses of the auto variables.

It depends on https://github.com/github/github/pull/181958. 