### PR TITLE
removed unused marketing tokens

### DIFF
--- a/data/colors/vars/marketing_dark.ts
+++ b/data/colors/vars/marketing_dark.ts
@@ -1,20 +1,3 @@
-import {alpha, get, lighten, mix} from '../../../src/utils'
-
-const mktg = {
-  blue: {
-    primary: '#4969ed',
-    secondary: '#3355e0'
-  },
-  green: {
-    primary: '#2ea44f',
-    secondary: '#22863a'
-  },
-  purple: {
-    primary: '#6f57ff',
-    secondary: '#614eda'
-  }
-}
-
 export default {
   mktg: {
     btn: {

--- a/data/colors/vars/marketing_light.ts
+++ b/data/colors/vars/marketing_light.ts
@@ -1,20 +1,3 @@
-import {alpha, get, lighten, mix} from '../../../src/utils'
-
-const mktg = {
-  blue: {
-    primary: '#4969ed',
-    secondary: '#3355e0'
-  },
-  green: {
-    primary: '#2ea44f',
-    secondary: '#22863a'
-  },
-  purple: {
-    primary: '#6f57ff',
-    secondary: '#614eda'
-  }
-}
-
 export default {
   mktg: {
     btn: {


### PR DESCRIPTION
This fixes #360 

As agreed upon by @tobiasahlin the `const` can be safely removed as the values are not exported or used.

I did run `npm run build` and got no difference with `git diff` in the output.