### PR TITLE
Undeprecate `timeline.badgeBg`

### DIFF
--- a/.changeset/heavy-chefs-do.md
+++ b/.changeset/heavy-chefs-do.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Undeprecate `timeline.badgeBg`

--- a/data/colors_v2/deprecations.json
+++ b/data/colors_v2/deprecations.json
@@ -294,7 +294,6 @@
   "toast.loading.iconBg": "neutral.emphasis",
   "toast.loading.iconBorder": null,
   "timeline.text": "fg.muted",
-  "timeline.badgeBg": "neutral.muted",
   "timeline.badgeSuccessBorder": null,
   "timeline.targetBadgeBorder": "accent.emphasis",
   "timeline.targetBadgeShadow": "accent.muted",

--- a/data/colors_v2/vars/component_dark.ts
+++ b/data/colors_v2/vars/component_dark.ts
@@ -8,7 +8,7 @@ export default {
     stackFadeMore: get('scale.gray.7'),
     childShadow: (theme: any) => `-2px -2px 0 ${get('scale.gray.9')(theme)}`
   },
-  
+
   topicTag: {
     border: 'transparent'
   },
@@ -37,9 +37,12 @@ export default {
   },
   input: {
     disabledBg: alpha(get('neutral.muted'), 0.5)
-  }, 
+  },
   diffstat: {
     additionBg: get('scale.green.3')
+  },
+  timeline: {
+    badgeBg: get('scale.gray.7') // needs to be opaque
   },
   ansi: {
     black: get('scale.gray.5'),

--- a/data/colors_v2/vars/component_light.ts
+++ b/data/colors_v2/vars/component_light.ts
@@ -8,7 +8,7 @@ export default {
     stackFadeMore: get('scale.gray.2'),
     childShadow: (theme: any) => `-2px -2px 0 ${alpha(get('scale.white'), 0.8)(theme)}`
   },
-  
+
   topicTag: {
     border: 'transparent'
   },
@@ -41,8 +41,9 @@ export default {
   diffstat: {
     additionBg: get('scale.green.4')
   },
-
-  // TODO: Move to VSCode theme?
+  timeline: {
+    badgeBg: get('scale.gray.1') // needs to be opaque
+  },
   ansi: {
     black: get('scale.gray.9'),
     blackBright: get('scale.gray.6'),

--- a/data/colors_v2/vars/deprecated.ts
+++ b/data/colors_v2/vars/deprecated.ts
@@ -274,7 +274,7 @@ export default {
       bg: get('accent.subtle')
     }
   },
-  
+
   markdown: {
     codeBg: get('neutral.muted'),
     frameBorder: get('border.default'),
@@ -437,7 +437,6 @@ export default {
   },
   timeline: {
     text: get('fg.muted'),
-    badgeBg: get('neutral.muted'),
     badgeSuccessBorder: unset,
     targetBadgeBorder: get('accent.emphasis'),
     targetBadgeShadow: get('accent.muted')


### PR DESCRIPTION
This undeprecates `timeline.badgeBg` and adds it back as a "component" variable.

Before | After
--- | ---
![Screen Shot 2021-09-02 at 12 22 42](https://user-images.githubusercontent.com/378023/131779122-6ae798d0-ef11-4435-a5be-019e634b52bc.png) | ![Screen Shot 2021-09-02 at 12 22 21](https://user-images.githubusercontent.com/378023/131779121-dfc0dc02-4d28-4652-8742-9b9f3eca8d1a.png)
`neutral.muted` | `scale.gray.1`

Dark | Dark Dimmed | Dark High Contrast
--- | --- | ---
![Screen Shot 2021-09-02 at 12 54 57](https://user-images.githubusercontent.com/378023/131779372-887a2fec-fc93-4d54-942e-2d76369cf812.png) | ![Screen Shot 2021-09-02 at 12 55 05](https://user-images.githubusercontent.com/378023/131779374-9b4d6fe3-6edd-4d58-bb6c-38fde351a218.png) | ![Screen Shot 2021-09-02 at 12 55 15](https://user-images.githubusercontent.com/378023/131779375-a66f4be1-d777-4361-bf79-c62e7d5928b4.png)
`scale.gray.7` | `scale.gray.7` | `scale.gray.7`

This is needed because:

- Using `canvas.subtle` is too subtle (`scale.gray.0`)
- Using `neutral.muted` doesn't cover the "time line" because it's semi-transparent
- Using the "gradient hack" doesn't work when color utilites are used, see https://github.com/primer/css/pull/1563

In the future we might can consider adding "states" to the `TimelineItem-badge` component so that no utilities are needed. But that requires some refactoring on dotcom.