### PR TITLE
Increase dark checks.inputBg contrast

### DIFF
--- a/.changeset/tough-moose-unite.md
+++ b/.changeset/tough-moose-unite.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Increase dark checks.inputBg contrast

--- a/data/colors_v2/vars/product_dark.ts
+++ b/data/colors_v2/vars/product_dark.ts
@@ -91,7 +91,7 @@ export default {
     inputText: get('fg.muted'),
     inputPlaceholderText: get('fg.subtle'),
     inputFocusText: get('fg.default'),
-    inputBg: get('canvas.default'),
+    inputBg: get('scale.gray.8'),
     inputShadow: (theme: any) => `0 0 0 1px ${get('border.default')(theme)}`,
     donutError: get('scale.red.4'),
     donutPending: get('scale.yellow.3'),


### PR DESCRIPTION
Currently the checks input is a bit hard to see in dark mode. This PR increases the contrast a bit:

Theme | Before | After
--- | ---  | ---
Dark | ![Screen Shot 2021-07-27 at 9 15 18](https://user-images.githubusercontent.com/378023/127075735-5c05b182-7604-47fa-ad5a-dd18f6afdd81.png) | ![Screen Shot 2021-07-27 at 9 15 28](https://user-images.githubusercontent.com/378023/127075739-2375ffdc-fea6-4d03-b1bb-77d0cdad5fd8.png)
Dark Dimmed | ![Screen Shot 2021-07-27 at 9 15 45](https://user-images.githubusercontent.com/378023/127075740-4f345563-7787-4897-bf14-6ccb408b7cba.png) | ![Screen Shot 2021-07-27 at 9 16 03](https://user-images.githubusercontent.com/378023/127075743-25a845a5-2f28-4758-af2d-bbf3402c6d53.png)
Dark High Contrast | ![Screen Shot 2021-07-27 at 9 08 48](https://user-images.githubusercontent.com/378023/127075786-291e2a77-d8fe-461c-8fb0-3524bdec2a7a.png) | ![Screen Shot 2021-07-27 at 9 09 04](https://user-images.githubusercontent.com/378023/127075789-0db7a31c-1f6c-42e6-9fd6-5bfbd040c9f8.png)

An alternative might be to just use a border like the rest of the inputs, but not sure how well that would go down with @adrianmg 😅 

---

Reported in https://github.com/github/design-systems/discussions/1439#discussioncomment-879059


