### PR TITLE
Add overlay-shadow

### DIFF
--- a/.changeset/proud-cooks-fly.md
+++ b/.changeset/proud-cooks-fly.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": minor
+---
+
+Add overlay-shadow

--- a/data/colors/dark.ts
+++ b/data/colors/dark.ts
@@ -420,7 +420,7 @@ export default {
     shadow: (theme: any) => `0 16px 32px ${alpha(get('scale.black'), 0.85)(theme)}`
   },
   overlay: {
-    shadow: (theme: any) => `0 0 0 1px ${get('scale.gray.6')(theme), 0 1px 3px ${alpha(get('scale.black'), 0.12)(theme)}, 0 16px 32px ${alpha(get('scale.black'), 0.85)(theme)}`,
+    shadow: (theme: any) => `0 0 0 1px ${get('scale.gray.6')(theme)}, 0 1px 3px ${alpha(get('scale.black'), 0.12)(theme)}, 0 16px 32px ${alpha(get('scale.black'), 0.85)(theme)}`,
   },
   label: {
     border: get('scale.gray.6'),

--- a/data/colors/dark.ts
+++ b/data/colors/dark.ts
@@ -419,6 +419,9 @@ export default {
   dropdown: {
     shadow: (theme: any) => `0 16px 32px ${alpha(get('scale.black'), 0.85)(theme)}`
   },
+  overlay: {
+    shadow: (theme: any) => `0 1px 3px ${alpha(get('scale.black'), 0.12)(theme)}, 0 16px 32px ${alpha(get('scale.black'), 0.85)(theme)}`,
+  },
   label: {
     border: get('scale.gray.6'),
     primary: {

--- a/data/colors/dark.ts
+++ b/data/colors/dark.ts
@@ -420,7 +420,7 @@ export default {
     shadow: (theme: any) => `0 16px 32px ${alpha(get('scale.black'), 0.85)(theme)}`
   },
   overlay: {
-    shadow: (theme: any) => `0 1px 3px ${alpha(get('scale.black'), 0.12)(theme)}, 0 16px 32px ${alpha(get('scale.black'), 0.85)(theme)}`,
+    shadow: (theme: any) => `0 0 0 1px ${get('scale.gray.6')(theme), 0 1px 3px ${alpha(get('scale.black'), 0.12)(theme)}, 0 16px 32px ${alpha(get('scale.black'), 0.85)(theme)}`,
   },
   label: {
     border: get('scale.gray.6'),

--- a/data/colors/light.ts
+++ b/data/colors/light.ts
@@ -420,7 +420,7 @@ export default {
     shadow: (theme: any) => `0 8px 24px ${alpha(get('scale.gray.4'), 0.2)(theme)}`
   },
   overlay: {
-    shadow: (theme: any) => `0 1px 3px ${alpha(get('scale.black'), 0.12)(theme)}, 0 8px 24px ${alpha(get('scale.gray.4'), 0.2)(theme)}`,
+    shadow: (theme: any) => `0 1px 3px ${alpha(get('scale.black'), 0.12)(theme)}, 0 8px 24px ${alpha(get('scale.gray.7'), 0.12)(theme)}`,
   },
   label: {
     border: get('scale.gray.2'),

--- a/data/colors/light.ts
+++ b/data/colors/light.ts
@@ -419,6 +419,9 @@ export default {
   dropdown: {
     shadow: (theme: any) => `0 8px 24px ${alpha(get('scale.gray.4'), 0.2)(theme)}`
   },
+  overlay: {
+    shadow: (theme: any) => `0 1px 3px ${alpha(get('scale.black'), 0.12)(theme)}, 0 8px 24px ${alpha(get('scale.gray.4'), 0.2)(theme)}`,
+  },
   label: {
     border: get('scale.gray.2'),
     primary: {

--- a/data/colors_v2/vars/component_dark.ts
+++ b/data/colors_v2/vars/component_dark.ts
@@ -14,7 +14,7 @@ export default {
     tapFocusBg: get('scale.blue.8')
   },
   overlay: {
-    shadow: (theme: any) => `0 1px 3px ${alpha(get('scale.black'), 0.12)(theme)}, 0 16px 32px ${alpha(get('scale.black'), 0.85)(theme)}`,
+    shadow: (theme: any) => `0 0 0 1px ${get('scale.gray.6')(theme)}, 0 1px 3px ${alpha(get('scale.black'), 0.12)(theme)}, 0 16px 32px ${alpha(get('scale.black'), 0.85)(theme)}`,
   },
   header: {
     text: alpha(get('scale.white'), 0.7),

--- a/data/colors_v2/vars/component_dark.ts
+++ b/data/colors_v2/vars/component_dark.ts
@@ -13,6 +13,9 @@ export default {
     tapHighlight: alpha(get('scale.gray.6'), 0.5),
     tapFocusBg: get('scale.blue.8')
   },
+  overlay: {
+    shadow: (theme: any) => `0 1px 3px ${alpha(get('scale.black'), 0.12)(theme)}, 0 16px 32px ${alpha(get('scale.black'), 0.85)(theme)}`,
+  },
   header: {
     text: alpha(get('scale.white'), 0.7),
     bg: get('scale.gray.8'),

--- a/data/colors_v2/vars/component_light.ts
+++ b/data/colors_v2/vars/component_light.ts
@@ -14,7 +14,7 @@ export default {
     tapFocusBg: get('scale.blue.1')
   },
   overlay: {
-    shadow: (theme: any) => `0 1px 3px ${alpha(get('scale.black'), 0.12)(theme)}, 0 8px 24px ${alpha(get('scale.gray.4'), 0.2)(theme)}`,
+    shadow: (theme: any) => `0 1px 3px ${alpha(get('scale.black'), 0.12)(theme)}, 0 8px 24px ${alpha(get('scale.gray.7'), 0.12)(theme)}`,
   },
   header: {
     text: alpha(get('scale.white'), 0.7),

--- a/data/colors_v2/vars/component_light.ts
+++ b/data/colors_v2/vars/component_light.ts
@@ -13,6 +13,9 @@ export default {
     tapHighlight: alpha(get('scale.gray.3'), 0.5),
     tapFocusBg: get('scale.blue.1')
   },
+  overlay: {
+    shadow: (theme: any) => `0 1px 3px ${alpha(get('scale.black'), 0.12)(theme)}, 0 8px 24px ${alpha(get('scale.gray.4'), 0.2)(theme)}`,
+  },
   header: {
     text: alpha(get('scale.white'), 0.7),
     bg: get('scale.gray.9'),


### PR DESCRIPTION
This add `overlay-shadow` variable. Meant to be used for the new [`Overlay`](https://primer.style/components/Overlay) component. Output:

```scss
--color-overlay-shadow: 0 1px 3px rgba(27,31,36,0.12), 0 8px 24px rgba(66,74,83,0.12); // light
--color-overlay-shadow: 0 0 0 1px #30363d, 0 1px 3px rgba(1,4,9,0.12), 0 16px 32px rgba(1,4,9,0.85); // dark
```