### PR TITLE
Add `canvasDefaultTransparent`

### DIFF
--- a/.changeset/two-ears-yawn.md
+++ b/.changeset/two-ears-yawn.md
@@ -2,4 +2,4 @@
 "@primer/primitives": patch
 ---
 
-Add `canvasDefaultTransparent`
+Add `canvasDefaultTransparent` app color variable

--- a/.changeset/two-ears-yawn.md
+++ b/.changeset/two-ears-yawn.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Add `canvasDefaultTransparent`

--- a/data/colors/vars/app_dark.ts
+++ b/data/colors/vars/app_dark.ts
@@ -3,6 +3,7 @@ import {get, alpha} from '../../../src/utils'
 // Variables to be moved to github/github
 
 export default {
+  canvasDefaultTransparent: alpha(get('canvas.default'), 0),
   marketingIcon: {
     primary: get('scale.blue.2'),
     secondary: get('scale.blue.5')

--- a/data/colors/vars/app_light.ts
+++ b/data/colors/vars/app_light.ts
@@ -3,6 +3,7 @@ import {alpha, get} from '../../../src/utils'
 // Variables to be moved to github/github
 
 export default {
+  canvasDefaultTransparent: alpha(get('canvas.default'), 0),
   marketingIcon: {
     primary: get('scale.blue.4'),
     secondary: get('scale.blue.3')


### PR DESCRIPTION
This adds a new `canvasDefaultTransparent` variable. It will be used to fix the "gradient bug" in Safari: https://github.com/github/github/issues/192288#issuecomment-916696060

I've a hard time coming up with a name/place for this variable. It's currently an "app" variable, but it's basically a variation of the global  `canvas.default`. And it's meant to be used together like:

```css
background: linear-gradient(to top, var(--color-canvas-default), var(--color-canvas-default-transparent));
```

I almost feel like it should be added to https://github.com/primer/primitives/blob/16f4670ea0a22c16c8391fc8d324d2892027ab7b/data/colors/vars/global_light.ts#L79 but then the name "primer" isn't accurate. So we should change `primer` to `misc` or something else. Naming hell!! 🔥 😈 

It's also very similar to https://github.com/primer/primitives/blob/773ca670d928226237cb51054f4be431990065c5/data/colors/vars/app_light.ts#L170 but with a slightly different value for dark mode.