### PR TITLE
[Actions] Update light theme color for gateWaitingText

### DIFF
--- a/.changeset/eleven-badgers-divide.md
+++ b/.changeset/eleven-badgers-divide.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+[Actions] Update light theme color for gateWaitingText

--- a/data/colors/vars/app_light.ts
+++ b/data/colors/vars/app_light.ts
@@ -138,7 +138,7 @@ export default {
     lineDtFmBg: get('scale.yellow.5'),
     gateBg: alpha(get('scale.yellow.6'), 0.15),
     gateText: get('scale.gray.2'),
-    gateWaitingText: get('scale.gray.3'),
+    gateWaitingText: get('scale.yellow.3'),
     stepHeaderOpenBg: get('scale.gray.8'),
     stepErrorText: get('scale.red.3'),
     stepWarningText: get('scale.yellow.3'),


### PR DESCRIPTION
Closes: https://github.com/github/c2c-actions-checks/issues/242

Currently the warning text color is incorrect but only in the light theme:

This will update the warning text to match warnings in logs:

## Current incorrect color

![image](https://user-images.githubusercontent.com/16109154/156201465-b6a1aa32-11e6-4008-b23d-f4de9310ec82.png)

## With updated color

![image](https://user-images.githubusercontent.com/16109154/156201642-c3413aa7-e2c2-41b6-a223-f2e0cc18a33d.png)

In our codebase we have `color: var(--color-checks-gate-waiting-text);` 

![image](https://user-images.githubusercontent.com/16109154/156202547-e89f0035-b219-4325-8e0b-0ad82d17e4e8.png)


This matches the same color we have for warnings in our logs for the light theme

This is exactly what `stepWarningText: get('scale.yellow.3'),` is

![image](https://user-images.githubusercontent.com/16109154/156201801-634fedc4-6cdb-4681-9a11-f9331ca9b706.png)


