### PR TITLE
Add `Noto Sans` to the font stack

### DIFF
--- a/.changeset/small-chicken-remain.md
+++ b/.changeset/small-chicken-remain.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": minor
+---
+
+Add `Noto Sans` to the font stack

--- a/tokens/functional/typography/typography.json
+++ b/tokens/functional/typography/typography.json
@@ -2,10 +2,10 @@
   "<namespace>": {
     "fontStack": {
       "system": {
-        "value": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'"
+        "value": "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'"
       },
       "sansSerif": {
-        "value": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'"
+        "value": "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'"
       },
       "monospace": {
         "value": "ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace"


### PR DESCRIPTION
## Summary

This adds `Noto Sans` to the font stack. See https://github.com/primer/css/pull/2300 for more infos.

## List of notable changes:

- **added** `Noto Sans` to `fontStack.system`
- **added** `Noto Sans` to `fontStack.sansSerif`

## What should reviewers focus on?

- We probably should wait to merge until the change has been tested with PCSS in dotcom.

## Steps to test:

Might not be easy to test, but

1. Open dotcom on Linux
2. Verify that mis-alignments described in https://github.com/primer/css/issues/1209 are improved.

## Supporting resources (related issues, external links, etc):

- Reported in https://github.com/primer/css/issues/1209

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
- [ ] Verify the design tokens changed in this PR are expected using the diffing results in this PR
