### PR TITLE
Add transformers and formatters to SD end export a preset

### DIFF
--- a/config/primer-style-dictionary.ts
+++ b/config/primer-style-dictionary.ts
@@ -1,0 +1,79 @@
+import StyleDictionary from 'style-dictionary'
+import {w3cJsonParser} from './parsers/w3c-json-parser'
+import {colorToHexAlpha} from './tranformers/color-to-hex-alpha'
+import {colorToRgbAlpha} from './tranformers/color-to-rgb-alpha'
+import {colorToHex6} from './tranformers/color-to-hex6'
+import {jsonDeprecated} from './tranformers/json-deprecated'
+import {namePathToDotNotation} from './tranformers/name-path-to-dot-notation'
+import {scssMixinCssVariables} from './formats/scss-mixin-css-variables'
+import {javascriptCommonJs} from './formats/javascript-commonJs'
+import {javascriptEsm} from './formats/javascript-esm'
+import {typescriptExportDefinition} from './formats/typescript-export-defition'
+
+/**
+ * Parsers
+ *
+ */
+StyleDictionary.registerParser(w3cJsonParser)
+
+/**
+ * Formats
+ *
+ */
+StyleDictionary.registerFormat({
+  name: 'scss/mixin-css-variables',
+  formatter: scssMixinCssVariables
+})
+
+StyleDictionary.registerFormat({
+  name: 'javascript/esm',
+  formatter: javascriptEsm
+})
+
+StyleDictionary.registerFormat({
+  name: 'javascript/commonJs',
+  formatter: javascriptCommonJs
+})
+
+StyleDictionary.registerFormat({
+  name: 'typescript/export-definition',
+  formatter: typescriptExportDefinition
+})
+
+/**
+ * Transformers
+ *
+ */
+StyleDictionary.registerTransform({
+  name: 'color/rgbAlpha',
+  ...colorToRgbAlpha
+})
+
+StyleDictionary.registerTransform({
+  name: 'color/hexAlpha',
+  ...colorToHexAlpha
+})
+
+StyleDictionary.registerTransform({
+  name: 'color/hex6',
+  ...colorToHex6
+})
+
+StyleDictionary.registerTransform({
+  name: 'json/deprecated',
+  ...jsonDeprecated
+})
+
+StyleDictionary.registerTransform({
+  name: 'name/pathToDotNotation',
+  ...namePathToDotNotation
+})
+
+/**
+ * @name {@link PrimerStyleDictionary}
+ * @description Returns style dictionary object with primer preset that includes parsers, formats and transformers
+ * @parsers [w3cJsonParser](./parsers/w3c-json-parser.ts)
+ * @formats [scss/mixin-css-variables](./formats/scss-mixin-css-variables.ts), [javascript/esm](./formats/javascript-esm.ts), [javascript/commonJs](./formats/javascript-commonJs.ts), [typescript/export-definition](./formats/typescript-export-defition.ts)
+ * @transformers [color/rgbAlpha](./tranformers/color-to-rgb-alpha.ts), [color/hexAlpha](./tranformers/color-to-hex-alpha.ts), [color/hex6](./tranformers/color-to-hex6.ts), [json/deprecated](./tranformers/json-deprecated.ts), [name/pathToDotNotation](./tranformers/name-path-to-dot-notation.ts)
+ */
+export const PrimerStyleDictionary: StyleDictionary.Core = StyleDictionary

--- a/script/tempColorTokenBuild.ts
+++ b/script/tempColorTokenBuild.ts
@@ -104,8 +104,6 @@ export const buildDesignTokens = (buildOptions: ConfigGeneratorOptions): void =>
    * convert colors
    */
   for (const [theme, source, include] of themes) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     PrimerStyleDictionary.extend(
       getStyleDictionaryConfig(`color/${theme}`, source, include, buildOptions)
     ).buildAllPlatforms()
@@ -130,7 +128,6 @@ export const buildDesignTokens = (buildOptions: ConfigGeneratorOptions): void =>
   })
   //
   for (const [name, source, include] of deprecatedBuilds) {
-    //
     PrimerStyleDictionary.extend(deprecatedConfig(name, source, include, buildOptions)).buildAllPlatforms()
   }
 }

--- a/script/tempColorTokenBuild.ts
+++ b/script/tempColorTokenBuild.ts
@@ -1,23 +1,14 @@
 import StyleDictionary from 'style-dictionary'
+import {PrimerStyleDictionary} from '../config/primer-style-dictionary'
 import {copyFilesAndFolders} from '../config/utilities/copyFilesAndFolders'
-import {w3cJsonParser} from '../config/parsers/w3c-json-parser'
+import {platformTypeDefinitions} from '../config/platforms/typesDefinitions'
+import {platformDeprecatedJson} from '../config/platforms/deprecatedJson'
 import {platformCss} from '../config/platforms/css'
 import {platformDocJson} from '../config/platforms/docJson'
 import {platformScss} from '../config/platforms/scss'
 import {platformJs} from '../config/platforms/javascript'
 import {platformTs} from '../config/platforms/typescript'
-import {platformTypeDefinitions} from '../config/platforms/typesDefinitions'
-import {platformDeprecatedJson} from '../config/platforms/deprecatedJson'
-import {colorToHexAlpha} from '../config/tranformers/color-to-hex-alpha'
-import {colorToRgbAlpha} from '../config/tranformers/color-to-rgb-alpha'
-import {colorToHex6} from '../config/tranformers/color-to-hex6'
-import {jsonDeprecated} from '../config/tranformers/json-deprecated'
-import {scssMixinCssVariables} from '../config/formats/scss-mixin-css-variables'
-import {javascriptCommonJs} from '../config/formats/javascript-commonJs'
-import {javascriptEsm} from '../config/formats/javascript-esm'
-import {typescriptExportDefinition} from '../config/formats/typescript-export-defition'
 import {platformJson} from '../config/platforms/json'
-import {namePathToDotNotation} from '../config/tranformers/name-path-to-dot-notation'
 import {ConfigGeneratorOptions, StyleDictionaryConfigGenerator} from '../@types/StyleDictionaryConfigGenerator'
 
 export const buildDesignTokens = (buildOptions: ConfigGeneratorOptions): void => {
@@ -94,20 +85,6 @@ export const buildDesignTokens = (buildOptions: ConfigGeneratorOptions): void =>
   ): StyleDictionary.Config => ({
     source, // build the special formats
     include,
-    parsers: [w3cJsonParser],
-    // formats need to be defined here but are used in platforms
-    format: {
-      'scss/mixin-css-variables': scssMixinCssVariables,
-      'javascript/esm': javascriptEsm,
-      'javascript/commonJs': javascriptCommonJs,
-      'typescript/export-definition': typescriptExportDefinition
-    },
-    // transforms need to be defined here but are used in platforms
-    transform: {
-      'color/rgbAlpha': colorToRgbAlpha,
-      'color/hexAlpha': colorToHexAlpha,
-      'color/hex6': colorToHex6
-    },
     platforms: {
       css: platformCss(`${outputName}.css`, options.prefix, options.buildPath),
       scss: platformScss(`${outputName}.scss`, options.prefix, options.buildPath),
@@ -127,7 +104,9 @@ export const buildDesignTokens = (buildOptions: ConfigGeneratorOptions): void =>
    * convert colors
    */
   for (const [theme, source, include] of themes) {
-    StyleDictionary.extend(
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    PrimerStyleDictionary.extend(
       getStyleDictionaryConfig(`color/${theme}`, source, include, buildOptions)
     ).buildAllPlatforms()
   }
@@ -144,16 +123,6 @@ export const buildDesignTokens = (buildOptions: ConfigGeneratorOptions): void =>
   const deprecatedConfig: StyleDictionaryConfigGenerator = (outputName, source, include, options) => ({
     source,
     include,
-    parsers: [w3cJsonParser],
-    format: {
-      'typescript/export-definition': typescriptExportDefinition
-    },
-    transform: {
-      'color/hexAlpha': colorToHexAlpha,
-      'color/hex6': colorToHex6,
-      'json/deprecated': jsonDeprecated,
-      'name/pathToDotNotation': namePathToDotNotation
-    },
     platforms: {
       deprecated: platformDeprecatedJson(`${outputName}.json`, options.prefix, options.buildPath),
       types: platformTypeDefinitions(`${outputName}`, options.prefix, options.buildPath)
@@ -162,7 +131,7 @@ export const buildDesignTokens = (buildOptions: ConfigGeneratorOptions): void =>
   //
   for (const [name, source, include] of deprecatedBuilds) {
     //
-    StyleDictionary.extend(deprecatedConfig(name, source, include, buildOptions)).buildAllPlatforms()
+    PrimerStyleDictionary.extend(deprecatedConfig(name, source, include, buildOptions)).buildAllPlatforms()
   }
 }
 


### PR DESCRIPTION
In an effort to clean up the build file I created a preset which does the following:

- import style dictionary
- register parser
- register formats
- register transformers

Exports style dictionary with the registered transformers

This removes all the setup work from the build script. Since the `style dictionary` object is exported it can still be configured more so brand can add custom transformers and we can add platforms etc.

Missing / problems:
- [ ] I would like to pipe the `StyleDictionary` type definitions through, so there is no need to import style dictionary in build
- [ ] TSDoc links to files are relative to the preset and don't work in other files (can this be fixed)?