### PR TITLE
Remove 2nd shadow from overlay-shadow

### DIFF
--- a/.changeset/great-dogs-rescue.md
+++ b/.changeset/great-dogs-rescue.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Remove 2nd shadow from overlay-shadow

--- a/data/colors/dark.ts
+++ b/data/colors/dark.ts
@@ -420,7 +420,7 @@ export default {
     shadow: (theme: any) => `0 16px 32px ${alpha(get('scale.black'), 0.85)(theme)}`
   },
   overlay: {
-    shadow: (theme: any) => `0 0 0 1px ${get('scale.gray.6')(theme)}, 0 1px 3px ${alpha(get('scale.black'), 0.12)(theme)}, 0 16px 32px ${alpha(get('scale.black'), 0.85)(theme)}`,
+    shadow: (theme: any) => `0 0 0 1px ${get('scale.gray.6')(theme)}, 0 16px 32px ${alpha(get('scale.black'), 0.85)(theme)}`,
   },
   label: {
     border: get('scale.gray.6'),

--- a/data/colors_v2/vars/component_dark.ts
+++ b/data/colors_v2/vars/component_dark.ts
@@ -13,7 +13,7 @@ export default {
     tapFocusBg: get('scale.blue.8')
   },
   overlay: {
-    shadow: (theme: any) => `0 0 0 1px ${get('scale.gray.6')(theme)}, 0 1px 3px ${alpha(get('scale.black'), 0.12)(theme)}, 0 16px 32px ${alpha(get('scale.black'), 0.85)(theme)}`,
+    shadow: (theme: any) => `0 0 0 1px ${get('scale.gray.6')(theme)}, 0 16px 32px ${alpha(get('scale.black'), 0.85)(theme)}`,
   },
   header: {
     text: alpha(get('scale.white'), 0.7),


### PR DESCRIPTION
It's barely visible, so might not really be needed. See [Slack](https://github.slack.com/archives/GACAW0NPM/p1623698859411600).