### PR TITLE
Adds TreeView component color primitives

### DIFF
--- a/.changeset/silver-experts-bake.md
+++ b/.changeset/silver-experts-bake.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Introduces TreeView.Item component color primitives

--- a/.changeset/silver-experts-bake.md
+++ b/.changeset/silver-experts-bake.md
@@ -1,5 +1,5 @@
 ---
-"@primer/primitives": patch
+"@primer/primitives": minor
 ---
 
 Introduces TreeView.Item component color primitives

--- a/data/colors/themes/dark_high_contrast.ts
+++ b/data/colors/themes/dark_high_contrast.ts
@@ -226,7 +226,7 @@ const exceptions = {
 
   treeViewNode: {
     chevron: {
-      hoverBg: get('scale.gray.7'),
+      hoverBg: get('scale.gray.6'),
     }
   },
 }

--- a/data/colors/themes/dark_high_contrast.ts
+++ b/data/colors/themes/dark_high_contrast.ts
@@ -224,7 +224,7 @@ const exceptions = {
     }
   },
 
-  treeViewNode: {
+  treeViewItem: {
     chevron: {
       hoverBg: get('scale.gray.6'),
     }

--- a/data/colors/themes/dark_high_contrast.ts
+++ b/data/colors/themes/dark_high_contrast.ts
@@ -223,6 +223,12 @@ const exceptions = {
       border: get('scale.blue.5'),
     }
   },
+
+  treeViewNode: {
+    chevron: {
+      hoverBg: get('scale.gray.7'),
+    }
+  },
 }
 
 export default merge(dark, exceptions, {scale})

--- a/data/colors/themes/light_high_contrast.ts
+++ b/data/colors/themes/light_high_contrast.ts
@@ -235,6 +235,12 @@ const exceptions = {
       border: get('scale.blue.5'),
     }
   },
+
+  treeViewNode: {
+    chevron: {
+      hoverBg: get('scale.gray.2'),
+    }
+  },
 }
 
 export default merge(light, exceptions, {scale})

--- a/data/colors/themes/light_high_contrast.ts
+++ b/data/colors/themes/light_high_contrast.ts
@@ -236,7 +236,7 @@ const exceptions = {
     }
   },
 
-  treeViewNode: {
+  treeViewItem: {
     chevron: {
       hoverBg: get('scale.gray.2'),
     }

--- a/data/colors/vars/component_dark.ts
+++ b/data/colors/vars/component_dark.ts
@@ -206,7 +206,7 @@ export default {
     },
   },
 
-  treeViewNode: {
+  treeViewItem: {
     chevron: {
       hoverBg: alpha(get('scale.gray.2'), 0.12),
     }

--- a/data/colors/vars/component_dark.ts
+++ b/data/colors/vars/component_dark.ts
@@ -205,4 +205,10 @@ export default {
       },
     },
   },
+
+  treeViewNode: {
+    chevron: {
+      hoverBg: alpha(get('scale.gray.2'), 0.12),
+    }
+  },
 }

--- a/data/colors/vars/component_light.ts
+++ b/data/colors/vars/component_light.ts
@@ -207,7 +207,7 @@ export default {
     },
   },
 
-  treeViewNode: {
+  treeViewItem: {
     chevron: {
       hoverBg: alpha(get('scale.gray.2'), 0.32),
     }

--- a/data/colors/vars/component_light.ts
+++ b/data/colors/vars/component_light.ts
@@ -206,4 +206,10 @@ export default {
       },
     },
   },
+
+  treeViewNode: {
+    chevron: {
+      hoverBg: alpha(get('scale.gray.2'), 0.32),
+    }
+  },
 }


### PR DESCRIPTION
We were using `actionListItem.default.hoverBg` for both the chevron hover background color _and_ the node hover background color. This was a problem because that color has no transparency, so they were indistinguishable when stacked on top of eachother.

I opted for adding TreeView-specific primitives instead of global primitives. I don't see another use case for stacked hover colors. We can reconsider adding a global primitives when/if that case comes up.

**Before**
<img width="375" alt="Screen Shot 2022-09-21 at 11 43 39 AM" src="https://user-images.githubusercontent.com/2313998/191549902-3c432d1f-ab47-44b7-b204-b0ff9cdf3461.png">

**After**
<img width="373" alt="Screen Shot 2022-09-21 at 11 43 59 AM" src="https://user-images.githubusercontent.com/2313998/191549972-afa33a5f-5111-4416-90a6-260588a3deb1.png">
