### PR TITLE
export StyleDictionary for app-level customisation

### DIFF
--- a/.changeset/seven-foxes-rescue.md
+++ b/.changeset/seven-foxes-rescue.md
@@ -1,0 +1,5 @@
+---
+'@primer/primitives': patch
+---
+
+export StyleDictionary for app-level extending

--- a/build.js
+++ b/build.js
@@ -312,7 +312,10 @@ function groupBy(collection, iteratee = x => x) {
  *   platforms: {...}
  *  })
  */
-function buildPrimitives({source, outputPath = 'tokens-v2-private', include, platforms, namespace = 'primer'}) {
+function buildPrimitives(
+  {source, outputPath = 'tokens-v2-private', include, platforms, namespace = 'primer'},
+  _StyleDictionary = StyleDictionary
+) {
   console.log('Build started...')
   console.log('\n==============================================')
 
@@ -427,9 +430,11 @@ function buildPrimitives({source, outputPath = 'tokens-v2-private', include, pla
   }
 
   //build all tokens
-  StyleDictionary.extend({
-    ...getConfig(glob.sync([...source]))
-  }).buildAllPlatforms()
+  _StyleDictionary
+    .extend({
+      ...getConfig(glob.sync([...source]))
+    })
+    .buildAllPlatforms()
 }
 
 /**
@@ -524,5 +529,6 @@ function _init() {
 
 module.exports = {
   buildPrimitives,
-  _init
+  _init,
+  StyleDictionary
 }


### PR DESCRIPTION
Part of https://github.com/github/primer/issues/924 and used in https://github.com/primer/react-brand/pull/23

Exports the StyleDictionary class in the npm package to allow app-level customisation. This is necessary when new transformgroups or custom formats need to be registered on the app side. 

The `buildPrimitives` function now accepts an optional argument for a custom StyleDictionary class. 