### PR TITLE
Removes postinstall command

### DIFF
--- a/.changeset/silent-apricots-impress.md
+++ b/.changeset/silent-apricots-impress.md
@@ -1,0 +1,5 @@
+---
+'@primer/primitives': patch
+---
+
+Fixes post installation command

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,6 @@ jobs:
     uses: primer/.github/.github/workflows/deploy.yml@main
     with:
       node_version: 14
-      install: yarn
+      install: yarn && cd docs && yarn && cd ..
       build: cd docs && yarn build
       output_dir: docs/public

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -14,6 +14,6 @@ jobs:
     uses: primer/.github/.github/workflows/deploy_preview.yml@main
     with:
       node_version: 14
-      install: yarn
+      install: yarn && cd docs && yarn && cd ..
       build: cd docs && yarn build:preview
       output_dir: docs/public

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "scripts": {
     "build": "ts-node ./script/build.ts && tsc",
     "build:tokens": "node ./build.js",
-    "postinstall": "cd docs && yarn",
     "prebuild": "rm -rf dist && rm -rf tokens-v2-private",
     "prepack": "yarn build && yarn build:tokens",
     "release": "changeset publish",


### PR DESCRIPTION
Adding `postinstall` in #318  causes errors the released package. This fixes it by removing postinstall and triggering a new patch release. 