### PR TITLE
Add SegmentedControl colors

### DIFF
--- a/.changeset/clever-waves-think.md
+++ b/.changeset/clever-waves-think.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": minor
+---
+
+Add SegmentedControl colors

--- a/data/colors/vars/component_dark.ts
+++ b/data/colors/vars/component_dark.ts
@@ -190,16 +190,20 @@ export default {
 
   segmentedControl: {
     bg: get('scale.gray.8'),
-    hoverBg: get('scale.gray.6'),
 
-    active: {
-      bg: get('scale.gray.7'),
-      border: get('scale.gray.6'),
-    },
+    button: {
+      hover: {
+        bg: get('scale.gray.6'),
+      },
 
-    pressed: {
-      bg: get('scale.gray.6'),
-      border: get('scale.gray.4'),
+      active: {
+        bg: get('scale.gray.7'),
+        border: get('scale.gray.6'),
+      },
+
+      selected: {
+        border: get('scale.gray.4'),
+      },
     },
   },
 }

--- a/data/colors/vars/component_dark.ts
+++ b/data/colors/vars/component_dark.ts
@@ -186,5 +186,20 @@ export default {
       bg: get('scale.blue.5'),
       disabledBg: get('scale.gray.5'),
     }
-  }
+  },
+
+  segmentedControl: {
+    bg: get('scale.gray.8'),
+    hoverBg: get('scale.gray.6'),
+
+    active: {
+      bg: get('scale.gray.7'),
+      border: get('scale.gray.6'),
+    },
+
+    pressed: {
+      bg: get('scale.gray.6'),
+      border: get('scale.gray.4'),
+    },
+  },
 }

--- a/data/colors/vars/component_dark.ts
+++ b/data/colors/vars/component_dark.ts
@@ -198,7 +198,6 @@ export default {
 
       active: {
         bg: get('scale.gray.7'),
-        border: get('scale.gray.6'),
       },
 
       selected: {

--- a/data/colors/vars/component_light.ts
+++ b/data/colors/vars/component_light.ts
@@ -191,16 +191,20 @@ export default {
 
   segmentedControl: {
     bg: get('scale.gray.1'),
-    hoverBg: get('neutral.muted'),
 
-    active: {
-      bg: alpha(get('scale.gray.3'), 0.4),
-      border: get('scale.gray.3'),
-    },
+    button: {
+      hover: {
+        bg: alpha(get('scale.gray.3'), 0.2),
+      },
 
-    pressed: {
-      bg: get('canvas.subtle'),
-      border: get('scale.gray.4'),
+      active: {
+        bg: alpha(get('scale.gray.3'), 0.4),
+        border: get('scale.gray.3'),
+      },
+
+      selected: {
+        border: get('scale.gray.4'),
+      },
     },
   },
 }

--- a/data/colors/vars/component_light.ts
+++ b/data/colors/vars/component_light.ts
@@ -202,7 +202,7 @@ export default {
       },
 
       selected: {
-        border: get('scale.gray.4'),
+        border: get('scale.gray.5'),
       },
     },
   },

--- a/data/colors/vars/component_light.ts
+++ b/data/colors/vars/component_light.ts
@@ -187,5 +187,20 @@ export default {
       bg: get('scale.blue.5'),
       disabledBg: get('scale.gray.5'),
     }
-  }
+  },
+
+  segmentedControl: {
+    bg: get('scale.gray.1'),
+    hoverBg: get('neutral.muted'),
+
+    active: {
+      bg: alpha(get('scale.gray.3'), 0.4),
+      border: get('scale.gray.3'),
+    },
+
+    pressed: {
+      bg: get('canvas.subtle'),
+      border: get('scale.gray.4'),
+    },
+  },
 }

--- a/data/colors/vars/component_light.ts
+++ b/data/colors/vars/component_light.ts
@@ -199,7 +199,6 @@ export default {
 
       active: {
         bg: alpha(get('scale.gray.3'), 0.4),
-        border: get('scale.gray.3'),
       },
 
       selected: {


### PR DESCRIPTION
This adds a few colors for the `SegmentedControl` component.

Light default | Dark default
--- | ---
<img width="341" alt="image" src="https://user-images.githubusercontent.com/378023/169250821-b90eaaf2-905f-4ae5-bae3-bf277dacba30.png"> | <img width="344" alt="Screen Shot 2022-05-31 at 16 38 47" src="https://user-images.githubusercontent.com/378023/171200497-8e0a22ec-234f-40f4-b8d3-0de0067cd0bd.png">

Will be used for:

- PCSS https://github.com/primer/css/pull/2083
- PRC https://github.com/primer/react/pull/2108