### PR TITLE
Un-deprecate `search-keyword-hl`

### DIFF
--- a/.changeset/small-buttons-peel.md
+++ b/.changeset/small-buttons-peel.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Un-deprecate `search-keyword-hl`

--- a/data/colors_v2/vars/deprecated.ts
+++ b/data/colors_v2/vars/deprecated.ts
@@ -309,9 +309,6 @@ export default {
     text: get('fg.onEmphasis'),
     bg: get('neutral.emphasisPlus')
   },
-  searchKeyword: {
-    hl: get('attention.subtle')
-  },
   filesExplorerIcon: get('accent.fg'),
   hlAuthorBg: get('accent.subtle'),
   hlAuthorBorder: get('accent.muted'),

--- a/data/colors_v2/vars/product_dark.ts
+++ b/data/colors_v2/vars/product_dark.ts
@@ -21,6 +21,7 @@ export default {
     },
     selectedLineHighlightMixBlendMode: 'screen'
   },
+  searchKeywordHl: alpha(get('scale.yellow.3'), 0.4),
   prettylights: {
     syntax: {
       comment: get('scale.gray.3'),

--- a/data/colors_v2/vars/product_light.ts
+++ b/data/colors_v2/vars/product_light.ts
@@ -21,6 +21,7 @@ export default {
     },
     selectedLineHighlightMixBlendMode: 'multiply'
   },
+  searchKeywordHl: get('scale.yellow.0'),
   prettylights: {
     syntax: {
       comment: get('scale.gray.5'),


### PR DESCRIPTION
This un-deprecates `search-keyword-hl` as a product variable and instead of using `attention.subtle`. It improves https://github.com/github/design-infrastructure/discussions/1439#discussioncomment-1152618.

`light` | `dark` | `dark_dimmed` | `dark_high_contrast`
--- | --- | --- | ---
![Screen Shot 2021-08-11 at 15 27 16](https://user-images.githubusercontent.com/378023/128980414-01cc646f-4240-4c14-b127-a7b89cd14df4.png) | ![Screen Shot 2021-08-11 at 15 28 08](https://user-images.githubusercontent.com/378023/128980418-d41914a5-29da-44d3-822f-ac64f11ca644.png) | ![Screen Shot 2021-08-11 at 15 28 43](https://user-images.githubusercontent.com/378023/128980420-428d11fd-fa56-4464-bea9-e0cd97ee3010.png) | ![Screen Shot 2021-08-11 at 15 29 55](https://user-images.githubusercontent.com/378023/128980424-e7e7deb9-c13a-49ca-a619-aab3fb88f768.png)


### Alternatives

Initially tried to use `attention-muted`. It kinda works for `dark` and `dark_dimmed`, but `light` and `dark_high_contrast` seem off:

`light` | `dark_high_contrast`
--- | ---
![Screen Shot 2021-08-11 at 15 19 45](https://user-images.githubusercontent.com/378023/128979281-62a771f7-6d07-4ff1-93ff-05c25ecc6d85.png) | ![Screen Shot 2021-08-11 at 15 19 27](https://user-images.githubusercontent.com/378023/128979275-156a0eaf-fa21-4331-8796-934a426e4e9c.png)

### Related

Also related to https://github.com/github/design-infrastructure/discussions/1439#discussioncomment-877969



