### PR TITLE
Background adjustments

### DIFF
--- a/.changeset/popular-cameras-drive.md
+++ b/.changeset/popular-cameras-drive.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": minor
+---
+
+Background adjustments for High Contrast theme.

--- a/data/colors/themes/dark_high_contrast.ts
+++ b/data/colors/themes/dark_high_contrast.ts
@@ -204,8 +204,10 @@ const exceptions = {
     
     default: {
       hoverBg: get('scale.gray.8'),
+      hoverBorder: get('border.default'),
       activeBg: get('scale.gray.6'),
-      selectedBg: get('scale.gray.6'),
+      selectedBg: get('scale.gray.6'), 
+      selectedBorder: get('scale.gray.4')
     },
     danger: {
       hoverBg: get('danger.emphasis'),

--- a/data/colors/themes/dark_high_contrast.ts
+++ b/data/colors/themes/dark_high_contrast.ts
@@ -198,16 +198,16 @@ const exceptions = {
       numBg: alpha(get('accent.muted'), 0.4),
     },
   },
-  
+
   actionListItem: {
     inlineDivider: get('border.muted'),
-    
+
     default: {
       hoverBg: get('scale.gray.8'),
       hoverBorder: get('border.default'),
       activeBg: get('scale.gray.6'),
-      selectedBg: get('scale.gray.6'), 
-      selectedBorder: get('scale.gray.4')
+      activeBorder: get('scale.gray.4'),
+      selectedBg: get('scale.gray.6')
     },
     danger: {
       hoverBg: get('danger.emphasis'),

--- a/data/colors/themes/dark_high_contrast.ts
+++ b/data/colors/themes/dark_high_contrast.ts
@@ -200,12 +200,12 @@ const exceptions = {
   },
   
   actionListItem: {
-    inlineDivider: get('border.default'),
+    inlineDivider: get('border.muted'),
     
     default: {
-      hoverBg: alpha(get('scale.gray.2'), 0.12),
-      activeBg: alpha(get('scale.gray.2'), 0.24),
-      selectedBg: alpha(get('scale.gray.2'), 0.08),
+      hoverBg: get('scale.gray.8'),
+      activeBg: get('scale.gray.6'),
+      selectedBg: get('scale.gray.6'),
     },
     danger: {
       hoverBg: get('danger.emphasis'),

--- a/data/colors/themes/light_high_contrast.ts
+++ b/data/colors/themes/light_high_contrast.ts
@@ -210,6 +210,19 @@ const exceptions = {
   },
   header: {
     divider: get('scale.gray.3')
+  },
+  actionListItem: {
+    inlineDivider: (get('border.muted'),
+    default: {
+      hoverBg: get('scale.gray.1'),
+      activeBg: get('scale.gray.2'),
+      selectedBg: get('scale.gray.2')
+    },
+    danger: {
+      hoverBg: get('anger.emphasis'),
+      activeBg: get('scale.red.7'),
+      hoverText: get('fg.onEmphasis')
+    }
   }
 }
 

--- a/data/colors/themes/light_high_contrast.ts
+++ b/data/colors/themes/light_high_contrast.ts
@@ -219,7 +219,7 @@ const exceptions = {
       selectedBg: get('scale.gray.2')
     },
     danger: {
-      hoverBg: get('anger.emphasis'),
+      hoverBg: get('danger.emphasis'),
       activeBg: get('scale.red.7'),
       hoverText: get('fg.onEmphasis')
     }

--- a/data/colors/themes/light_high_contrast.ts
+++ b/data/colors/themes/light_high_contrast.ts
@@ -212,7 +212,7 @@ const exceptions = {
     divider: get('scale.gray.3')
   },
   actionListItem: {
-    inlineDivider: (get('border.muted'),
+    inlineDivider: get('border.muted'),
     default: {
       hoverBg: get('scale.gray.1'),
       activeBg: get('scale.gray.2'),

--- a/data/colors/themes/light_high_contrast.ts
+++ b/data/colors/themes/light_high_contrast.ts
@@ -217,8 +217,8 @@ const exceptions = {
       hoverBg: get('scale.gray.1'),
       hoverBorder: get('border.muted'),
       activeBg: get('scale.gray.2'),
-      selectedBg: get('scale.gray.2'),
-      selectedBorder: get('border.default')
+      activeBorder: get('border.default'),
+      selectedBg: get('scale.gray.2')
     },
     danger: {
       hoverBg: get('danger.emphasis'),

--- a/data/colors/themes/light_high_contrast.ts
+++ b/data/colors/themes/light_high_contrast.ts
@@ -215,8 +215,10 @@ const exceptions = {
     inlineDivider: get('border.muted'),
     default: {
       hoverBg: get('scale.gray.1'),
+      hoverBorder: get('border.muted'),
       activeBg: get('scale.gray.2'),
-      selectedBg: get('scale.gray.2')
+      selectedBg: get('scale.gray.2'),
+      selectedBorder: get('border.default')
     },
     danger: {
       hoverBg: get('danger.emphasis'),

--- a/data/colors/vars/component_dark.ts
+++ b/data/colors/vars/component_dark.ts
@@ -157,8 +157,10 @@ export default {
 
     default: {
       hoverBg: alpha(get('scale.gray.2'), 0.12),
+      hoverBorder: 'transparent',
       activeBg: alpha(get('scale.gray.2'), 0.2),
       selectedBg: alpha(get('scale.gray.2'), 0.08),
+      selectedBorder: 'transparent'
     },
     danger: {
       hoverBg: alpha(get('scale.red.4'), 0.16),

--- a/data/colors/vars/component_dark.ts
+++ b/data/colors/vars/component_dark.ts
@@ -159,8 +159,8 @@ export default {
       hoverBg: alpha(get('scale.gray.2'), 0.12),
       hoverBorder: 'transparent',
       activeBg: alpha(get('scale.gray.2'), 0.2),
-      selectedBg: alpha(get('scale.gray.2'), 0.08),
-      selectedBorder: 'transparent'
+      activeBorder: 'transparent',
+      selectedBg: alpha(get('scale.gray.2'), 0.08)
     },
     danger: {
       hoverBg: alpha(get('scale.red.4'), 0.16),

--- a/data/colors/vars/component_light.ts
+++ b/data/colors/vars/component_light.ts
@@ -160,8 +160,8 @@ export default {
       hoverBg: alpha(get('scale.gray.2'), 0.32),
       hoverBorder: 'transparent',
       activeBg: alpha(get('scale.gray.2'), 0.48),
-      selectedBg: alpha(get('scale.gray.2'), 0.24),
-      selectedBorder: 'transparent'
+      activeBorder: 'transparent',
+      selectedBg: alpha(get('scale.gray.2'), 0.24)
     },
     danger: {
       hoverBg: alpha(get('danger.subtle'), 0.64),

--- a/data/colors/vars/component_light.ts
+++ b/data/colors/vars/component_light.ts
@@ -158,8 +158,10 @@ export default {
 
     default: {
       hoverBg: alpha(get('scale.gray.2'), 0.32),
+      hoverBorder: 'transparent',
       activeBg: alpha(get('scale.gray.2'), 0.48),
-      selectedBg: alpha(get('scale.gray.2'), 0.24)
+      selectedBg: alpha(get('scale.gray.2'), 0.24),
+      selectedBorder: 'transparent'
     },
     danger: {
       hoverBg: alpha(get('danger.subtle'), 0.64),


### PR DESCRIPTION
Adjusted backgrounds for consistent states in Dark and Light high contrast. 
#### Next step: 
- Add borders to the component so we can enable them in high contrast. Here are the specs [Figam](https://www.figma.com/file/ekYFyHK592wxLw1pxhDGEf/ActionList-colors?node-id=62%3A1179)

| Default | High contrast |
|--------|--------|
| <img width="896" alt="Default" src="https://user-images.githubusercontent.com/2427008/146009969-c9c16a42-c93d-4ac2-abf3-5fd1a1748dff.png"> | <img width="896" alt="High contrast" src="https://user-images.githubusercontent.com/2427008/146009781-e9d88c0f-b184-43b1-a793-b04c79d397ba.png"> |