### PR TITLE
Add checks-dropdown-shadow

### DIFF
--- a/.changeset/great-sloths-invite.md
+++ b/.changeset/great-sloths-invite.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Add checks-dropdown-shadow

--- a/data/colors_v2/vars/product_dark.ts
+++ b/data/colors_v2/vars/product_dark.ts
@@ -107,6 +107,7 @@ export default {
     dropdownText: get('fg.default'),
     dropdownBg: get('canvas.overlay'),
     dropdownBorder: get('border.default'),
+    dropdownShadow: alpha(get('scale.black'), 0.3),
     dropdownHoverText: get('fg.default'),
     dropdownHoverBg: get('neutral.subtle'),
     dropdownBtnHoverText: get('fg.default'),

--- a/data/colors_v2/vars/product_light.ts
+++ b/data/colors_v2/vars/product_light.ts
@@ -107,6 +107,7 @@ export default {
     dropdownText: get('scale.gray.3'),
     dropdownBg: get('scale.gray.8'),
     dropdownBorder: get('scale.gray.7'),
+    dropdownShadow: alpha(get('scale.black'), 0.3),
     dropdownHoverText: get('scale.gray.0'),
     dropdownHoverBg: get('scale.gray.7'),
     dropdownBtnHoverText: get('scale.gray.0'),


### PR DESCRIPTION
This is a replacement for `--color-fade-black-30` that won't be available in V2.

Part of https://github.com/github/github/pull/182094.