### PR TITLE
Border subtle → gray.5

### DIFF
--- a/.changeset/shiny-stingrays-yawn.md
+++ b/.changeset/shiny-stingrays-yawn.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Change HC border subtle → gray.5

--- a/data/colors_v2/themes/dark_high_contrast.ts
+++ b/data/colors_v2/themes/dark_high_contrast.ts
@@ -108,7 +108,8 @@ const exceptions = {
   },
   border: {
     default: get('scale.gray.5'),
-    muted: get('scale.gray.5')
+    muted: get('scale.gray.5'),
+    subtle: get('scale.gray.5')
   },
   neutral: {
     emphasis: get('scale.gray.6')


### PR DESCRIPTION
Makes border.subtle same as default & muted (gray.5)