### PR TITLE
Updated green for primary button and success.emphasis

### DIFF
--- a/.changeset/dirty-tables-shout.md
+++ b/.changeset/dirty-tables-shout.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Updated green for primary button and success.emphasis

--- a/data/colors_v2/vars/component_light.ts
+++ b/data/colors_v2/vars/component_light.ts
@@ -83,7 +83,7 @@ export default {
       disabledText: alpha(get('scale.white'), 0.8),
       disabledBg: '#94d3a2',
       disabledBorder: get('border.subtle'),
-      focusBg: get('scale.green.4')',
+      focusBg: get('scale.green.4'),
       focusBorder: get('border.subtle'),
       focusShadow: (theme: any) => `0 0 0 3px ${alpha(get('btn.primary.focusBg'), 0.4)(theme)}`,
       icon: alpha(get('scale.white'), 0.8),

--- a/data/colors_v2/vars/component_light.ts
+++ b/data/colors_v2/vars/component_light.ts
@@ -72,7 +72,7 @@ export default {
 
     primary: {
       text: get('scale.white'),
-      bg: '#2ea44f',
+      bg: get('scale.green.4'),
       border: get('border.subtle'),
       shadow: (theme: any) => `0 1px 0 ${alpha(get('scale.black'), 0.1)(theme)}`,
       insetShadow: (theme: any) => `inset 0 1px 0 ${alpha(get('scale.white'), 0.03)(theme)}`,
@@ -83,7 +83,7 @@ export default {
       disabledText: alpha(get('scale.white'), 0.8),
       disabledBg: '#94d3a2',
       disabledBorder: get('border.subtle'),
-      focusBg: '#2ea44f',
+      focusBg: get('scale.green.4')',
       focusBorder: get('border.subtle'),
       focusShadow: (theme: any) => `0 0 0 3px ${alpha(get('btn.primary.focusBg'), 0.4)(theme)}`,
       icon: alpha(get('scale.white'), 0.8),

--- a/data/colors_v2/vars/global_light.ts
+++ b/data/colors_v2/vars/global_light.ts
@@ -40,7 +40,7 @@ export default {
   },
   success: {
     fg: get('scale.green.5'),
-    emphasis: get('scale.green.5'),
+    emphasis: get('scale.green.4'),
     muted: alpha(get('scale.green.3'), 0.4),
     subtle: get('scale.green.0')
   },


### PR DESCRIPTION
Based on early feedback and todays discussion with @broccolini we decided to 
- change success.emphasis to green.4 instead of .5
- map primary button also to the scale since colors are identical

**This change is top priority and blocks staff ship**