### PR TITLE
Increase contrast for dark `fg.subtle`

### DIFF
--- a/.changeset/perfect-carrots-doubt.md
+++ b/.changeset/perfect-carrots-doubt.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Increase contrast for dark `fg.subtle`

--- a/data/colors/vars/global_dark.ts
+++ b/data/colors/vars/global_dark.ts
@@ -4,7 +4,7 @@ export default {
   fg: {
     default: get('scale.gray.1'),
     muted: get('scale.gray.3'),
-    subtle: get('scale.gray.5'),
+    subtle: get('scale.gray.4'),
     onEmphasis: get('scale.white')
   },
   canvas: {


### PR DESCRIPTION
This is part of https://github.com/github/primer/issues/766 and increases contrast for `fg.subtle` in the `dark` theme.

Before | After
--- | ---
<img width="138" alt="Screen Shot 2022-03-09 at 21 10 11" src="https://user-images.githubusercontent.com/378023/157655542-c6e87caa-09b9-4c18-9f58-5cc9e9bf718d.png"> | <img width="142" alt="Screen Shot 2022-03-09 at 21 10 25" src="https://user-images.githubusercontent.com/378023/157655546-ccfb0ddb-ceb1-461a-91a1-5b4e772b2d76.png">

With a `4.11` contrast ratio it still doesn't pass accessibility guidelines, but comes closer:

![Screen Shot 2022-03-11 at 16 53 37](https://user-images.githubusercontent.com/378023/157826302-e595eb7e-88e1-4fe4-817b-ee3eef6b48f0.png)

Here in `dark_high_contrast`:

Before | After
--- | ---
![Screen Shot 2022-03-11 at 17 03 09](https://user-images.githubusercontent.com/378023/157827048-f27737d0-4f2b-45b3-a9cb-e2c3e286ae96.png) | ![Screen Shot 2022-03-11 at 17 03 23](https://user-images.githubusercontent.com/378023/157827052-3ee31374-ec59-42b7-bdfd-cb2e9ec9c07f.png)

where it passes accessibility guidelines:

![image](https://user-images.githubusercontent.com/378023/157826823-8c7b6a14-c3b8-4d55-8169-3e5728b5f2b8.png)
