### PR TITLE
Added border to topic and counters

### DIFF
--- a/.changeset/tricky-needles-yell.md
+++ b/.changeset/tricky-needles-yell.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": minor
+---
+
+Add border to topic-tag and counters

--- a/data/colors/themes/light_high_contrast.ts
+++ b/data/colors/themes/light_high_contrast.ts
@@ -153,6 +153,12 @@ const exceptions = {
   sponsors: {
     muted: get('scale.pink.3')
   },
+  topicTag: {
+    border: get('accent.emphasis')
+  },
+  counter: {
+    border: get('border.default')
+  },
   btn: {
     bg: get('scale.gray.1'),
     border: get('border.subtle'),

--- a/data/colors/vars/component_dark.ts
+++ b/data/colors/vars/component_dark.ts
@@ -11,6 +11,9 @@ export default {
   topicTag: {
     border: 'transparent'
   },
+  counter: {
+    border: 'transparent'
+  },
   selectMenu: {
     backdropBorder: get('scale.gray.5'),
     tapHighlight: alpha(get('scale.gray.6'), 0.5),

--- a/data/colors/vars/component_light.ts
+++ b/data/colors/vars/component_light.ts
@@ -11,6 +11,9 @@ export default {
   topicTag: {
     border: 'transparent'
   },
+  counter: {
+    border: 'transparent'
+  },
   selectMenu: {
     backdropBorder: 'transparent',
     tapHighlight: alpha(get('scale.gray.3'), 0.5),


### PR DESCRIPTION
- Added `counter.border`* to `component light & dark`
**This requires updating primer css to support counter border.*

- Changed `topicTag.border` and `counter.border` for increased contrast and visibility.