### PR TITLE
Color mode selector for css files.

### DIFF
--- a/config/PrimerStyleDictionary.ts
+++ b/config/PrimerStyleDictionary.ts
@@ -13,7 +13,8 @@ import {
   javascriptCommonJs,
   javascriptEsm,
   typescriptExportDefinition,
-  jsonNestedPrefixed
+  jsonNestedPrefixed,
+  cssThemed
 } from './formats'
 
 /**
@@ -26,6 +27,11 @@ StyleDictionary.registerParser(w3cJsonParser)
  * Formats
  *
  */
+StyleDictionary.registerFormat({
+  name: 'css/themed',
+  formatter: cssThemed
+})
+
 StyleDictionary.registerFormat({
   name: 'scss/mixin-css-variables',
   formatter: scssMixinCssVariables

--- a/config/formats/cssThemed.ts
+++ b/config/formats/cssThemed.ts
@@ -1,0 +1,31 @@
+import StyleDictionary from 'style-dictionary'
+import {FormatterArguments} from 'style-dictionary/types/Format'
+import {format} from 'prettier'
+const {fileHeader, formattedVariables} = StyleDictionary.formatHelpers
+
+/**
+ * @description Converts `StyleDictionary.dictionary.tokens` to css with prefers dark and light section
+ * @param arguments [FormatterArguments](https://github.com/amzn/style-dictionary/blob/main/types/Format.d.ts)
+ * @param arguments.options outputReferences `boolean`, selector `string`, selectorLight `string`, selectorDark `string`
+ * @returns formatted `string`
+ */
+export const cssThemed: StyleDictionary.Formatter = ({dictionary, options = {}, file}: FormatterArguments) => {
+  const {selector, selectorLight, selectorDark} = options
+  const {outputReferences} = options
+  // add file header
+  const output = [fileHeader({file})]
+  // add single theme css
+  output.push(`${selector || ':root'}${selectorLight ? `, ${selectorLight}` : ''}{
+    ${formattedVariables({format: 'css', dictionary, outputReferences})}
+  }`)
+  // add auto dark theme css
+  if (selectorDark) {
+    output.push(`@media (prefers-color-scheme: dark) {
+      ${selectorDark} {
+        ${formattedVariables({format: 'css', dictionary, outputReferences})}
+      }
+    }`)
+  }
+  // return prettified
+  return format(output.join('\n'), {parser: 'css', printWidth: 500})
+}

--- a/config/formats/index.ts
+++ b/config/formats/index.ts
@@ -1,3 +1,4 @@
+export {cssThemed} from './cssThemed'
 export {javascriptCommonJs} from './javascriptCommonJs'
 export {javascriptEsm} from './javascriptEsm'
 export {jsonNestedPrefixed} from './jsonNestedPrefixed'

--- a/config/platforms/css.ts
+++ b/config/platforms/css.ts
@@ -2,21 +2,41 @@ import StyleDictionary from 'style-dictionary'
 import {PlatformInitializer} from '~/types/PlatformInitializer'
 import {isSource} from '~/config/filters'
 
-export const css: PlatformInitializer = (outputFile, prefix, buildPath, _options): StyleDictionary.Platform => ({
-  prefix,
-  buildPath,
-  transforms: ['name/cti/kebab', 'color/hex', 'color/hexAlpha', 'shadow/css'],
-  options: {
-    basePxFontSize: 16
-  },
-  files: [
-    {
-      destination: `${outputFile}`,
-      format: `css/variables`,
-      filter: isSource,
-      options: {
-        outputReferences: false
+const getCssSelectors = (outputFile: string): {selector: string; selectorLight: string; selectorDark: string} => {
+  // check for dark in the beginning of the output filename
+  const lastSlash = outputFile.lastIndexOf('/')
+  const outputBasename = outputFile.substring(lastSlash + 1, outputFile.indexOf('.'))
+  const themeName = outputBasename.replace('-', '_')
+  const mode = outputBasename.substring(0, 4) === 'dark' ? 'dark' : 'light'
+
+  return {
+    selector: `[data-color-mode="${mode}"][data-${mode}-theme="${themeName}"]`,
+    selectorLight: `[data-color-mode="auto"][data-light-theme="${themeName}"]`,
+    selectorDark: `[data-color-mode="auto"][data-dark-theme="${themeName}"]`
+  }
+}
+
+export const css: PlatformInitializer = (outputFile, prefix, buildPath, _options): StyleDictionary.Platform => {
+  const {selector, selectorLight, selectorDark} = getCssSelectors(outputFile)
+  return {
+    prefix,
+    buildPath,
+    transforms: ['name/cti/kebab', 'color/hex', 'color/hexAlpha', 'shadow/css'],
+    options: {
+      basePxFontSize: 16
+    },
+    files: [
+      {
+        destination: `${outputFile}`,
+        format: `css/themed`,
+        filter: isSource,
+        options: {
+          outputReferences: false,
+          selector,
+          selectorLight,
+          selectorDark
+        }
       }
-    }
-  ]
-})
+    ]
+  }
+}

--- a/config/platforms/css.ts
+++ b/config/platforms/css.ts
@@ -6,7 +6,7 @@ const getCssSelectors = (outputFile: string): {selector: string; selectorLight: 
   // check for dark in the beginning of the output filename
   const lastSlash = outputFile.lastIndexOf('/')
   const outputBasename = outputFile.substring(lastSlash + 1, outputFile.indexOf('.'))
-  const themeName = outputBasename.replace('-', '_')
+  const themeName = outputBasename.replace(/-/g, '_')
   const mode = outputBasename.substring(0, 4) === 'dark' ? 'dark' : 'light'
 
   return {


### PR DESCRIPTION
## Summary

This adds a selector like `:root, [data-color-mode="light"][data-light-theme="light"]` to the css files instead of just `:root`

## List of notable changes:

- **added** `getCssSelector` function to css platform to determine selector based on output filename
- **added** `css/themed` formatter to output css file with `prefers-color-scheme`
- **updated** `css` platform to include `options.selector = getCssSelector(outputFile)`

This produces the following for `dark-dimmed.css` and other `dark-...` files:

```css
:root,
[data-color-mode="dark"][data-dark-theme="dark_dimmed"] {
    //...
}
@media (prefers-color-scheme: light) {
  [data-color-mode="auto"][data-light-theme="dark_dimmed"] {
    //...
  }
}
@media (prefers-color-scheme: dark) {
  [data-color-mode="auto"][data-dark-theme="dark_dimmed"] {
    //...
  }
}
```

And the following for all `light-` css files.

```css
:root,
[data-color-mode="light"][data-dark-theme="light"] {
    //...
}
@media (prefers-color-scheme: light) {
  [data-color-mode="auto"][data-light-theme="light"] {
    //...
  }
}
@media (prefers-color-scheme: dark) {
  [data-color-mode="auto"][data-dark-theme="light"] {
    //...
  }
}
```

## What should reviewers focus on?

- is this what was desire in https://github.com/github/primer/issues/1408

## Steps to test:

1. clone and install branch
1. run `npm run build:color-tokens`
1. review output color files in `tokens-v2-private/css`


## Contributor checklist:

- [x] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
- [ ] Verify the design tokens changed in this PR are expected using the diffing results in this PR
