### PR TITLE
Improve diff-blob-expander icon (follow-up)

### DIFF
--- a/.changeset/metal-kids-smile.md
+++ b/.changeset/metal-kids-smile.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Improve diff-blob-expander-icon (follow-up)

--- a/.changeset/new-scissors-grow.md
+++ b/.changeset/new-scissors-grow.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Improve diff-blob-expander

--- a/data/colors/themes/dark_high_contrast.ts
+++ b/data/colors/themes/dark_high_contrast.ts
@@ -192,7 +192,7 @@ const exceptions = {
       fg: get('fg.onEmphasis'),
     },
     expander: {
-      icon: get('fg.onEmphasis'),
+      icon: get('fg.default'),
     },
     hunk: {
       numBg: alpha(get('accent.muted'), 0.4),

--- a/data/colors/themes/light_high_contrast.ts
+++ b/data/colors/themes/light_high_contrast.ts
@@ -204,9 +204,6 @@ const exceptions = {
       fg: get('fg.onEmphasis'),
       wordBg: get('danger.emphasis')
     },
-    expander: {
-      icon: get('fg.onEmphasis'),
-    },
     hunk: {
       numBg: get('scale.blue.1')
     }


### PR DESCRIPTION
Follow-up to https://github.com/primer/primitives/pull/280.

For LHC, we actually want to change the background and not the icon color, see https://github.com/github/design-infrastructure/discussions/1439#discussioncomment-1721488. So this PR:

- [x] Reverts changing the icon color https://github.com/primer/primitives/commit/a65bb0f3b2e09cba38ad5dece108a20be3dc0d87
- [x] But use `fg.default` for the icon in DHC https://github.com/primer/primitives/pull/281/commits/7512227e9ef9db7c126866d672a4fa41f9188063 because we will be using `--color-diff-blob-hunk-num-bg` on [dotcom](https://github.com/github/github/pull/202115) which is quite dark.