### PR TITLE
Global Nav → input fixes

### DIFF
--- a/.changeset/new-cherries-smoke.md
+++ b/.changeset/new-cherries-smoke.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Global Nav → input fixes

--- a/data/colors_v2/vars/product_dark.ts
+++ b/data/colors_v2/vars/product_dark.ts
@@ -16,9 +16,9 @@ export default {
     text: get('scale.gray.1'),
     icon: get('scale.gray.1'),
     inputBg: get('scale.gray.9'),
-    inputBorder: get('scale.gray.7'),
-    inputIcon: get('scale.gray.7'),
-    inputPlaceholder: get('scale.gray.5')
+    inputBorder: get('border.default'),
+    inputIcon: get('fg.subtle'),
+    inputPlaceholder: get('fg.subtle')
   },
   prettylights: {
     syntax: {


### PR DESCRIPTION
By using functional variables, the input field doesn’t loose the border in HC. Also `inputIcon` and `inputPlaceholder` are mapped to a functional variables now.