### PR TITLE
add deployment workflows for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,21 @@
+name: Deploy to production
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build_deploy:
+    name: Build and deploy
+    uses: primer/.github/.github/workflows/deploy.yml@main
+    with:
+      node_version: 14
+      install: yarn
+      build: cd docs && yarn build
+      output_dir: docs/public

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -1,0 +1,19 @@
+name: Deploy preview
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    name: Build and deploy
+    uses: primer/.github/.github/workflows/deploy_preview.yml@main
+    with:
+      node_version: 14
+      install: yarn
+      build: cd docs && yarn build:preview
+      output_dir: docs/public

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "setup": "cd ..; yarn; yarn build; yarn build:tokens",
     "prebuild": "yarn setup",
+    "prebuild:preview": "yarn setup",
     "build": "gatsby build --prefix-paths",
+    "build:preview": "gatsby build",
     "predevelop": "yarn setup",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "ts-node ./script/build.ts && tsc",
     "build:tokens": "node ./build.js",
+    "postinstall": "cd docs && yarn",
     "prebuild": "rm -rf dist && rm -rf tokens-v2-private",
     "prepack": "yarn build && yarn build:tokens",
     "release": "changeset publish",


### PR DESCRIPTION
### What are you trying to accomplish?

Part of https://github.com/github/primer/issues/886

Replaces deployment target for all docs from Vercel to GitHub Pages

### What approach did you choose and why?

Utilises reusable workflows make future deployments consistent with other Primer repo's.

### What should reviewers focus on?

- Use the new preview urls, which will appear in all new PRs - including this one - as follows:
   
  ![Screenshot 2022-04-19 at 14 41 00](https://user-images.githubusercontent.com/13340707/164017282-50994629-7c13-4c08-9e79-4c181a60a05d.png)
  ☝️  Look for this comment at the bottom of the PR

  or

  ![Screenshot 2022-04-19 at 14 41 10](https://user-images.githubusercontent.com/13340707/164017441-0fa7238c-a249-44c8-87b8-6f38c3ebf03e.png)
  ☝️  find the latest deployment preview URL in the Environments section at this bottom of this PR



- Review the latest preview deployment and check everything is appearing correctly 🙏 


### Todo

- [x] Create environments
- [x] Configure feature flags

### Post-merge 

- [ ] Remove Vercel environment
- [ ] Remove project and deployment triggers in Primer Vercel account

