### PR TITLE
Add consumer test for primer brand

### DIFF
--- a/.github/workflows/consumer_test.yml
+++ b/.github/workflows/consumer_test.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   test:
-    if: ${{ github.repository == 'primer/brand' }}
+    if: ${{ github.repository == 'primer/primitives' }}
     name: Primer Brand
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/consumer_test.yml
+++ b/.github/workflows/consumer_test.yml
@@ -1,0 +1,60 @@
+name: Consumer test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  TEST_FOLDER: primer-brand
+
+jobs:
+  test:
+    if: ${{ github.repository == 'primer/brand' }}
+    name: Primer Brand
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current repo
+        uses: actions/checkout@v3
+
+      - name: Checkout Primer Brand repo
+        uses: actions/checkout@v3
+        with:
+          repository: primer/brand
+          path: ${{env.TEST_FOLDER}}
+
+      - name: Set up Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: Caching dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install local dependencies
+        run: npm install --legacy-peer-deps
+
+      - name: Install consumer dependencies (reference)
+        run: pushd ${{env.TEST_FOLDER}}; npm install --legacy-peer-deps; popd
+
+      - name: Build and pack
+        run: npm pack
+
+      - name: Retrieving package version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@main
+
+      - name: Installing local build
+        run: |
+          cd ${{env.TEST_FOLDER}} 
+          cp ../primer-primitives-${{ steps.package-version.outputs.current-version}}.tgz ./
+          npm install primer-primitives-${{ steps.package-version.outputs.current-version}}.tgz
+
+      - name: Build consumer tokens
+        run: pushd ${{env.TEST_FOLDER}}; npm run build:tokens; popd


### PR DESCRIPTION
Adds a consumer / integration test for Primer Brand to help catch regressions end-to-end faster.

### Why do we need this?

We're currently refactoring the v2 token build scripts for product tokens. Primer Brand uses the same scripts to generate its own brand-specific tokens downstream, so the likelihood of regression there is high.


### How does it work?

This automation script will ephemerally build the canary package for Primitives and test it against Primer Brand in an Actions runner, to save time manually smoke testing each time a change is made.

![Screenshot of GitHub Actions check in a pull request footer showing successful consumer test ](https://user-images.githubusercontent.com/13340707/191769641-d76d511d-0e8d-48d2-8654-01a5ef794b81.png)
