### PR TITLE
Bug fixes from v2

### DIFF
--- a/.changeset/stale-spies-juggle.md
+++ b/.changeset/stale-spies-juggle.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Various v2 improvements

--- a/data/colors_v2/vars/component_dark.ts
+++ b/data/colors_v2/vars/component_dark.ts
@@ -35,6 +35,11 @@ export default {
   menu: {
     bgActive: get('scale.gray.8')
   },
+
+  input: {
+    disabledBg: alpha(get('neutral.muted'), 0.5),
+      },
+     
   ansi: {
     black: get('scale.gray.5'),
     blackBright: get('scale.gray.4'),

--- a/data/colors_v2/vars/component_dark.ts
+++ b/data/colors_v2/vars/component_dark.ts
@@ -35,11 +35,9 @@ export default {
   menu: {
     bgActive: get('scale.gray.8')
   },
-
   input: {
-    disabledBg: alpha(get('neutral.muted'), 0.5),
-      },
-     
+    disabledBg: alpha(get('neutral.muted'), 0.5)
+  }, 
   ansi: {
     black: get('scale.gray.5'),
     blackBright: get('scale.gray.4'),

--- a/data/colors_v2/vars/component_light.ts
+++ b/data/colors_v2/vars/component_light.ts
@@ -35,11 +35,9 @@ export default {
   menu: {
     bgActive: 'transparent'
   },
-
   input: {
-    disabledBg: get('neutral.muted'),
-      },
-      
+    disabledBg: get('neutral.muted')
+  },
   // TODO: Move to VSCode theme?
   ansi: {
     black: get('scale.gray.9'),

--- a/data/colors_v2/vars/component_light.ts
+++ b/data/colors_v2/vars/component_light.ts
@@ -35,6 +35,11 @@ export default {
   menu: {
     bgActive: 'transparent'
   },
+
+  input: {
+    disabledBg: get('neutral.muted'),
+      },
+      
   // TODO: Move to VSCode theme?
   ansi: {
     black: get('scale.gray.9'),

--- a/data/colors_v2/vars/deprecated.ts
+++ b/data/colors_v2/vars/deprecated.ts
@@ -329,7 +329,7 @@ export default {
   topicTag: {
     text: get('accent.fg'),
     bg: get('accent.subtle'),
-    hoverBg: alpha(get('accent.muted'), 0.5),
+    hoverBg: get('accent.muted'),
     activeBg: get('accent.subtle')
   },
   footerInvertocat: {

--- a/data/colors_v2/vars/deprecated.ts
+++ b/data/colors_v2/vars/deprecated.ts
@@ -329,7 +329,7 @@ export default {
   topicTag: {
     text: get('accent.fg'),
     bg: get('accent.subtle'),
-    hoverBg: get('accent.muted'),
+    hoverBg: alpha(get('accent.muted'), 0.5),
     activeBg: get('accent.subtle')
   },
   footerInvertocat: {

--- a/data/colors_v2/vars/deprecated.ts
+++ b/data/colors_v2/vars/deprecated.ts
@@ -375,7 +375,6 @@ export default {
     contrastBg: get('canvas.inset'),
     border: get('border.default'),
     shadow: get('primer.shadow.inset'),
-    disabledBg: get('neutral.muted'),
     disabledBorder: get('border.default'),
     warningBorder: get('attention.emphasis'),
     errorBorder: get('danger.emphasis'),

--- a/data/colors_v2/vars/deprecated.ts
+++ b/data/colors_v2/vars/deprecated.ts
@@ -266,7 +266,7 @@ export default {
   branchName: {
     text: get('fg.muted'),
     icon: get('fg.muted'),
-    bg: get('neutral.subtle'),
+    bg: get('accent.subtle'),
     link: {
       text: get('accent.fg'),
       icon: get('accent.fg'),

--- a/data/colors_v2/vars/global_light.ts
+++ b/data/colors_v2/vars/global_light.ts
@@ -29,7 +29,7 @@ export default {
   neutral: {
     emphasisPlus: get('scale.gray.9'),
     emphasis: get('scale.gray.5'),
-    muted: alpha(get('scale.gray.3'), 0.4),
+    muted: alpha(get('scale.gray.3'), 0.20),
     subtle: alpha(get('scale.gray.1'), 0.5)
   },
   accent: {

--- a/data/colors_v2/vars/global_light.ts
+++ b/data/colors_v2/vars/global_light.ts
@@ -29,7 +29,7 @@ export default {
   neutral: {
     emphasisPlus: get('scale.gray.9'),
     emphasis: get('scale.gray.5'),
-    muted: alpha(get('scale.gray.3'), 0.20),
+    muted: alpha(get('scale.gray.3'), 0.2),
     subtle: alpha(get('scale.gray.1'), 0.5)
   },
   accent: {


### PR DESCRIPTION
#### Changed `neutral.muted`
Updated `neutral.muted` to be lighter in light mode: this fixes the [contrast issue](https://github.com/github/design-infrastructure/discussions/1439#discussioncomment-1052279) with the markdown preformatted text background. With this update we're hoping to get the code block also using `neutral.muted`, as well as the badges from the timeline. I don't think this is blocking so here's an [issue](https://github.com/github/design-infrastructure/issues/1710) with post GA tasks.

Fixed in this PR: 
https://github.com/github/design-infrastructure/discussions/1439#discussioncomment-1126703

During cleanups this change will allow to refactor [other components](https://github.com/github/design-infrastructure/discussions/1439#discussioncomment-920957) to also use `neutral.muted` as mentioned above.

#### Undeprecated `input.disabledBg` 
Fixes this 👉 https://github.com/github/design-infrastructure/projects/63#card-66570268