### PR TITLE
Deprecate text-white

### DIFF
--- a/.changeset/wild-camels-begin.md
+++ b/.changeset/wild-camels-begin.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": minor
+---
+
+Deprecate text-white

--- a/data/colors_v2/vars/deprecated.ts
+++ b/data/colors_v2/vars/deprecated.ts
@@ -120,7 +120,7 @@ export default {
     danger: get('danger.fg'),
     success: get('success.fg'),
     warning: get('attention.fg'),
-    white: get('primer.fg.white')
+    white: get('fg.onEmphasis')
   },
   icon: {
     primary: get('fg.default'),

--- a/data/colors_v2/vars/deprecated.ts
+++ b/data/colors_v2/vars/deprecated.ts
@@ -120,7 +120,7 @@ export default {
     danger: get('danger.fg'),
     success: get('success.fg'),
     warning: get('attention.fg'),
-    white: get('fg.onEmphasis')
+    white: deprecated,
   },
   icon: {
     primary: get('fg.default'),

--- a/data/colors_v2/vars/global_dark.ts
+++ b/data/colors_v2/vars/global_dark.ts
@@ -77,9 +77,6 @@ export default {
 
   // Only meant for Primer components
   primer: {
-    fg: {
-      white: get('scale.white'),
-    },
     canvas: {
       backdrop: alpha(get('scale.black'), 0.8), // use for modal/dialogs
       sticky: alpha(get('scale.gray.9'), 0.95) // use for sticky headers

--- a/data/colors_v2/vars/global_light.ts
+++ b/data/colors_v2/vars/global_light.ts
@@ -77,9 +77,6 @@ export default {
 
   // Only meant to be used by Primer components
   primer: {
-    fg: {
-      white: get('scale.white'),
-    },
     canvas: {
       backdrop: alpha(get('scale.black'), 0.5), // use for modal/dialogs
       sticky: alpha(get('scale.white'), 0.95) // use for sticky headers


### PR DESCRIPTION
This reverts https://github.com/primer/primitives/pull/172 again and instead deprecates `text-white`. See [Slack](https://github.slack.com/archives/C016WHYJJAW/p1624525266196000).

## TODO:

- Make sure to add a hack on dotcom because `color-text-white` is still used over 500 times.