### PR TITLE
Remove calendarGraph

### DIFF
--- a/.changeset/kind-cars-film.md
+++ b/.changeset/kind-cars-film.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Remove calendarGraph

--- a/data/colors/dark.ts
+++ b/data/colors/dark.ts
@@ -781,18 +781,6 @@ export default {
     inputIcon: get('scale.gray.7'),
     inputPlaceholder: get('scale.gray.5')
   },
-  calendarGraph: {
-    dayBg: get('scale.gray.8'),
-    dayBorder: 'rgba(27,31,35,0.06)',
-    dayL1Bg: '#0e4429',
-    dayL2Bg: '#006d32',
-    dayL3Bg: '#26a641',
-    dayL4Bg: '#39d353',
-    dayL4Border: 'rgba(255,255,255,0.05)',
-    dayL3Border: 'rgba(255,255,255,0.05)',
-    dayL2Border: 'rgba(255,255,255,0.05)',
-    dayL1Border: 'rgba(255,255,255,0.05)'
-  },
   footerInvertocat: {
     octicon: get('scale.gray.6'),
     octiconHover: get('scale.gray.4')

--- a/data/colors/light.ts
+++ b/data/colors/light.ts
@@ -781,18 +781,6 @@ export default {
     inputIcon: get('scale.gray.3'),
     inputPlaceholder: get('scale.gray.4')
   },
-  calendarGraph: {
-    dayBg: '#ebedf0',
-    dayBorder: 'rgba(27,31,35,0.06)',
-    dayL1Bg: '#9be9a8',
-    dayL2Bg: '#40c463',
-    dayL3Bg: '#30a14e',
-    dayL4Bg: '#216e39',
-    dayL4Border: 'rgba(27,31,35,0.06)',
-    dayL3Border: 'rgba(27,31,35,0.06)',
-    dayL2Border: 'rgba(27,31,35,0.06)',
-    dayL1Border: 'rgba(27,31,35,0.06)'
-  },
   footerInvertocat: {
     octicon: get('scale.gray.3'),
     octiconHover: get('scale.gray.5')

--- a/data/colors_v2/vars/product_dark.ts
+++ b/data/colors_v2/vars/product_dark.ts
@@ -3,18 +3,6 @@ import {get, alpha} from '../../../src/utils'
 // Variables to be moved to github/github
 
 export default {
-  calendarGraph: {
-    dayBg: get('scale.gray.8'),
-    dayBorder: 'rgba(27, 31, 35, 0.06)',
-    dayL1Bg: '#0E4429',
-    dayL2Bg: '#006D32',
-    dayL3Bg: '#26A641',
-    dayL4Bg: '#39D353',
-    dayL4Border: 'rgba(255, 255, 255, 0.05)',
-    dayL3Border: 'rgba(255, 255, 255, 0.05)',
-    dayL2Border: 'rgba(255, 255, 255, 0.05)',
-    dayL1Border: 'rgba(255, 255, 255, 0.05)'
-  },
   marketingIcon: {
     primary: get('scale.blue.2'),
     secondary: get('scale.blue.5')

--- a/data/colors_v2/vars/product_light.ts
+++ b/data/colors_v2/vars/product_light.ts
@@ -3,18 +3,6 @@ import {alpha, get} from '../../../src/utils'
 // Variables to be moved to github/github
 
 export default {
-  calendarGraph: {
-    dayBg: '#EBEDF0',
-    dayBorder: 'rgba(27, 31, 35, 0.06)',
-    dayL1Bg: '#9BE9A8',
-    dayL2Bg: '#40C463',
-    dayL3Bg: '#30A14E',
-    dayL4Bg: '#216E39',
-    dayL4Border: 'rgba(27, 31, 35, 0.06)',
-    dayL3Border: 'rgba(27, 31, 35, 0.06)',
-    dayL2Border: 'rgba(27, 31, 35, 0.06)',
-    dayL1Border: 'rgba(27, 31, 35, 0.06)'
-  },
   marketingIcon: {
     primary: get('scale.blue.4'),
     secondary: get('scale.blue.3')


### PR DESCRIPTION
This is an alternative to https://github.com/primer/primitives/pull/111 and removes the `calendarGraph` variables.

They are already moved to dotcom and we don't need to keep the "new" names, see https://github.com/primer/primitives/pull/111#issuecomment-856556443.

Closes https://github.com/primer/primitives/pull/111