### PR TITLE
Add `primer.fg.white`

### DIFF
--- a/.changeset/nasty-doors-perform.md
+++ b/.changeset/nasty-doors-perform.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": minor
+---
+
+Add `primer.fg.white`

--- a/data/colors_v2/vars/deprecated.ts
+++ b/data/colors_v2/vars/deprecated.ts
@@ -120,7 +120,7 @@ export default {
     danger: get('danger.fg'),
     success: get('success.fg'),
     warning: get('attention.fg'),
-    white: get('fg.onEmphasis')
+    white: get('primer.fg.white')
   },
   icon: {
     primary: get('fg.default'),

--- a/data/colors_v2/vars/global_dark.ts
+++ b/data/colors_v2/vars/global_dark.ts
@@ -77,6 +77,9 @@ export default {
 
   // Only meant for Primer components
   primer: {
+    fg: {
+      white: get('scale.white'),
+    },
     canvas: {
       backdrop: alpha(get('scale.black'), 0.8), // use for modal/dialogs
       sticky: alpha(get('scale.gray.9'), 0.95) // use for sticky headers

--- a/data/colors_v2/vars/global_light.ts
+++ b/data/colors_v2/vars/global_light.ts
@@ -77,6 +77,9 @@ export default {
 
   // Only meant to be used by Primer components
   primer: {
+    fg: {
+      white: get('scale.white'),
+    },
     canvas: {
       backdrop: alpha(get('scale.black'), 0.5), // use for modal/dialogs
       sticky: alpha(get('scale.white'), 0.95) // use for sticky headers


### PR DESCRIPTION
This adds a new `primer.fg.white` variable that is `white` in all themes. It gets used to map `text.white` -> `primer.fg.white`.

This is needed because `fg.onEmphasis` got changed to dark in HC and causing regressions.