### PR TITLE
Increase `<code>` contrast

### DIFF
--- a/.changeset/long-pumpkins-unite.md
+++ b/.changeset/long-pumpkins-unite.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Increase `<code>` contrast

--- a/data/colors_v2/vars/deprecated.ts
+++ b/data/colors_v2/vars/deprecated.ts
@@ -274,7 +274,7 @@ export default {
     }
   },
   markdown: {
-    codeBg: get('neutral.subtle'),
+    codeBg: get('neutral.muted'),
     frameBorder: get('border.default'),
     blockquoteBorder: get('border.default'),
     tableBorder: get('border.default'),


### PR DESCRIPTION
This increases the background contrast for these `code` blocks by using `neutral.muted` instead of `neutral.subtle`.

Theme | Before | After
--- | --- | ---
Light | ![Screen Shot 2021-07-27 at 16 20 21](https://user-images.githubusercontent.com/378023/127113578-73c46aa4-c830-4893-babe-fe1225004aa5.png) | ![Screen Shot 2021-07-27 at 16 20 32](https://user-images.githubusercontent.com/378023/127113586-4eb62ea8-58c2-4278-88b5-f898a0b859b7.png)
Dark | ![Screen Shot 2021-07-27 at 16 20 45](https://user-images.githubusercontent.com/378023/127113590-53f04745-f587-46a0-9ffe-d98f073f37a2.png) | ![Screen Shot 2021-07-27 at 16 20 55](https://user-images.githubusercontent.com/378023/127113593-ec80ab72-cd95-488e-8a17-6bd2943d379b.png)
Dark Dimmed | ![Screen Shot 2021-07-27 at 16 21 13](https://user-images.githubusercontent.com/378023/127113597-ca334db1-d21c-4d75-b16e-d431aea45afa.png) | ![Screen Shot 2021-07-27 at 16 21 24](https://user-images.githubusercontent.com/378023/127113598-f040b4fb-36b7-4251-85a5-0a88c6a9816c.png)
Dark High Contrast | ![Screen Shot 2021-07-27 at 16 21 41](https://user-images.githubusercontent.com/378023/127113601-99ee5c79-c9d1-4599-a805-de838ad516c1.png) | ![Screen Shot 2021-07-27 at 16 21 51](https://user-images.githubusercontent.com/378023/127113603-7d12a330-da93-476d-8c5b-ae40e3d3e7fe.png)

---

Reported in [1](https://github.community/t/feedback-on-dark-mode-high-contrast/187924/2) + [2](https://github.community/t/feedback-on-dark-mode-high-contrast/187924/21)