### PR TITLE
Add `pageHeaderBg` primitive

### DIFF
--- a/.changeset/gentle-lions-grab.md
+++ b/.changeset/gentle-lions-grab.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": minor
+---
+
+Add `pageHeaderBg` primitive

--- a/data/colors/themes/light_high_contrast.ts
+++ b/data/colors/themes/light_high_contrast.ts
@@ -210,7 +210,8 @@ const exceptions = {
   },
   header: {
     divider: get('scale.gray.3')
-  }
+  },
+  pageHeaderBg: get('canvas.default')
 }
 
 export default merge(light, exceptions, {scale})

--- a/data/colors/vars/app_dark.ts
+++ b/data/colors/vars/app_dark.ts
@@ -4,6 +4,7 @@ import {get, alpha} from '../../../src/utils'
 
 export default {
   canvasDefaultTransparent: alpha(get('canvas.default'), 0),
+  pageHeaderBg: get('canvas.default'),
   marketingIcon: {
     primary: get('scale.blue.2'),
     secondary: get('scale.blue.5')

--- a/data/colors/vars/app_light.ts
+++ b/data/colors/vars/app_light.ts
@@ -4,6 +4,7 @@ import {alpha, get} from '../../../src/utils'
 
 export default {
   canvasDefaultTransparent: alpha(get('canvas.default'), 0),
+  pageHeaderBg: get('canvas.subtle'),
   marketingIcon: {
     primary: get('scale.blue.4'),
     secondary: get('scale.blue.3')


### PR DESCRIPTION
This adds the `pageHeaderBg` primitive. It makes the repo/org header use the `canvas.default` color in "Light High contrast".

Before | After
--- | ---
![Screen Shot 2021-12-16 at 15 13 39](https://user-images.githubusercontent.com/378023/146318372-2dff47cf-0b2c-487e-8a4a-3555bad9ddc7.png) | ![Screen Shot 2021-12-16 at 15 14 35](https://user-images.githubusercontent.com/378023/146318339-ce26f213-51ce-4fda-a98d-d9aa12586f32.png)

## Reasoning

The repo/org header currently uses [`--color-page-header-bg`](https://github.com/github/github/blob/590c8fdc3c2fb549a48697edd2324660c45281db/app/assets/stylesheets/hacks/hx_color-modes.scss#L34). But using the `color-variables()` mixin we can only set the light/dark **mode** but not individual themes. Since it looks a bit too dark in "Light High contrast", this PR adds the `pageHeaderBg` to Primer Primitives so we can add an exception. The `--color-page-header-bg` should be mapped to `canvas.default` except for "Light default" and "Light colorblind":

Theme | Color
--- | ---
Light default | `canvas.subtle` 👈 
Light high contrast | `canvas.default`
Light colorblind | `canvas.subtle` 👈 
Dark default | `canvas.default`
Dark high contrast | `canvas.default`
Dark colorblind | `canvas.default`
Dark dimmed | `canvas.default`

## Are additional changes needed?

⚠️ Yes, on dotcom we should remove [`page-header-bg`](https://github.com/github/github/blob/590c8fdc3c2fb549a48697edd2324660c45281db/app/assets/stylesheets/hacks/hx_color-modes.scss#L34) when shipping this change. 🚢 