### PR TITLE
Improving type formatter

### DIFF
--- a/config/formats/typescriptExportDefinition.test.ts
+++ b/config/formats/typescriptExportDefinition.test.ts
@@ -10,19 +10,6 @@ describe('Format: TypeScript definitions', () => {
           $type: 'color',
           value: '#FF0000'
         }),
-        // TODO: implement types
-        // small: getMockToken({
-        //   $type: 'dimension',
-        //   value: '10px'
-        // }),
-        // big: getMockToken({
-        //   $type: 'dimension',
-        //   value: '2rem'
-        // }),
-        // shadow: getMockToken({
-        //   $type: 'shadow',
-        //   value: 'shadow value'
-        // }),
         stringValue: getMockToken({
           value: '#FF0000'
         }),
@@ -34,10 +21,6 @@ describe('Format: TypeScript definitions', () => {
             width: '1px'
           }
         }),
-        // default: getMockToken({
-        //   value: 16,
-        //   $type: 'dimension'
-        // }),
         numberValue: getMockToken({
           value: 20
         }),
@@ -47,15 +30,7 @@ describe('Format: TypeScript definitions', () => {
       }
     }
   })
-  // @ ts-expect-error: Because complex is invalid
-  //   complex: {
-  //   top: 16,
-  //   bottom: () => 16
-  // }
-  // default: getMockToken({
-  //   value: 16,
-  //   $type: 'dimension'
-  // }),
+
   it('Formats tokens adding prefix', () => {
     const input = getMockFormatterArguments({
       dictionary,
@@ -123,23 +98,6 @@ describe('Format: TypeScript definitions', () => {
     )
     expect(typescriptExportDefinition(input)).toStrictEqual(expectedOutput)
   })
-
-  // it('throws an invalidToken error if a token has no value property', () => {
-  //   const input = getMockFormatterArguments({
-  //     dictionary: getMockDictionary({
-  //       // @ts-expect-error: Because of invalid token
-  //       tokens: {
-  //         subgroup: {
-  //           red: '#FF0000'
-  //         }
-  //       }
-  //     })
-  //   })
-
-  //   expect(() => {
-  //     typescriptExportDefinition(input)
-  //   }).toThrowError('Invalid token: #FF0000')
-  // })
 
   it('throws an invalidTokenValue error if a token has an invalid value for the defined type', () => {
     const input = getMockFormatterArguments({

--- a/config/formats/typescriptExportDefinition.test.ts
+++ b/config/formats/typescriptExportDefinition.test.ts
@@ -4,14 +4,26 @@ import {format} from 'prettier'
 
 describe('Format: TypeScript definitions', () => {
   const dictionary = getMockDictionary({
-    // @ts-expect-error: Because complex is invalid
     tokens: {
       subgroup: {
         red: getMockToken({
           $type: 'color',
           value: '#FF0000'
         }),
-        yellow: getMockToken({
+        // TODO: implement types
+        // small: getMockToken({
+        //   $type: 'dimension',
+        //   value: '10px'
+        // }),
+        // big: getMockToken({
+        //   $type: 'dimension',
+        //   value: '2rem'
+        // }),
+        // shadow: getMockToken({
+        //   $type: 'shadow',
+        //   value: 'shadow value'
+        // }),
+        stringValue: getMockToken({
           value: '#FF0000'
         }),
         border: getMockToken({
@@ -26,14 +38,24 @@ describe('Format: TypeScript definitions', () => {
         //   value: 16,
         //   $type: 'dimension'
         // }),
-        complex: {
-          top: 16,
-          bottom: () => 16
-        }
+        numberValue: getMockToken({
+          value: 20
+        }),
+        booleanValue: getMockToken({
+          value: true
+        })
       }
     }
   })
-
+  // @ ts-expect-error: Because complex is invalid
+  //   complex: {
+  //   top: 16,
+  //   bottom: () => 16
+  // }
+  // default: getMockToken({
+  //   value: 16,
+  //   $type: 'dimension'
+  // }),
   it('Formats tokens adding prefix', () => {
     const input = getMockFormatterArguments({
       dictionary,
@@ -58,12 +80,10 @@ describe('Format: TypeScript definitions', () => {
           tokens: {
             subgroup: {
               red: ColorHex;
-              yellow: string;
+              stringValue: string;
               border: Border;
-              complex: {
-                top: number;
-                bottom: any;
-              };
+              numberValue: number;
+              booleanValue: "boolean";
             };
           };
         };
@@ -92,17 +112,53 @@ describe('Format: TypeScript definitions', () => {
         tokens: {
           subgroup: {
             red: ColorHex;
-            yellow: string;
+            stringValue: string;
             border: Border;
-            complex: {
-              top: number;
-              bottom: any;
-            };
+            numberValue: number;
+            booleanValue: "boolean";
           };
         };
       };`,
       {parser: 'typescript', printWidth: 500}
     )
     expect(typescriptExportDefinition(input)).toStrictEqual(expectedOutput)
+  })
+
+  // it('throws an invalidToken error if a token has no value property', () => {
+  //   const input = getMockFormatterArguments({
+  //     dictionary: getMockDictionary({
+  //       // @ts-expect-error: Because of invalid token
+  //       tokens: {
+  //         subgroup: {
+  //           red: '#FF0000'
+  //         }
+  //       }
+  //     })
+  //   })
+
+  //   expect(() => {
+  //     typescriptExportDefinition(input)
+  //   }).toThrowError('Invalid token: #FF0000')
+  // })
+
+  it('throws an invalidTokenValue error if a token has an invalid value for the defined type', () => {
+    const input = getMockFormatterArguments({
+      dictionary: getMockDictionary({
+        // @ts-expect-error: Because of invalid token
+        tokens: {
+          subgroup: {
+            color: {
+              name: 'color token name',
+              value: 'rgb(100,200,255)',
+              $type: 'color'
+            }
+          }
+        }
+      })
+    })
+
+    expect(() => {
+      typescriptExportDefinition(input)
+    }).toThrowError('Invalid token: "color token name" with type "color" can not have a value of "rgb(100,200,255)"')
   })
 })

--- a/config/formats/typescriptExportDefinition.ts
+++ b/config/formats/typescriptExportDefinition.ts
@@ -52,28 +52,28 @@ const invalidTokenValueError = (token: w3cTransformedToken) => {
  * @param type
  * @returns
  */
-const convertPropToType = (token: w3cTransformedToken): string => {
-  if (!Object.prototype.hasOwnProperty.call(token, 'value')) {
-    throw new Error(`Invalid token: ${token}`)
+const convertPropToType = (tree: w3cTransformedToken): string => {
+  if (!Object.prototype.hasOwnProperty.call(tree, 'value')) {
+    throw new Error(`Invalid token: ${tree}`)
   }
-  switch (token.$type) {
+  switch (tree.$type) {
     case 'color':
-      if (typeof token.value === 'string' && token.value[0] === '#') {
+      if (typeof tree.value === 'string' && tree.value[0] === '#') {
         return 'ColorHex'
       }
-      return invalidTokenValueError(token)
+      return invalidTokenValueError(tree)
     case 'dimension':
-      if (typeof token.value === 'string' && token.value.substring(token.value.length - 3) === 'rem') return 'SizeRem'
-      if (typeof token.value === 'string' && token.value.substring(token.value.length - 2) === 'px') return 'SizePx'
-      return invalidTokenValueError(token)
+      if (typeof tree.value === 'string' && tree.value.substring(tree.value.length - 3) === 'rem') return 'SizeRem'
+      if (typeof tree.value === 'string' && tree.value.substring(tree.value.length - 2) === 'px') return 'SizePx'
+      return invalidTokenValueError(tree)
     case 'shadow':
       return 'Shadow'
     case 'border':
       return 'Border'
     default:
-      if (typeof token.value === 'number') return 'number'
-      if (typeof token.value === 'string') return 'string'
-      if (typeof token.value === 'boolean') return 'boolean'
+      if (typeof tree.value === 'number') return 'number'
+      if (typeof tree.value === 'string') return 'string'
+      if (typeof tree.value === 'boolean') return 'boolean'
       return 'any'
   }
 }
@@ -82,8 +82,8 @@ const convertPropToType = (token: w3cTransformedToken): string => {
  * @param item object
  * @returns boolean
  */
-const validTokenNode = (item: Record<string, unknown>): boolean => {
-  return typeof item === 'object' && 'value' in item
+const validTokenNode = (item: w3cTransformedToken | unknown): item is w3cTransformedToken => {
+  return typeof item === 'object' && item !== null && 'value' in item
 }
 /**
  * returns a set with every used token type
@@ -95,7 +95,7 @@ const getUsedTokenTypes = (tokens: StyleDictionary.DesignTokens, validTypes: str
   // using a set to assure every value only exists once
   const usedTypes = new Set<string>()
   // adds type to set
-  const callback = (item: Record<string, unknown>) => usedTypes.add(convertPropToType(item as w3cTransformedToken))
+  const callback = (tree: unknown) => usedTypes.add(convertPropToType(tree as w3cTransformedToken))
   // tree walker adds to usedTypes
   treeWalker(tokens, callback, validTokenNode)
   // clean up types
@@ -112,6 +112,9 @@ const getUsedTokenTypes = (tokens: StyleDictionary.DesignTokens, validTypes: str
  * @returns object
  */
 const getTokenObjectWithTypes = (tokens: StyleDictionary.DesignTokens): Record<string, unknown> => {
+  // TODO: FIX typescript issues
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
   return treeWalker(tokens, convertPropToType, validTokenNode) as Record<string, unknown>
 }
 /**

--- a/config/utilities/treeWalker.test.ts
+++ b/config/utilities/treeWalker.test.ts
@@ -1,0 +1,51 @@
+import {treeWalker} from './treeWalker'
+
+describe('Utilities: treeWalker', () => {
+  const isValidItem = (item: unknown) => {
+    return typeof item === 'object' && item !== null && 'value' in item
+  }
+
+  const callback = (_item: unknown) => {
+    return 'validItem'
+  }
+
+  it('returns undefined if item is not valid', () => {
+    const tree = {
+      invalidItem: 'pumpkin',
+      subItem: {
+        invalidSubitem: 'squash'
+      }
+    }
+
+    const expectedOutput = {
+      invalidItem: undefined,
+      subItem: {
+        invalidSubitem: undefined
+      }
+    }
+
+    expect(treeWalker(tree, callback, isValidItem)).toStrictEqual(expectedOutput)
+  })
+
+  it('returns callback return value if item is valid', () => {
+    const tree = {
+      validItem: {
+        value: 'pumpkin'
+      },
+      subItem: {
+        validSubitem: {
+          value: 'squash'
+        }
+      }
+    }
+
+    const expectedOutput = {
+      validItem: 'validItem',
+      subItem: {
+        validSubitem: 'validItem'
+      }
+    }
+
+    expect(treeWalker(tree, callback, isValidItem)).toStrictEqual(expectedOutput)
+  })
+})

--- a/config/utilities/treeWalker.ts
+++ b/config/utilities/treeWalker.ts
@@ -6,26 +6,22 @@
  * @returns object
  */
 export const treeWalker = (
-  tree: Record<string, unknown>,
-  // TODO: FIX typescript issues
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  callback,
-  validItem: (item: Record<string, unknown>) => boolean
+  tree: unknown,
+  callback: <T>(argument: T) => unknown,
+  isValidItem: (argument: unknown) => boolean
 ): unknown => {
   // is a valid item -> pass through callback
-  if (validItem(tree)) {
+  if (isValidItem(tree)) {
     return callback(tree)
   }
   // is non-object value -> ignore
-  if (typeof tree !== 'object') return
+  if (typeof tree !== 'object' || tree === null) {
+    return
+  }
   // is obj -> continue
-  const nextObj = {}
+  const nextObj: Record<string, unknown> = {}
   for (const [prop, value] of Object.entries(tree) as [prop: string, value: unknown][]) {
-    // TODO: FIX typescript issues
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    nextObj[prop] = treeWalker(value, callback, validItem)
+    nextObj[prop] = treeWalker(value, callback, isValidItem)
   }
   return nextObj
 }

--- a/config/utilities/treeWalker.ts
+++ b/config/utilities/treeWalker.ts
@@ -1,0 +1,31 @@
+/**
+ * @description converts tokens to type and returns array with used type
+ * @param tree object
+ * @param callback function to be run on valid items
+ * @param validItem function to test if a node is a validItem to be transformed
+ * @returns object
+ */
+export const treeWalker = (
+  tree: Record<string, unknown>,
+  // TODO: FIX typescript issues
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  callback,
+  validItem: (item: Record<string, unknown>) => boolean
+): unknown => {
+  // is a valid item -> pass through callback
+  if (validItem(tree)) {
+    return callback(tree)
+  }
+  // is non-object value -> ignore
+  if (typeof tree !== 'object') return
+  // is obj -> continue
+  const nextObj = {}
+  for (const [prop, value] of Object.entries(tree) as [prop: string, value: unknown][]) {
+    // TODO: FIX typescript issues
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    nextObj[prop] = treeWalker(value, callback, validItem)
+  }
+  return nextObj
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "jsx": "react",
     "target": "ES2016",
     "module": "commonjs",
-    "lib": ["ES2019.Array", "ES2022.Object"],
+    "lib": ["ESNext"],
     "moduleResolution": "node",
     "esModuleInterop": true,
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "jsx": "react",
     "target": "ES2016",
     "module": "commonjs",
-    "lib": ["ES2019.Array", "ES2019.Object"],
+    "lib": ["ES2019.Array", "ES2022.Object"],
     "moduleResolution": "node",
     "esModuleInterop": true,
     "strict": true,

--- a/types/w3cTransformedToken.d.ts
+++ b/types/w3cTransformedToken.d.ts
@@ -1,0 +1,8 @@
+import StyleDictionary from 'style-dictionary'
+
+export type w3cTokenType = 'color' | 'dimension' | 'fontFamily' | 'fontWeight' | 'duration' | 'cubicBezier'
+export type w3cCompositeTokenType = 'shadow' | 'border' | 'gradient' | 'transition' | 'strokeStyle' | 'typography'
+
+export type w3cTransformedToken = StyleDictionary.TransformedToken & {
+  $type?: w3cTokenType | w3cCompositeTokenType
+}

--- a/types/w3cTransformedToken.d.ts
+++ b/types/w3cTransformedToken.d.ts
@@ -3,6 +3,6 @@ import StyleDictionary from 'style-dictionary'
 export type w3cTokenType = 'color' | 'dimension' | 'fontFamily' | 'fontWeight' | 'duration' | 'cubicBezier'
 export type w3cCompositeTokenType = 'shadow' | 'border' | 'gradient' | 'transition' | 'strokeStyle' | 'typography'
 
-export type w3cTransformedToken = StyleDictionary.TransformedToken & {
+export interface w3cTransformedToken extends StyleDictionary.TransformedToken {
   $type?: w3cTokenType | w3cCompositeTokenType
 }


### PR DESCRIPTION
## Summary

Now the type formatter does not run into issues if an invalid token is provided. This can happen as tokens come from json an are not type-safe.

## List of notable changes:


- **updated** [convertPropToType](https://github.com/primer/primitives/compare/improve-type-def-formatter?expand=1#)
- **added** new test cases in [`config/formats/typescript-export-definition.test.ts`](https://github.com/primer/primitives/compare/improve-type-def-formatter?expand=1#diff-3ed1bc0bb9440ad951ea7e378564b888235bf2782387ad3c4073502a48f7d5a9)

## What should reviewers focus on?
- does the change make sense

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
- [ ] Verify the design tokens changed in this PR are expected using the diffing results in this PR
