### PR TITLE
Add dark high contrast mapping exceptions

### DIFF
--- a/.changeset/strong-apples-knock.md
+++ b/.changeset/strong-apples-knock.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Add dark high contrast mapping exceptions

--- a/data/colors_v2/themes/dark_high_contrast.ts
+++ b/data/colors_v2/themes/dark_high_contrast.ts
@@ -1,4 +1,4 @@
-import {merge} from '../../../src/utils'
+import {get, merge} from '../../../src/utils'
 import dark from './dark'
 
 const scale = {
@@ -47,4 +47,17 @@ const scale = {
   pink: ['#ffdbeb', '#ffc6e1', '#ffadd5', '#ee97c5', '#dd7cae', '#933869', '#752652', '#5c183f', '#4b0b31', '#390524']
 }
 
-export default merge(dark, {scale})
+const exceptions = {
+  fg: {
+    muted: get('scale.gray.1')
+  },
+  border: {
+    default: get('scale.gray.5'),
+    muted: get('scale.gray.5')
+  },
+  neutral: {
+    emphasis: get('scale.gray.6')
+  }
+}
+
+export default merge(dark, exceptions, {scale})


### PR DESCRIPTION
Adds the following dark high contrast mapping exceptions:

fg-muted: step 3 → step 1
neutral-emphasis: step 5 → step 6
border-default + border-muted: → step 5

[Discussion comment](https://github.com/github/design-systems/discussions/1458#discussioncomment-811133)