### PR TITLE
header-input border fix

### DIFF
--- a/.changeset/unlucky-news-breathe.md
+++ b/.changeset/unlucky-news-breathe.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+header-input border fix

--- a/data/colors_v2/vars/product_dark.ts
+++ b/data/colors_v2/vars/product_dark.ts
@@ -158,6 +158,6 @@ export default {
   },
   headerSearch: {
     bg: get('scale.gray.9'),
-    border: get('scale.gray.7')
+    border: get('scale.gray.6')
   }
 }

--- a/data/colors_v2/vars/product_light.ts
+++ b/data/colors_v2/vars/product_light.ts
@@ -158,6 +158,6 @@ export default {
   },
   headerSearch: {
     bg: get('scale.gray.9'),
-    border: get('scale.gray.7')
+    border: get('scale.gray.6')
   }
 }


### PR DESCRIPTION
- To match header button borders, I changed the step to gray.6 for both light and dark. 
- This also fixes the missing border in dark HC for the header input field.