### PR TITLE
Underline nav contrast improvements

### DIFF
--- a/.changeset/heavy-cougars-act.md
+++ b/.changeset/heavy-cougars-act.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Underline nav contrast improvements

--- a/data/colors/dark.ts
+++ b/data/colors/dark.ts
@@ -601,7 +601,7 @@ export default {
   underlinenav: {
     border: alpha(get('scale.gray.6'), 0),
     borderHover: get('scale.gray.6'),
-    borderActive: get('#f78166'),
+    borderActive: '#f78166',
     text: get('scale.gray.3'),
     textHover: get('scale.gray.1'),
     textActive: get('scale.gray.1'),

--- a/data/colors/dark.ts
+++ b/data/colors/dark.ts
@@ -601,7 +601,7 @@ export default {
   underlinenav: {
     border: alpha(get('scale.gray.6'), 0),
     borderHover: get('scale.gray.6'),
-    borderActive: get('scale.coral.3'),
+    borderActive: get('#f78166'),
     text: get('scale.gray.3'),
     textHover: get('scale.gray.1'),
     textActive: get('scale.gray.1'),

--- a/data/colors/dark.ts
+++ b/data/colors/dark.ts
@@ -601,7 +601,7 @@ export default {
   underlinenav: {
     border: alpha(get('scale.gray.6'), 0),
     borderHover: get('scale.gray.6'),
-    borderActive: '#f78166',
+    borderActive: get('scale.coral.3'),
     text: get('scale.gray.3'),
     textHover: get('scale.gray.1'),
     textActive: get('scale.gray.1'),

--- a/data/colors_v2/themes/dark_high_contrast.ts
+++ b/data/colors_v2/themes/dark_high_contrast.ts
@@ -156,6 +156,10 @@ const exceptions = {
     deletionBorder: get('scale.red.2'),
     additionBorder: get('scale.green.2')
   },
+  underlinenav : {
+    icon: get('scale.gray.1'),
+    borderHover: get('scale.gray.3'),
+  },
   btn: {
     selectedBg: alpha(get('scale.gray.6'), 0.9),
     primary: {


### PR DESCRIPTION
Based on this [feedback](https://github.com/github/github/discussions/183946#discussioncomment-1051866) I 
- Unified icon color
- Increased border hover contrast … _which was reported as well as an issue_
- ~~Mapped coral to scale~~
