### PR TITLE
Change `codemirror.selectionBg` to muted

### DIFF
--- a/.changeset/fast-worms-fry.md
+++ b/.changeset/fast-worms-fry.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Update `codemirror.selectionBg`

--- a/data/colors_v2/themes/dark_high_contrast.ts
+++ b/data/colors_v2/themes/dark_high_contrast.ts
@@ -175,6 +175,9 @@ const exceptions = {
       counterBg: alpha(get('scale.black'), 0.15)
     }
   },
+  codemirror: {
+    selectionBg: alpha(get('scale.blue.4'), 0.4),
+  },
   diffBlob: {
     addition: {
       numText: get('fg.onEmphasis'),

--- a/data/colors_v2/vars/product_dark.ts
+++ b/data/colors_v2/vars/product_dark.ts
@@ -63,7 +63,7 @@ export default {
     guttermarkerSubtleText: get('fg.subtle'),
     linenumberText: get('fg.muted'),
     cursor: get('fg.default'),
-    selectionBg: get('accent.subtle'),
+    selectionBg: get('accent.muted'),
     activelineBg: get('neutral.subtle'),
     matchingbracketText: get('fg.default'),
     linesBg: get('canvas.default'),

--- a/data/colors_v2/vars/product_light.ts
+++ b/data/colors_v2/vars/product_light.ts
@@ -63,7 +63,7 @@ export default {
     guttermarkerSubtleText: get('fg.subtle'),
     linenumberText: get('fg.muted'),
     cursor: get('fg.default'),
-    selectionBg: get('accent.subtle'),
+    selectionBg: get('accent.muted'),
     activelineBg: get('neutral.subtle'),
     matchingbracketText: get('fg.default'),
     linesBg: get('canvas.default'),


### PR DESCRIPTION
Currently text selection when editing a file is barely visible in HC:

![Screen Shot 2021-06-29 at 9 11 22](https://user-images.githubusercontent.com/378023/123718485-35057980-d8ba-11eb-91a3-e191fba448cf.png)

This PR changes the selection from `subtle ` to `muted`:

Light | Dark | Dark Dimmed | Dark high contrast
--- | --- | --- | ---
![Screen Shot 2021-06-29 at 9 10 23](https://user-images.githubusercontent.com/378023/123718575-78f87e80-d8ba-11eb-896d-652b5899519c.png) | ![Screen Shot 2021-06-29 at 9 10 35](https://user-images.githubusercontent.com/378023/123718572-785fe800-d8ba-11eb-8ff3-6b5c43fad0c8.png) | ![Screen Shot 2021-06-29 at 9 10 46](https://user-images.githubusercontent.com/378023/123718569-77c75180-d8ba-11eb-8d58-88cca1b25f97.png) | ![Screen Shot 2021-06-29 at 20 30 42](https://user-images.githubusercontent.com/378023/123790100-e89d5680-d918-11eb-89dd-6063787206f4.png)

This matches the [`accent.muted`](https://github.com/primer/primitives/blob/9d296aa182593456b44384af9c22e0a101515711/data/colors_v2/vars/deprecated.ts#L323) used for selection of code in "read-only" mode.