### PR TITLE
color contrast check prototype

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,23 +2,11 @@
   "name": "@primer/primitives",
   "version": "7.9.0",
   "description": "Typography, spacing, and color primitives for Primer design system",
-  "files": [
-    "dist",
-    "tokens-v2-private",
-    "build.js",
-    "tokens/"
-  ],
+  "files": ["dist", "tokens-v2-private", "build.js", "tokens/"],
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",
   "repository": "https://github.com/primer/primitives",
-  "keywords": [
-    "primitives",
-    "colors",
-    "spacing",
-    "typography",
-    "variables",
-    "design-system"
-  ],
+  "keywords": ["primitives", "colors", "spacing", "typography", "variables", "design-system"],
   "author": "GitHub, Inc.",
   "license": "MIT",
   "bugs": {
@@ -30,6 +18,7 @@
     "build:tokens": "node -e \"require('./build')._init()\"",
     "prebuild": "rm -rf dist",
     "prebuild:tokens": "rm -rf tokens-v2-private",
+    "postbuild": "ts-node ./script/color-contrast.ts",
     "prepack": "yarn build && yarn build:tokens",
     "release": "changeset publish",
     "test": "jest --verbose --coverage",
@@ -58,6 +47,7 @@
     "deep-shape-equals": "^0.1.2",
     "deepmerge": "^4.2.2",
     "flat": "^5.0.2",
+    "get-contrast-ratio": "^0.2.1",
     "jest": "^29.0.1",
     "lodash": "^4.17.20",
     "mkdirp": "^1.0.4",

--- a/script/color-contrast.ts
+++ b/script/color-contrast.ts
@@ -1,0 +1,53 @@
+// @ts-ignore
+import getContrastRatio from 'get-contrast-ratio';
+import colors from "../dist/ts"
+
+const flattenObject = (obj: any, prefix: string = "") =>
+  // @ts-ignore
+  Object.keys(obj).reduce((acc, k) => {
+    const pre = prefix.length ? prefix + '.' : '';
+    if (typeof obj[k] === 'object') Object.assign(acc, flattenObject(obj[k], pre + k));
+    // @ts-ignore
+    else acc[pre + k] = obj[k];
+    return acc;
+  }, {})
+
+// const runContrastTest = ([required, ...pair]: (number | string)[], colors: any) => {
+const runContrastTest = (colorPairs: (number | string)[][], colors: any) =>
+  Object.fromEntries(
+    colorPairs.map(([required, ...pair]: (number | string)[]) => {
+      // concat name
+      const contrastPair = pair.join(' vs. ')
+      // @ts-ignore
+      const [pass, contrast] = testContrast(required, colors[pair[0]], colors[pair[1]])
+      // build required string
+      const requiredContrast = `${required}:1`
+      // 
+      return [
+        [contrastPair], {
+          pass,
+          contrast,
+          requiredContrast
+        }
+      ]
+    })
+  )
+
+const testContrast = (required: number, colorA: string, colorB: string): [pass: string, contrast: string] => {
+  // get contrast
+  const contrast = getContrastRatio(colorA, colorB)
+  return [
+    contrast >= required ? '✅' : '❌',
+    `${contrast}:1`
+  ]
+}
+
+const colorPairs = [
+  [4.5, 'fg.default', 'canvas.default'],
+  [4.5, 'fg.muted', 'canvas.default'],
+  [4.5, 'fg.default', 'canvas.subtle'],
+  [4.5, 'fg.muted', 'canvas.subtle']
+]
+
+const flattenColors = flattenObject(colors.colors.light)
+console.table(runContrastTest(colorPairs, flattenColors))

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2016",
     "module": "commonjs",
-    "lib": ["ES2019.Array"],
+    "lib": ["ES2019.Array","ES2019.Object"],
     "moduleResolution": "node",
     "esModuleInterop": true,
     "strict": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -994,6 +994,11 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@smockle/contrast@^7.0.107":
+  version "7.0.107"
+  resolved "https://registry.yarnpkg.com/@smockle/contrast/-/contrast-7.0.107.tgz#cf70dcdd91f8e096aa7db65f3dc3d093515ff819"
+  integrity sha512-i0EfCVadyJqbcTX9yx4UQi1GRZ0qdb2QknBRNgHR6HJZlo6XhvY8m/rd2XA0kqx/0r0uYFY0f1cOWV4m2NwINQ==
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz"
@@ -2171,10 +2176,24 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
+get-contrast-ratio@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/get-contrast-ratio/-/get-contrast-ratio-0.2.1.tgz#3f8e2a9610df2fb55fc2004bfce002ff0aa25c0a"
+  integrity sha512-lNIpmDIoxlVJsEQ5G/XCxH2YiiXH0ukOZ0ASvPp9ku2f+2AOYG5OXQ9cLgc9p3lNom5gy8JLkfSzi8fZN9LdKg==
+  dependencies:
+    get-relative-luminance "0.3.1"
+
 get-package-type@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
+
+get-relative-luminance@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/get-relative-luminance/-/get-relative-luminance-0.3.1.tgz#f86b722194f87f23c9d4df9075e066329001907f"
+  integrity sha512-nLEJhDAPC4anQlFhBxt8lHRwxs5OvOxmN0mHCxOCFDtzy0x5cXTMKNKUycpulsAw1zNOtz6GIRcIaVMcUUcU7Q==
+  dependencies:
+    parse-color "1.0.0"
 
 get-stdin@^4.0.1:
   version "4.0.1"
@@ -3571,7 +3590,7 @@ param-case@^3.0.4:
     dot-case "^3.0.4"
     tslib "^2.0.3"
 
-parse-color@^1.0.0:
+parse-color@1.0.0, parse-color@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/parse-color/-/parse-color-1.0.0.tgz"
   integrity sha1-e3SLlag/A/FqlPU15S1/PZRlhhk=


### PR DESCRIPTION
This is just the start. Many questions are popping up:

1. where do we store the contrast requirement (directly in `token.json`? In a separate spec file?)
2. Should a build fail if contrasts fail? (Currently impossible, so we would need to add an `ignore` flag that will report the fail but ignore it)
3. Should we ignore component tokens and run it on primitives only (I think yes)
4. We need to import the json when we have one for the new build process and use that to test

## Todo:
- [ ] replace lib with own code to reduce dependency (if possible) 
- [ ] add better table (left aligned, not `'` around strings)
- [ ] clean up code to make it easier to read
- [ ] add all pairs
- [ ] make it run on all modes (rules may differ depending on mode, e.g. HC)