### PR TITLE
add system-ui to base fonts

### DIFF
--- a/tokens/functional/typography/typography.json
+++ b/tokens/functional/typography/typography.json
@@ -2,10 +2,10 @@
   "<namespace>": {
     "fontStack": {
       "system": {
-        "value": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'"
+        "value": "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'"
       },
       "sansSerif": {
-        "value": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'"
+        "value": "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'"
       },
       "monospace": {
         "value": "ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace"


### PR DESCRIPTION
This adds `system-ui` to our base font tokens.

This value represents the same font that the operating system can use. On Safari `system-ui` is the same as `-apple-system`, and on Chrome on Mac it is the same as `BlinkMacSystemFont`.

CSS spec: https://drafts.csswg.org/css-fonts-4/#valdef-font-family-system-ui
Chrome Status: https://chromestatus.com/feature/5640395337760768 - implemented in Chrome 56+, Edge 79+
Webkit Bug: https://bugs.webkit.org/show_bug.cgi?id=151493 - implemented in Safari 11+
Firefox Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1226042 - implemented in Firefox 92.