### PR TITLE
Fix `headerSearch.*` vars in colors_v2

### DIFF
--- a/.changeset/calm-rocks-talk.md
+++ b/.changeset/calm-rocks-talk.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Fix `headerSearch.*` variables in colors_v2

--- a/data/colors_v2/vars/component_dark.ts
+++ b/data/colors_v2/vars/component_dark.ts
@@ -24,10 +24,10 @@ export default {
     text: alpha(get('scale.white'), 0.7),
     bg: get('scale.gray.8'),
     logo: get('scale.gray.0'),
-    search: {
-      bg: get('scale.gray.9'),
-      border: get('scale.gray.6')
-    }
+  },
+  headerSearch: {
+    bg: get('scale.gray.9'),
+    border: get('scale.gray.6')
   },
   sidenav: {
     selectedBg: get('scale.gray.7')

--- a/data/colors_v2/vars/component_light.ts
+++ b/data/colors_v2/vars/component_light.ts
@@ -24,10 +24,10 @@ export default {
     text: alpha(get('scale.white'), 0.7),
     bg: get('scale.gray.9'),
     logo: get('scale.white'),
-    search: {
+  },
+  headerSearch: {
       bg: get('scale.gray.9'),
       border: get('scale.gray.6')
-    }
   },
   sidenav: {
     selectedBg: get('scale.white')


### PR DESCRIPTION
In colors_v2, `headerSearch.bg` and `headerSearch.border` were changed `header.search.bg` and `header.search.border` (note the extra dot). This PR changes it back to avoid breaking changes.

This PR brings v2 coverage back to 100%.