### PR TITLE
Update selectedLineHighlightMixBlendMode in dark mode

### DIFF
--- a/.changeset/tough-beds-sparkle.md
+++ b/.changeset/tough-beds-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Update `diffBlob.selectedLineHighlightMixBlendMode` in dark mode

--- a/data/colors_v2/vars/product_dark.ts
+++ b/data/colors_v2/vars/product_dark.ts
@@ -19,7 +19,7 @@ export default {
     expander: {
       icon: get('fg.muted'),
     },
-    selectedLineHighlightMixBlendMode: 'multiply'
+    selectedLineHighlightMixBlendMode: 'screen'
   },
   prettylights: {
     syntax: {


### PR DESCRIPTION
This changes the `diffBlob.selectedLineHighlightMixBlendMode` from `multiply` to `screen` in dark mode.

Light | Dark | Dark Dimmed | Dark high contrast
--- | --- | --- | ---
`multiply ` | `screen ` | `screen ` | `screen `
![Screen Shot 2021-06-29 at 8 52 08](https://user-images.githubusercontent.com/378023/123717402-bb6c8c00-d8b7-11eb-8b37-5ae96088e797.png) | ![Screen Shot 2021-06-29 at 8 50 59](https://user-images.githubusercontent.com/378023/123717394-b9a2c880-d8b7-11eb-84cb-16203deafaa7.png) | ![Screen Shot 2021-06-29 at 8 51 12](https://user-images.githubusercontent.com/378023/123717404-bb6c8c00-d8b7-11eb-9b59-4cb932e4933a.png) | ![Screen Shot 2021-06-29 at 8 51 26](https://user-images.githubusercontent.com/378023/123717406-bc052280-d8b7-11eb-8e8c-0ef7468cb34d.png)

Might not be perfect, but should improve the almost invisible `multiply` in dark mode.

![Screen Shot 2021-06-22 at 15 20 04](https://user-images.githubusercontent.com/378023/122874161-9fc02d80-d36d-11eb-8571-a0e616fbceac.png)