### PR TITLE
Update `fg.subtle`

### DIFF
--- a/.changeset/famous-penguins-sing.md
+++ b/.changeset/famous-penguins-sing.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": minor
+---
+
+Update `fg.subtle`

--- a/data/colors/deprecations.json
+++ b/data/colors/deprecations.json
@@ -85,7 +85,7 @@
   "text.secondary": "fg.muted",
   "text.tertiary": "fg.muted",
   "text.placeholder": "fg.subtle",
-  "text.disabled": "fg.muted",
+  "text.disabled": "fg.subtle",
   "text.inverse": "fg.onEmphasis",
   "text.link": "accent.fg",
   "text.danger": "danger.fg",

--- a/data/colors/vars/deprecated_dark.ts
+++ b/data/colors/vars/deprecated_dark.ts
@@ -108,7 +108,7 @@ export default {
     secondary: get('fg.muted'),
     tertiary: get('fg.muted'),
     placeholder: get('fg.subtle'),
-    disabled: get('fg.muted'),
+    disabled: get('fg.subtle'),
     inverse: get('fg.onEmphasis'),
     link: get('accent.fg'),
     danger: get('danger.fg'),

--- a/data/colors/vars/deprecated_light.ts
+++ b/data/colors/vars/deprecated_light.ts
@@ -108,7 +108,7 @@ export default {
     secondary: get('fg.muted'),
     tertiary: get('fg.muted'),
     placeholder: get('fg.subtle'),
-    disabled: get('fg.muted'),
+    disabled: get('fg.subtle'),
     inverse: get('fg.onEmphasis'),
     link: get('accent.fg'),
     danger: get('danger.fg'),

--- a/data/colors/vars/global_light.ts
+++ b/data/colors/vars/global_light.ts
@@ -4,7 +4,7 @@ export default {
   fg: {
     default: get('scale.gray.9'),
     muted: get('scale.gray.6'),
-    subtle: get('scale.gray.5'),
+    subtle: get('scale.gray.4'),
     onEmphasis: get('scale.white')
   },
   canvas: {


### PR DESCRIPTION
This is based on the discussion in https://github.com/github/primer/issues/292#issuecomment-925746809 and does the following:

- [x] Map the depreacated `text.disabled` to `fg.subtle` (instead of `fg.muted`).
- [x] Decrease contrast for `fg.subtle` from `gray.5` to `gray.4`.

## Ripple effect

Here the places that might need changes too:

### Line numbers

The line numbers currently use `fg-subtle`.  So if they need to pass contrast ratio, we would have to update them to `fg.muted`.

<img width="326" alt="Screen Shot 2021-09-23 at 21 35 54" src="https://user-images.githubusercontent.com/378023/134508095-f0b7e40e-b5cd-47b3-88f9-8f1c9bb41b6f.png">