### PR TITLE
Changed alert foregrounds to use `fg.default`

### DIFF
--- a/.changeset/slimy-bulldogs-boil.md
+++ b/.changeset/slimy-bulldogs-boil.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Changed alert foregrounds to use `fg.default`

--- a/data/colors_v2/vars/deprecated.ts
+++ b/data/colors_v2/vars/deprecated.ts
@@ -209,25 +209,25 @@ export default {
   },
   alert: {
     info: {
-      text: get('accent.fg'),
+      text: get('fg.default'),
       icon: get('accent.fg'),
       bg: get('accent.subtle'),
       border: get('accent.muted')
     },
     warn: {
-      text: get('attention.fg'),
+      text: get('fg.default'),
       icon: get('attention.fg'),
       bg: get('attention.subtle'),
       border: get('attention.muted')
     },
     error: {
-      text: get('danger.fg'),
+      text: get('fg.default'),
       icon: get('danger.fg'),
       bg: get('danger.subtle'),
       border: get('danger.muted')
     },
     success: {
-      text: get('success.fg'),
+      text: get('fg.default'),
       icon: get('success.fg'),
       bg: get('success.subtle'),
       border: get('success.muted')


### PR DESCRIPTION
One of the last minute fixes we didn't get around doing before beta rollout. Reference here 👉 https://github.com/github/primer/issues/158#issuecomment-868286654