### PR TITLE
Add `primer.fg.disabled`

### DIFF
--- a/.changeset/young-tips-attack.md
+++ b/.changeset/young-tips-attack.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": minor
+---
+
+Add `primer.fg.disabled`

--- a/data/colors/vars/global_dark.ts
+++ b/data/colors/vars/global_dark.ts
@@ -77,6 +77,9 @@ export default {
 
   // Only meant for Primer components
   primer: {
+    fg: {
+      disabled: get('scale.gray.5')
+    },
     canvas: {
       backdrop: alpha(get('scale.black'), 0.8), // use for modal/dialogs
       sticky: alpha(get('scale.gray.9'), 0.95) // use for sticky headers

--- a/data/colors/vars/global_light.ts
+++ b/data/colors/vars/global_light.ts
@@ -77,6 +77,9 @@ export default {
 
   // Only meant to be used by Primer components
   primer: {
+    fg: {
+      disabled: get('scale.gray.4')
+    },
     canvas: {
       backdrop: alpha(get('scale.black'), 0.5), // use for modal/dialogs
       sticky: alpha(get('scale.white'), 0.95) // use for sticky headers


### PR DESCRIPTION
This adds the `primer.fg.disabled` variable. It's meant to be used for disabled text. See https://github.com/github/primer/issues/292 for more details.

The `primer` is used to stay undocumented and mostly be used for components like buttons, text inputs etc.

Light | Dark
--- | ---
![Screen Shot 2021-10-01 at 15 56 28](https://user-images.githubusercontent.com/378023/135579148-fdd4b8e6-1cc9-4294-9d68-3c36d2aa120f.png) | ![Screen Shot 2021-10-01 at 15 58 34](https://user-images.githubusercontent.com/378023/135579152-8dd878a9-121f-4483-87af-4998abc9f706.png)
`gray.4` | `gray.5`

