### PR TITLE
Add feature preview navigation items

### DIFF
--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -1,2 +1,9 @@
-- title: Colors
-  url: /colors
+- title: Primitives
+  url: /
+  children:
+    - title: Colors
+      url: /colors
+    - title: Typography
+      url: /typography
+    - title: Spacing
+      url: /spacing


### PR DESCRIPTION
This PR adds upcoming design tokens to the `/primitives` docs navigation. Both Spacing and Typography pages still carry a note with the following message:

> Note: feature preview only, not yet distributed for general use

c/c @langermank