### PR TITLE
Update `closed` role for `dark_colorblind`

### DIFF
--- a/.changeset/perfect-plants-divide.md
+++ b/.changeset/perfect-plants-divide.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Update `closed` role for `dark_colorblind`

--- a/data/colors/themes/dark_colorblind.ts
+++ b/data/colors/themes/dark_colorblind.ts
@@ -56,10 +56,10 @@ const exceptions = {
     subtle: alpha(get('scale.orange.4'), 0.15)
   },
   closed: {
-    fg: get('scale.gray.4'),
-    emphasis: get('scale.gray.5'),
+    fg: get('scale.gray.3'),
+    emphasis: get('scale.gray.4'),
     muted: alpha(get('scale.gray.4'), 0.4),
-    subtle: alpha(get('scale.gray.4'), 0.15)
+    subtle: alpha(get('scale.gray.4'), 0.1)
   }
 }
 


### PR DESCRIPTION
This is a follow-up to https://github.com/primer/primitives/pull/296. It increases contrast for the `closed` role in `dark_colorblind`.

Before | After
--- | ---
![Screen Shot 2022-03-04 at 16 36 34](https://user-images.githubusercontent.com/378023/156720485-b7fb072e-7bb9-42d4-a3b3-0a4df350de85.png) | ![Screen Shot 2022-03-04 at 16 36 41](https://user-images.githubusercontent.com/378023/156720488-32bcb4b3-2740-4ec4-91c3-00a509adac35.png)
![Screen Shot 2022-03-04 at 16 16 45](https://user-images.githubusercontent.com/378023/156720479-5831b9f8-6a98-4fd8-b90d-f7a377b4ae2b.png) | ![Screen Shot 2022-03-04 at 16 35 55](https://user-images.githubusercontent.com/378023/156720482-49a01cc4-4412-4b9f-88fd-ff4a05b37a09.png)

Before | After
--- | ---
![Screen Shot 2022-03-04 at 16 40 23](https://user-images.githubusercontent.com/378023/156720626-315290be-7f27-4332-9ce6-5bea0c4e8ae3.png) | ![Screen Shot 2022-03-04 at 16 40 35](https://user-images.githubusercontent.com/378023/156720628-4ef99549-d54c-4432-a030-5d609754959d.png)

/cc @Juliusschaeper 