### PR TITLE
Jules hc avatar and diffstat borders

### DIFF
--- a/.changeset/little-boats-do.md
+++ b/.changeset/little-boats-do.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Update hc avatar and diffstat borders

--- a/data/colors_v2/themes/dark_high_contrast.ts
+++ b/data/colors_v2/themes/dark_high_contrast.ts
@@ -112,7 +112,7 @@ const exceptions = {
     subtle: get('scale.gray.5')
   },
   avatar: {
-    border: alpha(get('white'), 0.9),
+    border: alpha(get('scale.white'), 0.9),
   },
   diffstat: {
     deletionBorder: get('scale.red.2'),

--- a/data/colors_v2/themes/dark_high_contrast.ts
+++ b/data/colors_v2/themes/dark_high_contrast.ts
@@ -112,7 +112,7 @@ const exceptions = {
     subtle: get('scale.gray.5')
   },
   avatar: {
-    border: get('white'),
+    border: alpha(get('white'), 0.9),
   },
   diffstat: {
     deletionBorder: get('scale.red.2'),

--- a/data/colors_v2/themes/dark_high_contrast.ts
+++ b/data/colors_v2/themes/dark_high_contrast.ts
@@ -111,6 +111,13 @@ const exceptions = {
     muted: get('scale.gray.5'),
     subtle: get('scale.gray.5')
   },
+  avatar: {
+    border: get('white'),
+  },
+  diffstat: {
+    deletionBorder: get('scale.red.2'),
+    additionBorder: get('scale.green.2')
+  },
   neutral: {
     emphasis: get('scale.gray.6')
   },

--- a/data/colors_v2/vars/component_dark.ts
+++ b/data/colors_v2/vars/component_dark.ts
@@ -8,6 +8,10 @@ export default {
     stackFadeMore: get('scale.gray.7'),
     childShadow: (theme: any) => `-2px -2px 0 ${get('scale.gray.9')(theme)}`
   },
+  diffstat: {
+    deletionBorder: get('border.subtle'),
+    additionBorder: get('border.subtle'),
+  },
   selectMenu: {
     backdropBorder: get('scale.gray.5'),
     tapHighlight: alpha(get('scale.gray.6'), 0.5),

--- a/data/colors_v2/vars/component_dark.ts
+++ b/data/colors_v2/vars/component_dark.ts
@@ -3,6 +3,7 @@ import {alpha, darken, get} from '../../../src/utils'
 export default {
   avatar: {
     bg: alpha(get('scale.white'), 0.1),
+    border: get('border.subtle'),
     stackFade: get('scale.gray.6'),
     stackFadeMore: get('scale.gray.7'),
     childShadow: (theme: any) => `-2px -2px 0 ${get('scale.gray.9')(theme)}`

--- a/data/colors_v2/vars/component_light.ts
+++ b/data/colors_v2/vars/component_light.ts
@@ -3,6 +3,7 @@ import {alpha, darken, get} from '../../../src/utils'
 export default {
   avatar: {
     bg: get('scale.white'),
+    border: get('border.subtle'),
     stackFade: get('scale.gray.3'),
     stackFadeMore: get('scale.gray.2'),
     childShadow: (theme: any) => `-2px -2px 0 ${alpha(get('scale.white'), 0.8)(theme)}`

--- a/data/colors_v2/vars/component_light.ts
+++ b/data/colors_v2/vars/component_light.ts
@@ -8,6 +8,10 @@ export default {
     stackFadeMore: get('scale.gray.2'),
     childShadow: (theme: any) => `-2px -2px 0 ${alpha(get('scale.white'), 0.8)(theme)}`
   },
+  diffstat: {
+    deletionBorder: get('border.subtle'),
+    additionBorder: get('border.subtle'),
+  },
   selectMenu: {
     backdropBorder: 'transparent',
     tapHighlight: alpha(get('scale.gray.3'), 0.5),

--- a/data/colors_v2/vars/deprecated.ts
+++ b/data/colors_v2/vars/deprecated.ts
@@ -252,9 +252,6 @@ export default {
       bg: get('neutral.subtle')
     }
   },
-  avatar: {
-    border: get('border.subtle'),
-  },
   box: {
     blueBorder: get('accent.muted'),
     rowYellowBg: get('attention.subtle'),

--- a/data/colors_v2/vars/deprecated.ts
+++ b/data/colors_v2/vars/deprecated.ts
@@ -448,9 +448,7 @@ export default {
     neutralBg: get('neutral.muted'),
     neutralBorder: get('border.subtle'),
     deletionBg: get('danger.emphasis'),
-    deletionBorder: get('border.subtle'),
     additionBg: get('success.emphasis'),
-    additionBorder: get('border.subtle'),
   },
   diff: {
     addition: {


### PR DESCRIPTION
`border.subtle` doesn’t work on Avatars and +/- diffstats since in both cases it’s too dark. Therefore I made two exceptions to keep border.subtle the same as border default and muted. 