### PR TITLE
Improve diff-blob-expander-icon

### DIFF
--- a/.changeset/stupid-hairs-decide.md
+++ b/.changeset/stupid-hairs-decide.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Improve diff-blob-expander-icon

--- a/data/colors/themes/dark_dimmed.ts
+++ b/data/colors/themes/dark_dimmed.ts
@@ -1,4 +1,4 @@
-import {merge} from '../../../src/utils'
+import {get, merge} from '../../../src/utils'
 import dark from './dark'
 
 const scale = {

--- a/data/colors/themes/dark_dimmed.ts
+++ b/data/colors/themes/dark_dimmed.ts
@@ -59,4 +59,12 @@ const scale = {
   ]
 }
 
+const exceptions = {
+  diffBlob: {
+    expander: {
+      icon: get('fg.default'),
+    }
+  }
+}
+
 export default merge(dark, {scale})

--- a/data/colors/themes/light_high_contrast.ts
+++ b/data/colors/themes/light_high_contrast.ts
@@ -198,6 +198,9 @@ const exceptions = {
       fg: get('fg.onEmphasis'),
       wordBg: get('danger.emphasis')
     },
+    expander: {
+      icon: get('fg.onEmphasis'),
+    },
     hunk: {
       numBg: get('scale.blue.1')
     }


### PR DESCRIPTION
This addresses https://github.com/github/design-infrastructure/discussions/1439#discussioncomment-1714926 by improving contrast of that expander icon:

### Before

![Screen Shot 2021-11-30 at 17 26 41](https://user-images.githubusercontent.com/378023/144011661-4cce724d-f1c1-455c-91d0-97f20c9f82b7.png)

### After

Light High Contrast | Dark Dimmed
--- | ---
![Screen Shot 2021-11-30 at 17 03 35](https://user-images.githubusercontent.com/378023/144008824-b037d482-e92c-4927-b8cf-bb42c01a40f2.png) | ![Screen Shot 2021-11-30 at 17 02 09](https://user-images.githubusercontent.com/378023/144008820-6b1fccf6-8c6d-4cb9-bc69-0151b5a20c4d.png)
`fg.onEmphasis` | `fg.default`