### PR TITLE
Use default header for Box-header--blue in dark mode

### DIFF
--- a/.changeset/four-parrots-tap.md
+++ b/.changeset/four-parrots-tap.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Use default header for Box-header--blue in dark mode

--- a/data/colors_v2/vars/component_dark.ts
+++ b/data/colors_v2/vars/component_dark.ts
@@ -8,6 +8,10 @@ export default {
     stackFadeMore: get('scale.gray.7'),
     childShadow: (theme: any) => `-2px -2px 0 ${get('scale.gray.9')(theme)}`
   },
+  box: {
+    headerBlueBg: get('canvas.subtle'),
+    headerBlueBorder: get('border.default'),
+  },
   diffstat: {
     deletionBorder: get('border.subtle'),
     additionBorder: get('border.subtle'),

--- a/data/colors_v2/vars/component_light.ts
+++ b/data/colors_v2/vars/component_light.ts
@@ -8,6 +8,10 @@ export default {
     stackFadeMore: get('scale.gray.2'),
     childShadow: (theme: any) => `-2px -2px 0 ${alpha(get('scale.white'), 0.8)(theme)}`
   },
+  box: {
+    headerBlueBg: get('accent.subtle'),
+    headerBlueBorder: get('accent.muted'),
+  },
   diffstat: {
     deletionBorder: get('border.subtle'),
     additionBorder: get('border.subtle'),

--- a/data/colors_v2/vars/deprecated.ts
+++ b/data/colors_v2/vars/deprecated.ts
@@ -256,8 +256,6 @@ export default {
     blueBorder: get('accent.muted'),
     rowYellowBg: get('attention.subtle'),
     rowBlueBg: get('accent.subtle'),
-    headerBlueBg: get('accent.subtle'),
-    headerBlueBorder: get('accent.muted'),
     borderInfo: get('accent.muted'),
     bgInfo: get('accent.subtle'),
     borderWarning: get('attention.muted'),


### PR DESCRIPTION
This PR un-deprecates the blue Box header variables so that it can:

- stay blue in light mode
- change to gray in dark mode

Before | After
--- | ---
![Screen Shot 2021-06-23 at 16 53 32](https://user-images.githubusercontent.com/378023/123058250-986b5380-d443-11eb-9159-a9f91f779635.png) | ![Screen Shot 2021-06-23 at 16 53 32](https://user-images.githubusercontent.com/378023/123058250-986b5380-d443-11eb-9159-a9f91f779635.png)
![Screen Shot 2021-06-23 at 16 47 39](https://user-images.githubusercontent.com/378023/123058098-6bb73c00-d443-11eb-8e85-96a0f763cbec.png) | ![Screen Shot 2021-06-23 at 16 48 41](https://user-images.githubusercontent.com/378023/123058102-6d80ff80-d443-11eb-9a35-68203e65ef25.png)
