### PR TITLE
Remapped neutral.emphasis to gray.4 instead of gray.6

### DIFF
--- a/.changeset/friendly-trains-cry.md
+++ b/.changeset/friendly-trains-cry.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Remapped neutral.emphasis to gray.4 instead of gray.6

--- a/data/colors_v2/themes/dark_high_contrast.ts
+++ b/data/colors_v2/themes/dark_high_contrast.ts
@@ -125,7 +125,7 @@ const exceptions = {
     subtle: get('scale.gray.5')
   },
   neutral: {
-    emphasis: get('scale.gray.6')
+    emphasis: get('scale.gray.4')
   },
   accent: {
     muted: get('scale.blue.4'),


### PR DESCRIPTION
This will fix the draft pill and tooltips not having enough contrast.