### PR TITLE
[experiment][do not merge] shading a canvas or UI plane

### DIFF
--- a/data/colors/vars/global_dark.ts
+++ b/data/colors/vars/global_dark.ts
@@ -18,6 +18,11 @@ export default {
     muted: get('scale.gray.7'),
     subtle: alpha(get('scale.gray.0'), 0.1)
   },
+  shade: {
+    default: alpha(get('scale.gray.2'), 0.2),
+    muted: alpha(get('scale.gray.2'), 0.12),
+    subtle: alpha(get('scale.gray.2'), 0.08),
+  },
   shadow: {
     small: '0 0 transparent',
     medium: (theme: any) => `0 3px 6px ${get('scale.black')(theme)}`,

--- a/data/colors/vars/global_light.ts
+++ b/data/colors/vars/global_light.ts
@@ -18,6 +18,11 @@ export default {
     muted: lighten(get('scale.gray.2'), 0.03),
     subtle: alpha(get('scale.black'), 0.15)
   },
+  shade: {
+    default: alpha(get('scale.gray.2'), 0.48),
+    muted: alpha(get('scale.gray.2'), 0.32),
+    subtle: alpha(get('scale.gray.2'), 0.24),
+  },
   shadow: {
     small: (theme: any) => `0 1px 0 ${alpha(get('scale.black'), 0.04)(theme)}`,
     medium: (theme: any) => `0 3px 6px ${alpha(get('scale.gray.4'), 0.15)(theme)}`,


### PR DESCRIPTION
These changes add partially transparent colors that will have some contrast with any color they are placed on top of.

For example:
The ActionList component does not have a background color applied to it, so its background color depends on where it is placed. The items in an ActionList can use these colors as background colors for `:hover`, `:focus`, `:active`, and `selected` styles to ensure the state will be visible no matter what background color the component appears on.

Draft PR using these colors in react/primer: https://github.com/primer/react/pull/1527