### PR TITLE
Add note to color documentation

### DIFF
--- a/docs/content/colors.mdx
+++ b/docs/content/colors.mdx
@@ -13,9 +13,9 @@ import {ColorThemePicker} from '../src/components/color-theme-picker'
 import {ColorScales} from '../src/components/color-scales'
 
 <Note variant="warning">
-  
-The following color variables are **intented for use at the component level** and are used by the maintainers of Primer. For more information about how to apply color read the [documentation](#) in [Primer Interfaces](#).
-  
+
+The following color variables are **intended for use at the component-level** and are used by the maintainers of Primer. For more information about how to apply color read the [documentation](#) in [Primer Interfaces](#).
+
 </Note>
 
 ## Themes

--- a/docs/content/colors.mdx
+++ b/docs/content/colors.mdx
@@ -12,6 +12,12 @@ import {SwatchGrid} from '../src/components/swatch-grid'
 import {ColorThemePicker} from '../src/components/color-theme-picker'
 import {ColorScales} from '../src/components/color-scales'
 
+<Note variant="warning">
+  
+The following color variables are **intented for use at the component level** and are used by the maintainers of Primer. For more information about how to apply color read the [documentation](#) in [Primer Interfaces](#).
+  
+</Note>
+
 ## Themes
 
 Preview color variables in any of the available themes:

--- a/docs/content/colors.mdx
+++ b/docs/content/colors.mdx
@@ -14,7 +14,7 @@ import {ColorScales} from '../src/components/color-scales'
 
 <Note variant="warning">
 
-The following color variables are **intended for use at the component-level** and are used by the maintainers of Primer. For more information about how to apply color read the [documentation](#) in [Primer Interfaces](#).
+The following color variables are **intended for use at the component-level** and are used by the maintainers of Primer. For more information about how to apply color, read the [interface guidelines for color](https://primer.style/design/foundations/color).
 
 </Note>
 


### PR DESCRIPTION
Added note from @ashygee to the top of the primitives color documentation linking to the [color interface guidelines](https://primer.style/design/foundations/color)