### PR TITLE
Deprecate fade variables

### DIFF
--- a/.changeset/hip-berries-end.md
+++ b/.changeset/hip-berries-end.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Deprecate fade variables

--- a/data/colors_v2/vars/deprecated.ts
+++ b/data/colors_v2/vars/deprecated.ts
@@ -187,6 +187,26 @@ export default {
       shadow: get('primer.shadow.focus') // blue focus ring
     }
   },
+  fade: {
+    fg10: deprecated,
+    fg15: deprecated,
+    fg30: deprecated,
+    fg50: deprecated,
+    fg70: deprecated,
+    fg85: deprecated,
+    black10: deprecated,
+    black15: deprecated,
+    black30: deprecated,
+    black50: deprecated,
+    black70: deprecated,
+    black85: deprecated,
+    white10: deprecated,
+    white15: deprecated,
+    white30: deprecated,
+    white50: deprecated,
+    white70: deprecated,
+    white85: deprecated
+  },
   alert: {
     info: {
       text: get('fg.default'),

--- a/data/colors_v2/vars/deprecated.ts
+++ b/data/colors_v2/vars/deprecated.ts
@@ -495,14 +495,6 @@ export default {
     errorIndicatorBg: get('danger.emphasis'),
     errorIndicatorBorder: unset
   },
-  fade: {
-    fg10: deprecated,
-    fg15: deprecated,
-    fg30: deprecated,
-    fg50: deprecated,
-    fg70: deprecated,
-    fg85: deprecated
-  },
   underlinenav: {
     border: unset,
     borderHover: get('neutral.muted'),


### PR DESCRIPTION
This deprecates all the `fade` variables. They will be `red`. E.g. `--color-fade-black-15: #ff0000;`. This should prevent further use of the fade variables.

And with that, closes https://github.com/primer/primitives/issues/95

![Screen Shot 2021-06-08 at 11 59 30](https://user-images.githubusercontent.com/378023/121116284-3d393e80-c851-11eb-9366-90b90ca9638c.png)
