### PR TITLE
Add `open` and `closed` roles

### DIFF
--- a/.changeset/eight-gifts-count.md
+++ b/.changeset/eight-gifts-count.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": minor
+---
+
+Add `open` and `closed` roles

--- a/data/colors/themes/dark_colorblind.ts
+++ b/data/colors/themes/dark_colorblind.ts
@@ -1,4 +1,4 @@
-import {merge} from '../../../src/utils'
+import {alpha, get, merge} from '../../../src/utils'
 import dark from './dark'
 
 const scale = {
@@ -48,4 +48,19 @@ const scale = {
   coral: ['#FFDDD2', '#FFC2B2', '#FFA28B', '#F78166', '#EA6045', '#CF462D', '#AC3220', '#872012', '#640D04', '#460701']
 }
 
-export default merge(dark, {scale})
+const exceptions = {
+  open: {
+    fg: get('scale.orange.3'),
+    emphasis: get('scale.orange.5'),
+    muted: alpha(get('scale.orange.4'), 0.4),
+    subtle: alpha(get('scale.orange.4'), 0.15)
+  },
+  closed: {
+    fg: get('scale.gray.4'),
+    emphasis: get('scale.gray.5'),
+    muted: alpha(get('scale.gray.4'), 0.4),
+    subtle: alpha(get('scale.gray.4'), 0.15)
+  }
+}
+
+export default merge(dark, exceptions, {scale})

--- a/data/colors/themes/light_colorblind.ts
+++ b/data/colors/themes/light_colorblind.ts
@@ -49,6 +49,18 @@ const scale = {
 }
 
 const exceptions = {
+  open: {
+    fg: get('scale.orange.5'),
+    emphasis: get('scale.orange.4'),
+    muted: alpha(get('scale.orange.3'), 0.4),
+    subtle: get('scale.orange.0')
+  },
+  closed: {
+    fg: get('scale.gray.5'),
+    emphasis: get('scale.gray.5'),
+    muted: alpha(get('scale.gray.3'), 0.4),
+    subtle: get('scale.gray.0')
+  },
   diffBlob: {
     addition: {
       numBg: get('success.muted'),

--- a/data/colors/vars/global_dark.ts
+++ b/data/colors/vars/global_dark.ts
@@ -62,6 +62,18 @@ export default {
     muted: alpha(get('scale.red.4'), 0.4),
     subtle: alpha(get('scale.red.4'), 0.15)
   },
+  open: {
+    fg: get('scale.green.3'),
+    emphasis: get('scale.green.5'),
+    muted: alpha(get('scale.green.4'), 0.4),
+    subtle: alpha(get('scale.green.4'), 0.15)
+  },
+  closed: {
+    fg: get('scale.red.4'),
+    emphasis: get('scale.red.5'),
+    muted: alpha(get('scale.red.4'), 0.4),
+    subtle: alpha(get('scale.red.4'), 0.15)
+  },
   done: {
     fg: get('scale.purple.4'),
     emphasis: get('scale.purple.5'),

--- a/data/colors/vars/global_light.ts
+++ b/data/colors/vars/global_light.ts
@@ -62,6 +62,18 @@ export default {
     muted: alpha(get('scale.red.3'), 0.4),
     subtle: get('scale.red.0')
   },
+  open: {
+    fg: get('scale.green.5'),
+    emphasis: get('scale.green.4'),
+    muted: alpha(get('scale.green.3'), 0.4),
+    subtle: get('scale.green.0')
+  },
+  closed: {
+    fg: get('scale.red.5'),
+    emphasis: get('scale.red.5'),
+    muted: alpha(get('scale.red.3'), 0.4),
+    subtle: get('scale.red.0')
+  },
   done: {
     fg: get('scale.purple.5'),
     emphasis: get('scale.purple.5'),

--- a/docs/content/colors.mdx
+++ b/docs/content/colors.mdx
@@ -86,6 +86,18 @@ Use to inform of error or another negative message.
 
 <SwatchGrid names={Object.keys(flatten(colors.light)).filter(key => key.split('.')[0] === 'danger')} />
 
+### Open
+
+Use when refering to open tasks or workflows.
+
+<SwatchGrid names={Object.keys(flatten(colors.light)).filter(key => key.split('.')[0] === 'open')} />
+
+### Closed
+
+Use when refering to closed tasks or workflows.
+
+<SwatchGrid names={Object.keys(flatten(colors.light)).filter(key => key.split('.')[0] === 'closed')} />
+
 ### Done
 
 Completion color for productivity and code review workflows.


### PR DESCRIPTION
This is part of https://github.com/github/primer/issues/725 and adds 2 new roles (`open` + `closed`):

Light default | Light colorblind
--- | ---
<img width="936" alt="Screen Shot 2022-02-28 at 18 48 00" src="https://user-images.githubusercontent.com/378023/155961575-5c2d5cbc-f5ca-44e9-804a-911eb437c4e7.png"> | <img width="941" alt="Screen Shot 2022-02-28 at 18 46 13" src="https://user-images.githubusercontent.com/378023/155961414-b4fbb33e-4bbc-4cad-bd21-32f90b924d45.png">

[Docs Preview](https://primitives-7enqp4pmt-primer.vercel.app/primitives/colors#open)

It also adds the following exceptions

- `open` -> orange
- `closed` -> gray

to the colorblind themes. This will make sure that the `Open` and `Done` states don't clash and the `Closed` state is more neutral like `Draft`:

Before | After
--- | ---
<img width="121" alt="Screen Shot 2022-03-02 at 17 28 42" src="https://user-images.githubusercontent.com/378023/156324689-8d9a5a4b-0aa8-4657-88b1-719b5c58f0b6.png"> | <img width="115" alt="Screen Shot 2022-03-02 at 17 31 10" src="https://user-images.githubusercontent.com/378023/156324699-44778a8d-2aaa-4970-ae72-170cdcb942a5.png">


### Reasoning

The new roles are needed to improve colorblind themes, see this [color roles ADR](https://github.com/github/primer/blob/main/adrs/2022-03-02-color-roles.md).

### TODO

- [x] [Add open and closed roles](https://github.com/primer/primitives/pull/296/commits/cdbf8173f0f3bf4f58e2a3912dad8b43ceebb078)
- [x] Add exception for colorblind themes:
    - Open -> orange
    - Closed -> gray