### PR TITLE
Fix checks header

### DIFF
--- a/.changeset/large-clouds-smash.md
+++ b/.changeset/large-clouds-smash.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Fix checks header

--- a/data/colors_v2/vars/product_dark.ts
+++ b/data/colors_v2/vars/product_dark.ts
@@ -106,7 +106,7 @@ export default {
     gateBg: get('attention.subtle'),
     gateText: get('fg.muted'),
     gateWaitingText: get('attention.fg'),
-    stepHeaderOpenBg: get('neutral.subtle'),
+    stepHeaderOpenBg: get('canvas.subtle)'),
     stepErrorText: get('danger.fg'),
     stepWarningText: get('attention.fg'),
     loglineText: get('fg.muted'),

--- a/data/colors_v2/vars/product_dark.ts
+++ b/data/colors_v2/vars/product_dark.ts
@@ -106,7 +106,7 @@ export default {
     gateBg: get('attention.subtle'),
     gateText: get('fg.muted'),
     gateWaitingText: get('attention.fg'),
-    stepHeaderOpenBg: get('canvas.subtle)'),
+    stepHeaderOpenBg: get('canvas.subtle'),
     stepErrorText: get('danger.fg'),
     stepWarningText: get('attention.fg'),
     loglineText: get('fg.muted'),


### PR DESCRIPTION
This fixes the checks header that is currently semi-transparent in dark mode and makes it hard to read when scrolling.

Before | After
--- | ---
![Screen Shot 2021-06-23 at 14 52 07](https://user-images.githubusercontent.com/378023/123043838-d6f91200-d433-11eb-8dba-b300bc7ded88.png) | ![Screen Shot 2021-06-23 at 14 52 29](https://user-images.githubusercontent.com/378023/123043842-d82a3f00-d433-11eb-8b5e-9d716e316514.png)
