### PR TITLE
Update CODEOWNERS to add react-reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @primer/css-reviewers
+* @primer/css-reviewers @primer/react-reviewers


### PR DESCRIPTION
This includes @primer/react-reviewers as codeowners on primer/primitives.

I wanted to add react-reviewers to share in the code ownership, since it's used in both primer/css and primer/react