### PR TITLE
Typography bug fixes + border thickness naming

### DIFF
--- a/.changeset/red-tigers-sort.md
+++ b/.changeset/red-tigers-sort.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Typography bug fixes + border thickness naming

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Build (base)
         run: pushd base; yarn build; popd
 
+      - name: Build (base experimental)
+        run: pushd base; yarn build:tokens; popd
+
       - name: Diff
         uses: primer/comment-token-update@main
         env:

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -87,9 +87,7 @@ jobs:
           # this action may not work as expected.
           comment-token: 'diff'
           script: |
-            diff=$(for file in tokens-v2-private/css/tokens/**/*.css
-
-            tokens-v2-private/css/tokens/functional/typography/typography.css
+            diff=$(for file in dist/scss/**/*.scss, tokens-v2-private/css/tokens/**/*.css
               do
                 # using `2> /dev/null || true` here to suppress errors because,
                 # in this case, differences are not errors

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -87,7 +87,7 @@ jobs:
           # this action may not work as expected.
           comment-token: 'diff'
           script: |
-            diff=$(for file in tokens-v2-private/css/**/**/*.css
+            diff=$(for file in tokens-v2-private/css/tokens/functional/typography/typography.css
               do
                 # using `2> /dev/null || true` here to suppress errors because,
                 # in this case, differences are not errors

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -87,7 +87,7 @@ jobs:
           # this action may not work as expected.
           comment-token: 'diff'
           script: |
-            diff=$(for file in dist/scss/**/*.scss, tokens-v2-private/css/tokens/**/*.css
+            diff=$(for file in tokens-v2-private/css/tokens/functional/typography/typography.css
               do
                 # using `2> /dev/null || true` here to suppress errors because,
                 # in this case, differences are not errors

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -87,7 +87,9 @@ jobs:
           # this action may not work as expected.
           comment-token: 'diff'
           script: |
-            diff=$(for file in tokens-v2-private/css/tokens/functional/typography/typography.css
+            diff=$(for file in tokens-v2-private/css/tokens/**/*.css
+
+            tokens-v2-private/css/tokens/functional/typography/typography.css
               do
                 # using `2> /dev/null || true` here to suppress errors because,
                 # in this case, differences are not errors

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -84,7 +84,7 @@ jobs:
           # this action may not work as expected.
           comment-token: 'diff'
           script: |
-            diff=$(for file in dist/scss/**/*.scss, tokens-v2-private/css/**/*.css
+            diff=$(for file in tokens-v2-private/css/**/*.css
               do
                 # using `2> /dev/null || true` here to suppress errors because,
                 # in this case, differences are not errors

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -84,7 +84,7 @@ jobs:
           # this action may not work as expected.
           comment-token: 'diff'
           script: |
-            diff=$(for file in dist/scss/**/*.scss
+            diff=$(for file in dist/scss/**/*.scss, tokens-v2-private/css/**/*.css
               do
                 # using `2> /dev/null || true` here to suppress errors because,
                 # in this case, differences are not errors

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -87,7 +87,7 @@ jobs:
           # this action may not work as expected.
           comment-token: 'diff'
           script: |
-            diff=$(for file in tokens-v2-private/css/**/*.css
+            diff=$(for file in tokens-v2-private/css/**/**/*.css
               do
                 # using `2> /dev/null || true` here to suppress errors because,
                 # in this case, differences are not errors

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -87,7 +87,7 @@ jobs:
           # this action may not work as expected.
           comment-token: 'diff'
           script: |
-            diff=$(for file in dist/scss/**/*.scss
+            diff=$(for file in tokens-v2-private/css/tokens/functional/typography/typography.css
               do
                 # using `2> /dev/null || true` here to suppress errors because,
                 # in this case, differences are not errors

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -87,7 +87,7 @@ jobs:
           # this action may not work as expected.
           comment-token: 'diff'
           script: |
-            diff=$(for file in tokens-v2-private/css/tokens/functional/typography/typography.css
+            diff=$(for file in dist/scss/**/*.scss
               do
                 # using `2> /dev/null || true` here to suppress errors because,
                 # in this case, differences are not errors

--- a/build.js
+++ b/build.js
@@ -69,6 +69,10 @@ StyleDictionary.registerTransform({
         return '0'
       }
 
+      if (token.name.includes('lineHeight')) {
+        return `${floatValue / baseFontSize}`
+      }
+
       return `${floatValue / baseFontSize}rem`
     }
     return token.value

--- a/build.js
+++ b/build.js
@@ -121,7 +121,13 @@ StyleDictionary.registerTransform({
   matcher: token => token.type === 'typography',
   transformer: token => {
     const {value} = token
-    return `${value.fontWeight} ${value.fontSize}/${value.lineHeight} ${value.fontFamily}`
+
+    // if lineHeight has value, include in shorthand
+    if (value.lineHeight) {
+      return `${value.fontWeight} ${value.fontSize}/${value.lineHeight} ${value.fontFamily}`
+    }
+
+    return `${value.fontWeight} ${value.fontSize} ${value.fontFamily}`
   }
 })
 

--- a/docs/src/components/tables/TypographyShorthandTable.tsx
+++ b/docs/src/components/tables/TypographyShorthandTable.tsx
@@ -115,7 +115,7 @@ export function TypographyShorthandTable({filePath}) {
                             Line height:
                           </Box>
                           <TokenInlineCode>
-                            {token.original.value.lineHeight.includes('{') ? (
+                            {token.original.value.lineHeight && token.original.value.lineHeight.includes('{') ? (
                               <a href={`#${token.original.value.lineHeight.replace(/[{}]/g, '').replace(/\./g, '-')}`}>
                                 {token.original.value.lineHeight.replace(/[{}]/g, '')}
                               </a>

--- a/tokens/functional/size/border.json
+++ b/tokens/functional/size/border.json
@@ -7,8 +7,8 @@
       "thick": {
         "value": "inset 0 0 0 {<namespace>.borderWidth.thick}"
       },
-      "thickest": {
-        "value": "inset 0 0 0 {<namespace>.borderWidth.thickest}"
+      "thicker": {
+        "value": "inset 0 0 0 {<namespace>.borderWidth.thicker}"
       }
     },
     "borderWidth": {
@@ -18,7 +18,7 @@
       "thick": {
         "value": "max(2px, 0.125rem)"
       },
-      "thickest": {
+      "thicker": {
         "value": "max(4px, 0.25rem)"
       }
     },

--- a/tokens/functional/size/border.json
+++ b/tokens/functional/size/border.json
@@ -4,21 +4,21 @@
       "thin": {
         "value": "inset 0 0 0 {<namespace>.borderWidth.thin}"
       },
-      "normal": {
-        "value": "inset 0 0 0 {<namespace>.borderWidth.normal}"
-      },
       "thick": {
         "value": "inset 0 0 0 {<namespace>.borderWidth.thick}"
+      },
+      "thickest": {
+        "value": "inset 0 0 0 {<namespace>.borderWidth.thickest}"
       }
     },
     "borderWidth": {
       "thin": {
         "value": "max(1px, 0.0625rem)"
       },
-      "normal": {
+      "thick": {
         "value": "max(2px, 0.125rem)"
       },
-      "thick": {
+      "thickest": {
         "value": "max(4px, 0.25rem)"
       }
     },

--- a/tokens/functional/typography/typography.json
+++ b/tokens/functional/typography/typography.json
@@ -20,7 +20,7 @@
           "value": "40px"
         },
         "lineHeight": {
-          "value": "56px"
+          "value": "calc(56/40)"
         },
         "weight": {
           "value": "{base.text.weight.medium}"

--- a/tokens/functional/typography/typography.json
+++ b/tokens/functional/typography/typography.json
@@ -203,7 +203,6 @@
           "value": {
             "fontWeight": "{<namespace>.text.codeInline.weight}",
             "fontSize": "{<namespace>.text.codeInline.size}",
-            "lineHeight": "inherit",
             "fontFamily": "{<namespace>.fontStack.monospace}"
           },
           "type": "typography"

--- a/tokens/functional/typography/typography.json
+++ b/tokens/functional/typography/typography.json
@@ -46,10 +46,10 @@
         },
         "lineHeight": {
           "large": {
-            "value": "48px"
+            "value": "calc(48/32)"
           },
           "medium": {
-            "value": "32px"
+            "value": "calc(32/20)"
           }
         },
         "weight": {
@@ -81,7 +81,7 @@
           "value": "20px"
         },
         "lineHeight": {
-          "value": "32px"
+          "value": "calc(32/20)"
         },
         "weight": {
           "value": "{base.text.weight.normal}"
@@ -110,13 +110,13 @@
         },
         "lineHeight": {
           "large": {
-            "value": "24px"
+            "value": "calc(24/16)"
           },
           "medium": {
-            "value": "20px"
+            "value": "calc(20/14)"
           },
           "small": {
-            "value": "20px"
+            "value": "calc(20/12)"
           }
         },
         "weight": {
@@ -157,7 +157,7 @@
           "value": "12px"
         },
         "lineHeight": {
-          "value": "16px"
+          "value": "calc(16/12)"
         },
         "weight": {
           "value": "{base.text.weight.normal}"
@@ -177,7 +177,7 @@
           "value": "13px"
         },
         "lineHeight": {
-          "value": "20px"
+          "value": "calc(20/13)"
         },
         "weight": {
           "value": "{base.text.weight.normal}"


### PR DESCRIPTION
- Adjust border thickness naming
- Use unitless `calc()` for `line-height`