### PR TITLE
Add `header.divider`

### DIFF
--- a/.changeset/nervous-ghosts-vanish.md
+++ b/.changeset/nervous-ghosts-vanish.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": minor
+---
+
+Add `header.divider`

--- a/data/colors/themes/light_high_contrast.ts
+++ b/data/colors/themes/light_high_contrast.ts
@@ -210,6 +210,9 @@ const exceptions = {
     hunk: {
       numBg: get('scale.blue.1')
     }
+  },
+  header: {
+    divider: get('scale.gray.3')
   }
 }
 

--- a/data/colors/vars/component_dark.ts
+++ b/data/colors/vars/component_dark.ts
@@ -26,6 +26,7 @@ export default {
   header: {
     text: alpha(get('scale.white'), 0.7),
     bg: get('scale.gray.8'),
+    divider: get('scale.gray.3'),
     logo: get('scale.gray.0')
   },
   headerSearch: {
@@ -153,7 +154,7 @@ export default {
 
   actionListItem: {
     inlineDivider: alpha(get('border.default'), 0.48),
-  
+
     default: {
       hoverBg: alpha(get('scale.gray.2'), 0.12),
       activeBg: alpha(get('scale.gray.2'), 0.2),

--- a/data/colors/vars/component_light.ts
+++ b/data/colors/vars/component_light.ts
@@ -26,6 +26,7 @@ export default {
   header: {
     text: alpha(get('scale.white'), 0.7),
     bg: get('scale.gray.9'),
+    divider: get('scale.gray.6'),
     logo: get('scale.white')
   },
   headerSearch: {
@@ -154,7 +155,7 @@ export default {
 
   actionListItem: {
     inlineDivider: alpha(get('border.default'), 0.48),
-    
+
     default: {
       hoverBg: alpha(get('scale.gray.2'), 0.32),
       activeBg: alpha(get('scale.gray.2'), 0.48),


### PR DESCRIPTION
This fixes https://github.com/github/design-infrastructure/discussions/1439#discussioncomment-1715832 by adding a new `header.divider` primitive. It will be used to make the dividers in the header have more contrast in "Light High Contrast":

Before | After
--- | ---
![Screen Shot 2021-12-01 at 17 48 15](https://user-images.githubusercontent.com/378023/144201745-7c0f4e7f-d665-4f65-9f64-eafc3d97276c.png) | ![Screen Shot 2021-12-01 at 17 48 00](https://user-images.githubusercontent.com/378023/144201741-0e1b2f3d-8672-4696-bf9a-ae16a51881de.png)