### PR TITLE
add self serve tooling for new primitives

### DIFF
--- a/.changeset/pink-rice-tell.md
+++ b/.changeset/pink-rice-tell.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+add self serve tooling for v2 primitives

--- a/build.js
+++ b/build.js
@@ -1,20 +1,7 @@
-/**
- * platforms: CSS, js, ts, json
- * transforms:
- * - px to rem
- * - custom media queries (postcss)
- * - camel-kebab
- * - responsive tokens (same token, different value)
- */
-const glob = require('glob')
+const glob = require('fast-glob')
 const StyleDictionary = require('style-dictionary')
-const {fileHeader, formattedVariables} = StyleDictionary.formatHelpers
-const tokenFiles = glob.sync(`tokens/**/*.json`)
-const transforms = require('style-dictionary/lib/common/transforms')
-const _ = require('lodash')
 
-console.log('Build started...')
-console.log('\n==============================================')
+const {fileHeader, formattedVariables} = StyleDictionary.formatHelpers
 
 // REGISTER THE CUSTOM TRANFORMS
 
@@ -94,7 +81,7 @@ StyleDictionary.registerTransform({
 StyleDictionary.registerTransform({
   name: 'attribute/typescript',
   type: 'attribute',
-  transformer: (token, options) => {
+  transformer: token => {
     return {
       typescript: {
         // these transforms will need to match the ones you use for typescript
@@ -173,7 +160,7 @@ StyleDictionary.registerFormat({
 
 StyleDictionary.registerFormat({
   name: 'custom/format/custom-media',
-  formatter(dictionary) {
+  formatter({dictionary}) {
     return dictionary.allProperties
       .map(prop => {
         const {value, path, name} = prop
@@ -188,8 +175,8 @@ StyleDictionary.registerFormat({
 // format docs
 StyleDictionary.registerFormat({
   name: 'json/docs',
-  formatter: function(dictionary) {
-    const groupedTokens = _.groupBy(dictionary.allProperties, 'filePath')
+  formatter: function({dictionary}) {
+    const groupedTokens = groupBy(dictionary.allProperties, 'filePath')
 
     return JSON.stringify(groupedTokens, null, 2)
   }
@@ -274,7 +261,7 @@ StyleDictionary.registerFormat({
     const output =
       fileHeader({file}) +
       `declare const ${moduleName}: ${JSON.stringify(recursiveTypeGeneration(dictionary.tokens), null, 2)}
-export default ${moduleName};`
+ export default ${moduleName};`
 
     return output
       .replace(/"any"/g, 'any')
@@ -283,149 +270,251 @@ export default ${moduleName};`
   }
 })
 
-// APPLY THE CONFIGURATION
-// IMPORTANT: the registration of custom transforms
-// needs to be done _before_ applying the configuration
-// const StyleDictionaryExtended = StyleDictionary.extend(__dirname + '/config.js')
+/**
+ * @name groupBy
+ * @description Equivalent to lodash _.groupBy, to avoid creating another package dependency for users
+ * @param {Array|Object} The collection to iterate over.
+ * @param {Function} The iteratee to transform keys.
+ * @returns {Object} Returns the composed aggregate object.
+ */
+function groupBy(collection, iteratee = x => x) {
+  const current = typeof iteratee === 'function' ? iteratee : ({[iteratee]: prop}) => prop
 
-// FINALLY, BUILD ALL THE PLATFORMS
+  const array = Array.isArray(collection) ? collection : Object.values(collection)
 
-// build all tokens
-StyleDictionary.extend({
-  source: [`tokens/**/*.json`],
-  platforms: {
-    css: {
-      buildPath: 'tokens-v2-private/css/',
-      transformGroup: 'css',
-      // map the array of token file paths to style dictionary output files
-      files: tokenFiles.map(filePath => {
-        return {
-          format: `css/variables`,
-          destination: filePath.replace(`.json`, `.css`),
-          filter: token => token.filePath === filePath,
-          options: {
-            outputReferences: true
+  return array.reduce((acc, item) => {
+    const value = current(item)
+
+    acc[value] = acc[value] || []
+
+    acc[value].push(item)
+
+    return acc
+  }, {})
+}
+
+/**
+ * @name build
+ * @description
+ *   Used to generate design tokens programmatically using StyleDictionary
+ *   Called internally to build primitives and exported for self-serve use
+ *
+ * @param {Object} options
+ * @param {string} options.source glob or file path to a JSON object of tokens
+ * @param {string} options.outputPath location to write the output files
+ * @param {string} options.namespace a custom namespace to use for the output files
+ * @param {Platform} options.platforms add custom platform configurations to style-dictionary
+ * @example
+ *  build({
+ *   source: [`src/colors.json`],
+ *   outputPath: 'dist',
+ *   namespace: 'primer',
+ *   platforms: {...}
+ *  })
+ */
+function build({source, outputPath = 'tokens-v2-private', include, platforms, namespace = 'primer'}) {
+  console.log('Build started...')
+  console.log('\n==============================================')
+
+  const customParseConfig = {
+    parsers: [
+      {
+        pattern: /\.json$/,
+        parse: ({contents, filePath}) => {
+          try {
+            let mutableContent = JSON.stringify(contents)
+
+            if (filePath.includes('/functional/')) {
+              mutableContent = mutableContent.replace(/<namespace>/g, namespace)
+            }
+
+            const parsed = JSON.parse(mutableContent)
+
+            return JSON.parse(parsed)
+          } catch (error) {
+            console.log(error)
           }
         }
-      })
-    },
-    cssViewport: {
-      buildPath: 'tokens-v2-private/css/tokens/functional/size/',
-      transformGroup: 'css',
-      files: [
-        {
-          filter: token => token.filePath.includes('viewport'),
-          format: 'custom/format/custom-media',
-          destination: 'viewport.css'
-        }
-      ]
-    },
-    js: {
-      buildPath: 'tokens-v2-private/js/',
-      transforms: ['name/js/es6', 'pxToRem'],
-      // map the array of token file paths to style dictionary output files
-      files: tokenFiles.map(filePath => {
-        return {
-          format: `javascript/es6`,
-          destination: filePath.replace(`.json`, `.js`),
-          filter: token => token.filePath === filePath
-        }
-      })
-    },
-    jsModule: {
-      buildPath: 'tokens-v2-private/js/module/',
-      transforms: ['pxToRem'],
-      // map the array of token file paths to style dictionary output files
-      files: tokenFiles.map(filePath => {
-        return {
-          format: `javascript/module`,
-          destination: filePath.replace(`.json`, `.js`),
-          filter: token => token.filePath === filePath
-        }
-      })
-    },
-    tsTypes: {
-      buildPath: 'tokens-v2-private/ts/',
-      transforms: ['pxToRem'],
-      // map the array of token file paths to style dictionary output files
-      files: tokenFiles.map(filePath => {
-        return {
-          format: `typescript/module-declarations-v2`,
-          destination: filePath.replace(`.json`, `.d.ts`),
-          filter: token => token.filePath === filePath
-        }
-      })
-    },
-    ts: {
-      buildPath: 'tokens-v2-private/ts/',
-      transforms: ['pxToRem'],
-      // map the array of token file paths to style dictionary output files
-      files: tokenFiles.map(filePath => {
-        return {
-          format: `javascript/module-v2`,
-          destination: filePath.replace(`.json`, `.js`),
-          filter: token => token.filePath === filePath
-        }
-      })
-    },
-    docs: {
-      buildPath: 'tokens-v2-private/docs/',
-      transformGroup: 'css',
-      files: [
-        {
-          format: 'json/docs',
-          destination: 'docValues.json',
-          options: {
-            outputReferences: false
+      }
+    ]
+  }
+
+  const getConfig = files => {
+    const defaultPlatformConfig = {
+      css: {
+        buildPath: `${outputPath}/css/`,
+        transformGroup: 'css',
+        // map the array of token file paths to style dictionary output files
+        files: files.map(filePath => {
+          return {
+            format: `css/variables`,
+            destination: filePath.replace(`.json`, `.css`),
+            filter: token => token.filePath === filePath,
+            options: {
+              outputReferences: true
+            }
           }
-        }
-      ]
+        })
+      },
+      cssViewport: {
+        buildPath: `${outputPath}/css/tokens/functional/size/`,
+        transformGroup: 'css',
+        files: [
+          {
+            filter: token => token.filePath.includes('viewport'),
+            format: 'custom/format/custom-media',
+            destination: 'viewport.css'
+          }
+        ]
+      },
+      js: {
+        buildPath: `${outputPath}/js/`,
+        transforms: ['name/js/es6', 'pxToRem'],
+        // map the array of token file paths to style dictionary output files
+        files: files.map(filePath => {
+          return {
+            format: `javascript/es6`,
+            destination: filePath.replace(`.json`, `.js`),
+            filter: token => token.filePath === filePath
+          }
+        })
+      },
+      jsModule: {
+        buildPath: `${outputPath}/js/module/`,
+        transforms: ['pxToRem'],
+        // map the array of token file paths to style dictionary output files
+        files: files.map(filePath => {
+          return {
+            format: `javascript/module`,
+            destination: filePath.replace(`.json`, `.js`),
+            filter: token => token.filePath === filePath
+          }
+        })
+      },
+      tsTypes: {
+        buildPath: `${outputPath}/ts/`,
+        transforms: ['pxToRem'],
+        // map the array of token file paths to style dictionary output files
+        files: files.map(filePath => {
+          return {
+            format: `typescript/module-declarations-v2`,
+            destination: filePath.replace(`.json`, `.d.ts`),
+            filter: token => token.filePath === filePath
+          }
+        })
+      },
+      ts: {
+        buildPath: `${outputPath}/ts/`,
+        transforms: ['pxToRem'],
+        // map the array of token file paths to style dictionary output files
+        files: files.map(filePath => {
+          return {
+            format: `javascript/module-v2`,
+            destination: filePath.replace(`.json`, `.js`),
+            filter: token => token.filePath === filePath
+          }
+        })
+      },
+      docs: {
+        buildPath: `${outputPath}/docs/`,
+        transformGroup: 'css',
+        files: [
+          {
+            format: 'json/docs',
+            destination: 'docValues.json',
+            options: {
+              outputReferences: false
+            }
+          }
+        ]
+      }
     }
-  }
-}).buildAllPlatforms()
 
-// build desktop tokens
-StyleDictionary.extend({
-  source: [`tokens/base/size/size.json`, `tokens/functional/size/size-fine.json`],
-  platforms: {
-    css: {
-      buildPath: 'tokens-v2-private/css/',
-      transformGroup: 'css',
-      files: [
-        {
-          destination: `tokens/functional/size/size-fine.css`,
-          format: `css/touch-target-desktop`,
-          filter: token => token.filePath.includes('fine')
-          // this doesn't work
-          //   options: {
-          //     outputReferences: true
-          //   }
-        }
-      ]
+    const config = {
+      ...{include: include ? [include] : undefined},
+      source: files,
+      ...customParseConfig,
+      platforms: platforms ? platforms : defaultPlatformConfig
     }
+    return config
   }
-}).buildAllPlatforms()
 
-// build mobile tokens
-StyleDictionary.extend({
-  source: [`tokens/base/size/size.json`, `tokens/functional/size/size-course.json`],
-  platforms: {
-    css: {
-      buildPath: 'tokens-v2-private/css/',
-      transformGroup: 'css',
-      files: [
-        {
-          destination: `tokens/functional/size/size-course.css`,
-          format: `css/touch-target-mobile`,
-          filter: token => token.filePath.includes('course')
-          //   options: {
-          //     outputReferences: true
-          //   }
-        }
-      ]
+  //build all tokens
+  StyleDictionary.extend({
+    ...getConfig(glob.sync([...source]))
+  }).buildAllPlatforms()
+}
+
+/**
+ * @name init
+ * @description
+ *   Triggers the build for @primer/primitive default tokens
+ *   from an npm script. Internal use only. Use `build` for self-serve.
+ * @private
+ */
+function _init() {
+  const outputPath = 'tokens-v2-private'
+  //build all tokens
+  build({
+    source: [`tokens/**/*.json`, `!tokens/**/size-*.json`],
+    outputPath
+  })
+
+  //build size fine
+  build({
+    source: [`tokens/functional/size/size-fine.json`, `tokens/base/size/size.json`],
+    outputPath
+  })
+
+  //build size coarse
+  build({
+    source: [`tokens/functional/size/size-coarse.json`, `tokens/base/size/size.json`],
+    outputPath
+  })
+
+  build({
+    source: [`tokens/base/size/size.json`, `tokens/functional/size/size-fine.json`],
+    outputPath,
+    platforms: {
+      css: {
+        buildPath: `${outputPath}/css/`,
+        transformGroup: 'css',
+        files: [
+          {
+            destination: `tokens/functional/size/size-fine.css`,
+            format: `css/touch-target-desktop`,
+            filter: token => token.filePath.includes('fine'),
+            options: {
+              outputReferences: true
+            }
+          }
+        ]
+      }
     }
-  }
-}).buildAllPlatforms()
+  })
 
-console.log('\n==============================================')
-console.log('\nBuild completed!')
+  build({
+    source: [`tokens/base/size/size.json`, `tokens/functional/size/size-coarse.json`],
+    platforms: {
+      css: {
+        buildPath: `${outputPath}/css/`,
+        transformGroup: 'css',
+        files: [
+          {
+            destination: `tokens/functional/size/size-coarse.css`,
+            format: `css/touch-target-mobile`,
+            filter: token => token.filePath.includes('coarse'),
+            options: {
+              outputReferences: true
+            }
+          }
+        ]
+      }
+    }
+  })
+}
+
+module.exports = {
+  build,
+  _init
+}

--- a/build.js
+++ b/build.js
@@ -305,14 +305,14 @@ function groupBy(collection, iteratee = x => x) {
  * @param {string} options.namespace a custom namespace to use for the output files
  * @param {Platform} options.platforms add custom platform configurations to style-dictionary
  * @example
- *  build({
+ *  buildPrimitives({
  *   source: [`src/colors.json`],
  *   outputPath: 'dist',
  *   namespace: 'primer',
  *   platforms: {...}
  *  })
  */
-function build({source, outputPath = 'tokens-v2-private', include, platforms, namespace = 'primer'}) {
+function buildPrimitives({source, outputPath = 'tokens-v2-private', include, platforms, namespace = 'primer'}) {
   console.log('Build started...')
   console.log('\n==============================================')
 
@@ -442,24 +442,24 @@ function build({source, outputPath = 'tokens-v2-private', include, platforms, na
 function _init() {
   const outputPath = 'tokens-v2-private'
   //build all tokens
-  build({
+  buildPrimitives({
     source: [`tokens/**/*.json`, `!tokens/**/size-*.json`],
     outputPath
   })
 
   //build size fine
-  build({
+  buildPrimitives({
     source: [`tokens/functional/size/size-fine.json`, `tokens/base/size/size.json`],
     outputPath
   })
 
   //build size coarse
-  build({
+  buildPrimitives({
     source: [`tokens/functional/size/size-coarse.json`, `tokens/base/size/size.json`],
     outputPath
   })
 
-  build({
+  buildPrimitives({
     source: [`tokens/base/size/size.json`, `tokens/functional/size/size-fine.json`],
     outputPath,
     platforms: {
@@ -480,7 +480,7 @@ function _init() {
     }
   })
 
-  build({
+  buildPrimitives({
     source: [`tokens/base/size/size.json`, `tokens/functional/size/size-coarse.json`],
     platforms: {
       css: {
@@ -501,7 +501,7 @@ function _init() {
   })
 
   //build docs data
-  build({
+  buildPrimitives({
     source: [`tokens/**/*.json`],
     outputPath,
     platforms: {
@@ -523,6 +523,6 @@ function _init() {
 }
 
 module.exports = {
-  build,
+  buildPrimitives,
   _init
 }

--- a/build.js
+++ b/build.js
@@ -414,19 +414,6 @@ function build({source, outputPath = 'tokens-v2-private', include, platforms, na
             filter: token => token.filePath === filePath
           }
         })
-      },
-      docs: {
-        buildPath: `${outputPath}/docs/`,
-        transformGroup: 'css',
-        files: [
-          {
-            format: 'json/docs',
-            destination: 'docValues.json',
-            options: {
-              outputReferences: false
-            }
-          }
-        ]
       }
     }
 
@@ -506,6 +493,27 @@ function _init() {
             filter: token => token.filePath.includes('coarse'),
             options: {
               outputReferences: true
+            }
+          }
+        ]
+      }
+    }
+  })
+
+  //build docs data
+  build({
+    source: [`tokens/**/*.json`],
+    outputPath,
+    platforms: {
+      docs: {
+        buildPath: `${outputPath}/docs/`,
+        transformGroup: 'css',
+        files: [
+          {
+            format: 'json/docs',
+            destination: 'docValues.json',
+            options: {
+              outputReferences: false
             }
           }
         ]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Typography, spacing, and color primitives for Primer design system",
   "files": [
     "dist",
-    "tokens-v2-private"
+    "tokens-v2-private",
+    "build.js",
+    "tokens/"
   ],
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",
@@ -25,8 +27,9 @@
   "homepage": "https://github.com/primer/primitives#readme",
   "scripts": {
     "build": "ts-node ./script/build.ts && tsc",
-    "build:tokens": "node ./build.js",
-    "prebuild": "rm -rf dist && rm -rf tokens-v2-private",
+    "build:tokens": "node -e \"require('./build')._init()\"",
+    "prebuild": "rm -rf dist",
+    "prebuild:tokens": "rm -rf tokens-v2-private",
     "prepack": "yarn build && yarn build:tokens",
     "release": "changeset publish",
     "watch": "ls data/**/*.scss script/**/*.ts | entr -s 'yarn build'"

--- a/tokens/functional/size/border.json
+++ b/tokens/functional/size/border.json
@@ -1,14 +1,14 @@
 {
-  "primer": {
+  "<namespace>": {
     "borderInset": {
       "thin": {
-        "value": "inset 0 0 0 {primer.borderWidth.thin}"
+        "value": "inset 0 0 0 {<namespace>.borderWidth.thin}"
       },
       "normal": {
-        "value": "inset 0 0 0 {primer.borderWidth.normal}"
+        "value": "inset 0 0 0 {<namespace>.borderWidth.normal}"
       },
       "thick": {
-        "value": "inset 0 0 0 {primer.borderWidth.thick}"
+        "value": "inset 0 0 0 {<namespace>.borderWidth.thick}"
       }
     },
     "borderWidth": {

--- a/tokens/functional/size/breakpoints.json
+++ b/tokens/functional/size/breakpoints.json
@@ -1,5 +1,5 @@
 {
-  "primer": {
+  "<namespace>": {
     "breakpoint": {
       "xsmall": {
         "value": "320px"

--- a/tokens/functional/size/size-coarse.json
+++ b/tokens/functional/size/size-coarse.json
@@ -1,5 +1,5 @@
 {
-  "primer": {
+  "<namespace>": {
     "control": {
       "minTarget": {
         "auto": {

--- a/tokens/functional/size/size-fine.json
+++ b/tokens/functional/size/size-fine.json
@@ -1,5 +1,5 @@
 {
-  "primer": {
+  "<namespace>": {
     "control": {
       "minTarget": {
         "auto": {

--- a/tokens/functional/size/size.json
+++ b/tokens/functional/size/size.json
@@ -1,5 +1,5 @@
 {
-  "primer": {
+  "<namespace>": {
     "control": {
       "minTarget": {
         "fine": {
@@ -17,7 +17,7 @@
           "value": "{base.size.20}"
         },
         "paddingBlock": {
-          "value": "calc(({primer.control.xsmall.size} - {primer.control.xsmall.lineBoxHeight}) / 2)"
+          "value": "calc(({<namespace>.control.xsmall.size} - {<namespace>.control.xsmall.lineBoxHeight}) / 2)"
         },
         "paddingInline": {
           "condensed": {
@@ -42,7 +42,7 @@
           "value": "{base.size.20}"
         },
         "paddingBlock": {
-          "value": "calc(({primer.control.small.size} - {primer.control.small.lineBoxHeight}) / 2)"
+          "value": "calc(({<namespace>.control.small.size} - {<namespace>.control.small.lineBoxHeight}) / 2)"
         },
         "paddingInline": {
           "condensed": {
@@ -64,7 +64,7 @@
           "value": "{base.size.20}"
         },
         "paddingBlock": {
-          "value": "calc(({primer.control.medium.size} - {primer.control.medium.lineBoxHeight}) / 2)"
+          "value": "calc(({<namespace>.control.medium.size} - {<namespace>.control.medium.lineBoxHeight}) / 2)"
         },
         "paddingInline": {
           "condensed": {
@@ -89,7 +89,7 @@
           "value": "{base.size.20}"
         },
         "paddingBlock": {
-          "value": "calc(({primer.control.large.size} - {primer.control.large.lineBoxHeight}) / 2)"
+          "value": "calc(({<namespace>.control.large.size} - {<namespace>.control.large.lineBoxHeight}) / 2)"
         },
         "paddingInline": {
           "normal": {
@@ -111,7 +111,7 @@
           "value": "{base.size.20}"
         },
         "paddingBlock": {
-          "value": "calc(({primer.control.xlarge.size} - {primer.control.xlarge.lineBoxHeight}) / 2)"
+          "value": "calc(({<namespace>.control.xlarge.size} - {<namespace>.control.xlarge.lineBoxHeight}) / 2)"
         },
         "paddingInline": {
           "normal": {

--- a/tokens/functional/size/viewport.json
+++ b/tokens/functional/size/viewport.json
@@ -1,17 +1,17 @@
 {
-  "primer": {
+  "<namespace>": {
     "viewportRange": {
       "narrow": {
-        "value": "(max-width: calc({primer.breakpoint.medium} - 0.02px))"
+        "value": "(max-width: calc({<namespace>.breakpoint.medium} - 0.02px))"
       },
       "narrowLandscape": {
-        "value": "(max-width: calc({primer.breakpoint.large} - 0.02px) and (max-height: calc({primer.breakpoint.small} - 0.02px)) and (orientation: landscape))"
+        "value": "(max-width: calc({<namespace>.breakpoint.large} - 0.02px) and (max-height: calc({<namespace>.breakpoint.small} - 0.02px)) and (orientation: landscape))"
       },
       "regular": {
-        "value": "(min-width: {primer.breakpoint.medium})"
+        "value": "(min-width: {<namespace>.breakpoint.medium})"
       },
       "wide": {
-        "value": "(min-width: {primer.breakpoint.xxlarge})"
+        "value": "(min-width: {<namespace>.breakpoint.xxlarge})"
       },
       "portrait": {
         "value": "(orientation: portrait)"

--- a/tokens/functional/typography/typography.json
+++ b/tokens/functional/typography/typography.json
@@ -1,5 +1,5 @@
 {
-  "primer": {
+  "<namespace>": {
     "fontStack": {
       "system": {
         "value": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'"
@@ -27,10 +27,10 @@
         },
         "shorthand": {
           "value": {
-            "fontWeight": "{primer.text.display.weight}",
-            "fontSize": "{primer.text.display.size}",
-            "lineHeight": "{primer.text.display.lineHeight}",
-            "fontFamily": "{primer.fontStack.sansSerif}"
+            "fontWeight": "{<namespace>.text.display.weight}",
+            "fontSize": "{<namespace>.text.display.size}",
+            "lineHeight": "{<namespace>.text.display.lineHeight}",
+            "fontFamily": "{<namespace>.fontStack.sansSerif}"
           },
           "type": "typography"
         }
@@ -58,19 +58,19 @@
         "shorthand": {
           "large": {
             "value": {
-              "fontWeight": "{primer.text.title.weight}",
-              "fontSize": "{primer.text.title.size.large}",
-              "lineHeight": "{primer.text.title.lineHeight.large}",
-              "fontFamily": "{primer.fontStack.sansSerif}"
+              "fontWeight": "{<namespace>.text.title.weight}",
+              "fontSize": "{<namespace>.text.title.size.large}",
+              "lineHeight": "{<namespace>.text.title.lineHeight.large}",
+              "fontFamily": "{<namespace>.fontStack.sansSerif}"
             },
             "type": "typography"
           },
           "medium": {
             "value": {
-              "fontWeight": "{primer.text.title.weight}",
-              "fontSize": "{primer.text.title.size.medium}",
-              "lineHeight": "{primer.text.title.lineHeight.medium}",
-              "fontFamily": "{primer.fontStack.sansSerif}"
+              "fontWeight": "{<namespace>.text.title.weight}",
+              "fontSize": "{<namespace>.text.title.size.medium}",
+              "lineHeight": "{<namespace>.text.title.lineHeight.medium}",
+              "fontFamily": "{<namespace>.fontStack.sansSerif}"
             },
             "type": "typography"
           }
@@ -88,10 +88,10 @@
         },
         "shorthand": {
           "value": {
-            "fontWeight": "{primer.text.subtitle.weight}",
-            "fontSize": "{primer.text.subtitle.size}",
-            "lineHeight": "{primer.text.subtitle.lineHeight}",
-            "fontFamily": "{primer.fontStack.sansSerif}"
+            "fontWeight": "{<namespace>.text.subtitle.weight}",
+            "fontSize": "{<namespace>.text.subtitle.size}",
+            "lineHeight": "{<namespace>.text.subtitle.lineHeight}",
+            "fontFamily": "{<namespace>.fontStack.sansSerif}"
           },
           "type": "typography"
         }
@@ -125,28 +125,28 @@
         "shorthand": {
           "large": {
             "value": {
-              "fontWeight": "{primer.text.body.weight}",
-              "fontSize": "{primer.text.body.size.large}",
-              "lineHeight": "{primer.text.body.lineHeight.large}",
-              "fontFamily": "{primer.fontStack.sansSerif}"
+              "fontWeight": "{<namespace>.text.body.weight}",
+              "fontSize": "{<namespace>.text.body.size.large}",
+              "lineHeight": "{<namespace>.text.body.lineHeight.large}",
+              "fontFamily": "{<namespace>.fontStack.sansSerif}"
             },
             "type": "typography"
           },
           "medium": {
             "value": {
-              "fontWeight": "{primer.text.body.weight}",
-              "fontSize": "{primer.text.body.size.medium}",
-              "lineHeight": "{primer.text.body.lineHeight.medium}",
-              "fontFamily": "{primer.fontStack.sansSerif}"
+              "fontWeight": "{<namespace>.text.body.weight}",
+              "fontSize": "{<namespace>.text.body.size.medium}",
+              "lineHeight": "{<namespace>.text.body.lineHeight.medium}",
+              "fontFamily": "{<namespace>.fontStack.sansSerif}"
             },
             "type": "typography"
           },
           "small": {
             "value": {
-              "fontWeight": "{primer.text.body.weight}",
-              "fontSize": "{primer.text.body.size.small}",
-              "lineHeight": "{primer.text.body.lineHeight.small}",
-              "fontFamily": "{primer.fontStack.sansSerif}"
+              "fontWeight": "{<namespace>.text.body.weight}",
+              "fontSize": "{<namespace>.text.body.size.small}",
+              "lineHeight": "{<namespace>.text.body.lineHeight.small}",
+              "fontFamily": "{<namespace>.fontStack.sansSerif}"
             },
             "type": "typography"
           }
@@ -164,10 +164,10 @@
         },
         "shorthand": {
           "value": {
-            "fontWeight": "{primer.text.caption.weight}",
-            "fontSize": "{primer.text.caption.size}",
-            "lineHeight": "{primer.text.caption.lineHeight}",
-            "fontFamily": "{primer.fontStack.sansSerif}"
+            "fontWeight": "{<namespace>.text.caption.weight}",
+            "fontSize": "{<namespace>.text.caption.size}",
+            "lineHeight": "{<namespace>.text.caption.lineHeight}",
+            "fontFamily": "{<namespace>.fontStack.sansSerif}"
           },
           "type": "typography"
         }
@@ -184,10 +184,10 @@
         },
         "shorthand": {
           "value": {
-            "fontWeight": "{primer.text.codeBlock.weight}",
-            "fontSize": "{primer.text.codeBlock.size}",
-            "lineHeight": "{primer.text.codeBlock.lineHeight}",
-            "fontFamily": "{primer.fontStack.monospace}"
+            "fontWeight": "{<namespace>.text.codeBlock.weight}",
+            "fontSize": "{<namespace>.text.codeBlock.size}",
+            "lineHeight": "{<namespace>.text.codeBlock.lineHeight}",
+            "fontFamily": "{<namespace>.fontStack.monospace}"
           },
           "type": "typography"
         }
@@ -201,10 +201,10 @@
         },
         "shorthand": {
           "value": {
-            "fontWeight": "{primer.text.codeInline.weight}",
-            "fontSize": "{primer.text.codeInline.size}",
+            "fontWeight": "{<namespace>.text.codeInline.weight}",
+            "fontSize": "{<namespace>.text.codeInline.size}",
             "lineHeight": "inherit",
-            "fontFamily": "{primer.fontStack.monospace}"
+            "fontFamily": "{<namespace>.fontStack.monospace}"
           },
           "type": "typography"
         }


### PR DESCRIPTION
### What's changing?

Refactoring v2 tokens to build and export self-serve primitives from `@primer/primitives`

**🎥  Check out the demo:** https://www.loom.com/share/a300e866498844bba551fc4b5c6795ae
 
### Why?

Part of https://github.com/github/primer/issues/924

Primer Brand is expected to generate its own primitives, rather than importing the product tokens from in `@primer/primitives`. 

See epic for more details: https://github.com/github/primer/issues/924

### How?

- Converts previous build functions to usage-agnostic tooling
  - Internally dogfoods the tooling to continue building product-specific tokens
  - Exports the tooling so that Primer Brand can build the same tokens, but also override them where necessary 