### PR TITLE
[WIP] Support 3:1 contrast minimum for interactive controls

### DIFF
--- a/.changeset/cool-drinks-occur.md
+++ b/.changeset/cool-drinks-occur.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": minor
+---
+
+Add border with 3:1 contrast ratio for interactive controls

--- a/data/colors/themes/dark_high_contrast.ts
+++ b/data/colors/themes/dark_high_contrast.ts
@@ -223,6 +223,10 @@ const exceptions = {
       border: get('scale.blue.5'),
     }
   },
+
+  control: {
+    border: get('border.default') // maintains min 3:1 contrast ratio
+  }
 }
 
 export default merge(dark, exceptions, {scale})

--- a/data/colors/themes/light_high_contrast.ts
+++ b/data/colors/themes/light_high_contrast.ts
@@ -235,6 +235,9 @@ const exceptions = {
       border: get('scale.blue.5'),
     }
   },
+  control: {
+    border: get('border.default') // maintains min 3:1 contrast ratio
+  }
 }
 
 export default merge(light, exceptions, {scale})

--- a/data/colors/vars/component_dark.ts
+++ b/data/colors/vars/component_dark.ts
@@ -186,5 +186,9 @@ export default {
       bg: get('scale.blue.5'),
       disabledBg: get('scale.gray.5'),
     }
+  },
+
+  control: {
+    border: get('scale.gray.4') // maintains min 3:1 contrast ratio
   }
 }

--- a/data/colors/vars/component_light.ts
+++ b/data/colors/vars/component_light.ts
@@ -187,5 +187,9 @@ export default {
       bg: get('scale.blue.5'),
       disabledBg: get('scale.gray.5'),
     }
+  },
+
+  control: {
+    border: get('scale.gray.3') // maintains min 3:1 contrast ratio
   }
 }

--- a/data/colors/vars/component_light.ts
+++ b/data/colors/vars/component_light.ts
@@ -190,6 +190,6 @@ export default {
   },
 
   control: {
-    border: get('scale.gray.3') // maintains min 3:1 contrast ratio
+    border: get('scale.gray.4') // maintains min 3:1 contrast ratio
   }
 }


### PR DESCRIPTION
**_Implementation is on pause until we're aligned with a11y, brand, and design infra teams._**

Related to https://github.com/github/primer/issues/836

The deployments from this PR are being used to test style updates in Primer CSS and Primer React.

`@primer/css` update PR: https://github.com/primer/css/pull/2045
dotcom update branch: [`mp/control-min-contrast`](https://github.com/github/github/pull/new/mp/control-min-contrast)