### PR TITLE
Translate "transparent" to "rgba(0,0,0,0)"

### DIFF
--- a/.changeset/cuddly-news-compete.md
+++ b/.changeset/cuddly-news-compete.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Change "transparent" colors to "rgba(0,0,0,0)"

--- a/script/lib/variable-collection.ts
+++ b/script/lib/variable-collection.ts
@@ -44,6 +44,11 @@ export default class VariableCollection {
     }
 
     const fullName = [this.prefix, ...path].map(value => (isString(value) ? kebabCase(value) : value)).join('-')
+
+    if (value === 'transparent') {
+      value = 'rgba(0,0,0,0)'
+    }
+
     const variable: ModeVariable = {name: fullName, path, value}
 
     this.data.set(fullName, variable)


### PR DESCRIPTION
## Problem

`"transparent"` colors where causing problems in the [primer/components](https://github.com/primer/components) repo: https://github.com/primer/components/pull/1297#discussion_r650248001

## Solution

This PR updates the build script to translate "transparent" to "rgba(0,0,0,0)"
