### PR TITLE
Move header-search from product to component

### DIFF
--- a/.changeset/four-monkeys-clap.md
+++ b/.changeset/four-monkeys-clap.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Move header-search from product to component

--- a/data/colors_v2/vars/component_dark.ts
+++ b/data/colors_v2/vars/component_dark.ts
@@ -23,7 +23,11 @@ export default {
   header: {
     text: alpha(get('scale.white'), 0.7),
     bg: get('scale.gray.8'),
-    logo: get('scale.gray.0')
+    logo: get('scale.gray.0'),
+    search: {
+      bg: get('scale.gray.9'),
+      border: get('scale.gray.6')
+    }
   },
   sidenav: {
     selectedBg: get('scale.gray.7')

--- a/data/colors_v2/vars/component_light.ts
+++ b/data/colors_v2/vars/component_light.ts
@@ -23,7 +23,11 @@ export default {
   header: {
     text: alpha(get('scale.white'), 0.7),
     bg: get('scale.gray.9'),
-    logo: get('scale.white')
+    logo: get('scale.white'),
+    search: {
+      bg: get('scale.gray.9'),
+      border: get('scale.gray.6')
+    }
   },
   sidenav: {
     selectedBg: get('scale.white')

--- a/data/colors_v2/vars/product_dark.ts
+++ b/data/colors_v2/vars/product_dark.ts
@@ -160,9 +160,5 @@ export default {
     sidebarBg: get('scale.gray.8'),
     gradientIn: get('scale.gray.8'),
     gradientOut: alpha(get('scale.gray.8'), 0)
-  },
-  headerSearch: {
-    bg: get('scale.gray.9'),
-    border: get('scale.gray.6')
   }
 }

--- a/data/colors_v2/vars/product_light.ts
+++ b/data/colors_v2/vars/product_light.ts
@@ -160,9 +160,5 @@ export default {
     sidebarBg: get('scale.white'),
     gradientIn: get('scale.white'),
     gradientOut: alpha(get('scale.white'), 0)
-  },
-  headerSearch: {
-    bg: get('scale.gray.9'),
-    border: get('scale.gray.6')
   }
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/primer/css/pull/1506.

The output is the same, but because the "Header" component now has an input, it more more sense to have these variables under "component".