### PR TITLE
Bug fixes

### DIFF
--- a/.changeset/smart-waves-brake.md
+++ b/.changeset/smart-waves-brake.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Bug fixes

--- a/data/colors_v2/themes/dark_high_contrast.ts
+++ b/data/colors_v2/themes/dark_high_contrast.ts
@@ -194,6 +194,9 @@ const exceptions = {
     expander: {
       icon: get('fg.onEmphasis'),
     },
+    hunk: {
+      numBg: alpha(get('accent.muted'), 0.4),
+    },
   },
 }
 

--- a/data/colors_v2/vars/component_dark.ts
+++ b/data/colors_v2/vars/component_dark.ts
@@ -8,10 +8,7 @@ export default {
     stackFadeMore: get('scale.gray.7'),
     childShadow: (theme: any) => `-2px -2px 0 ${get('scale.gray.9')(theme)}`
   },
-  diffstat: {
-    deletionBorder: get('border.subtle'),
-    additionBorder: get('border.subtle'),
-  },
+  
   topicTag: {
     border: 'transparent'
   },

--- a/data/colors_v2/vars/component_light.ts
+++ b/data/colors_v2/vars/component_light.ts
@@ -8,10 +8,7 @@ export default {
     stackFadeMore: get('scale.gray.2'),
     childShadow: (theme: any) => `-2px -2px 0 ${alpha(get('scale.white'), 0.8)(theme)}`
   },
-  diffstat: {
-    deletionBorder: get('border.subtle'),
-    additionBorder: get('border.subtle'),
-  },
+  
   topicTag: {
     border: 'transparent'
   },

--- a/data/colors_v2/vars/deprecated.ts
+++ b/data/colors_v2/vars/deprecated.ts
@@ -233,6 +233,7 @@ export default {
       border: get('success.muted')
     }
   },
+
   autocomplete: {
     shadow: get('shadow.medium'),
     rowBorder: get('border.muted')
@@ -273,6 +274,7 @@ export default {
       bg: get('accent.subtle')
     }
   },
+  
   markdown: {
     codeBg: get('neutral.muted'),
     frameBorder: get('border.default'),
@@ -443,6 +445,8 @@ export default {
   diffstat: {
     neutralBg: get('neutral.muted'),
     neutralBorder: get('border.subtle'),
+    deletionBorder: get('border.subtle'),
+    additionBorder: get('border.subtle'),
     deletionBg: get('danger.emphasis'),
     additionBg: get('success.emphasis'),
   },

--- a/data/colors_v2/vars/deprecated.ts
+++ b/data/colors_v2/vars/deprecated.ts
@@ -329,11 +329,11 @@ export default {
   topicTag: {
     text: get('accent.fg'),
     bg: get('accent.subtle'),
-    hoverBg: get('accent.muted'),
+    hoverBg: get('accent.emphasis'),
     activeBg: get('accent.subtle')
   },
   footerInvertocat: {
-    octicon: get('neutral.muted'),
+    octicon: get('fg.subtle'),
     octiconHover: get('fg.muted')
   },
   dropdown: {


### PR DESCRIPTION
A few more things: 

- Added the topic tag new hover state
- Reverted the `invertocat` variable because with my change it had no contrast on light mode
![image](https://user-images.githubusercontent.com/6951037/130630332-d612a751-4805-4308-b4a0-eaf6f2f6a31b.png)
- Reduced contrast of the diffblob hunk expander via an exception on high contrast
- Deprecated 2 more variables (Hoooray)