### PR TITLE
Deprecate globalNav

### DIFF
--- a/.changeset/lucky-baboons-walk.md
+++ b/.changeset/lucky-baboons-walk.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Deprecate globalNav

--- a/data/colors_v2/vars/deprecated.ts
+++ b/data/colors_v2/vars/deprecated.ts
@@ -584,6 +584,16 @@ export default {
       gradientBg: unset
     }
   },
+  globalNav: {
+    logo: deprecated,
+    bg: deprecated,
+    text: deprecated,
+    icon: deprecated,
+    inputBg: deprecated,
+    inputBorder: deprecated,
+    inputIcon: deprecated,
+    inputPlaceholder: deprecated,
+  },
   introShelf: {
     gradientLeft: get('accent.subtle'),
     gradientRight: get('success.subtle'),

--- a/data/colors_v2/vars/product_dark.ts
+++ b/data/colors_v2/vars/product_dark.ts
@@ -10,16 +10,6 @@ export default {
   diffBlob: {
     selectedLineHighlightMixBlendMode: 'multiply'
   },
-  globalNav: {
-    logo: get('scale.gray.0'),
-    bg: get('scale.gray.8'),
-    text: get('scale.gray.1'),
-    icon: get('scale.gray.1'),
-    inputBg: get('scale.gray.9'),
-    inputBorder: get('border.default'),
-    inputIcon: get('fg.subtle'),
-    inputPlaceholder: get('fg.subtle')
-  },
   prettylights: {
     syntax: {
       comment: get('scale.gray.3'),

--- a/data/colors_v2/vars/product_light.ts
+++ b/data/colors_v2/vars/product_light.ts
@@ -10,16 +10,6 @@ export default {
   diffBlob: {
     selectedLineHighlightMixBlendMode: 'multiply'
   },
-  globalNav: {
-    logo: get('scale.white'),
-    bg: get('scale.gray.9'),
-    text: get('scale.white'),
-    icon: get('scale.white'),
-    inputBg: get('scale.gray.0'),
-    inputBorder: get('scale.gray.0'),
-    inputIcon: get('scale.gray.3'),
-    inputPlaceholder: get('scale.gray.4')
-  },
   prettylights: {
     syntax: {
       comment: get('scale.gray.5'),


### PR DESCRIPTION
These variables seem un-used? Checked in Primer CSS and dotcom. Maybe they got replaced at some point? 🤷 