### PR TITLE
Map `border.tertiary` to `border.default`

### DIFF
--- a/.changeset/new-guests-love.md
+++ b/.changeset/new-guests-love.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Map `border.tertiary` to `border.default`

--- a/data/colors/deprecations.json
+++ b/data/colors/deprecations.json
@@ -101,7 +101,7 @@
   "icon.warning": "attention.fg",
   "border.primary": "border.default",
   "border.secondary": "border.muted",
-  "border.tertiary": "neutral.muted",
+  "border.tertiary": "border.default",
   "border.overlay": "border.default",
   "border.inverse": "fg.onEmphasis",
   "border.info": "accent.emphasis",

--- a/data/colors/vars/deprecated_dark.ts
+++ b/data/colors/vars/deprecated_dark.ts
@@ -128,7 +128,7 @@ export default {
   border: {
     primary: get('border.default'),
     secondary: get('border.muted'),
-    tertiary: get('neutral.muted'),
+    tertiary: get('border.default'),
     overlay: get('border.default'),
     inverse: get('fg.onEmphasis'), // or move to marketing
     info: get('accent.emphasis'),

--- a/data/colors/vars/deprecated_light.ts
+++ b/data/colors/vars/deprecated_light.ts
@@ -128,7 +128,7 @@ export default {
   border: {
     primary: get('border.default'),
     secondary: get('border.muted'),
-    tertiary: get('neutral.muted'),
+    tertiary: get('border.default'),
     overlay: get('border.default'),
     inverse: get('fg.onEmphasis'), // or move to marketing
     info: get('accent.emphasis'),


### PR DESCRIPTION
This maps the deprecated `border.tertiary` to `border.default`.

## Reasoning

This came up in https://github.com/primer/css/pull/1615. The history seems to be:

- In **pre primitives** `border-gray-dark` was the "strongest", most contrasting border color
- In **primitives v1** it got renamed to `color-border-tertiary` which probably suggests it's the "weakest", but the color was still stronger than the default border.
- So because in **primitives v2** the default border is the strongest, I think it would make sense to use this mapping:

`.border-gray-dark` -> `.color-border-tertiary` -> `.color-border-default`

Here a screenshot of `color-border-tertiary` from v1:

![image](https://user-images.githubusercontent.com/378023/134290482-8c510ca5-70e9-47e7-a625-fae3edd6a453.png)

Keeping the current `color-neutral-subtle` would make the border barely visible:

![image](https://user-images.githubusercontent.com/378023/134296740-a104e807-d166-4797-b257-6b8ee0e12969.png)

We might also want to change all the `border-tertiary` -> `neutral-subtle` migrations in https://github.com/github/github/pull/192360 to `border-default`. E.g. the border for this "Load more" button would be pretty hard to see:

![Screen Shot 2021-09-21 at 17 34 49](https://user-images.githubusercontent.com/378023/134142151-f30d25bb-721b-4e82-bffe-9ba65e61bcfe.png)

/cc @ashygee 