### PR TITLE
JSON schema validation for color design tokens

### DIFF
--- a/config/schema-validators/validate-json-schema.test.ts
+++ b/config/schema-validators/validate-json-schema.test.ts
@@ -1,35 +1,36 @@
 import {validateSchema} from './validate-json-schema'
 import type {ColorProperties} from './validate-json-schema'
+import type {ColorDesignTokenDefinition} from '../../types/DesignToken'
 
 describe('JSON schema validation', () => {
   describe('color', () => {
-    it('should validate successfully with the correct input', async () => {
+    it('should validate successfully with the correct shape of input', async () => {
+      const expectedTokenShape: ColorDesignTokenDefinition = {
+        $value: 'value',
+        $type: 'color'
+      }
       const data: ColorProperties = {
         color: {
           a: {
-            $value: 'value',
-            $type: 'color'
+            ...expectedTokenShape
           },
           b: {
-            c: {
-              $value: 'value',
-              $type: 'color'
+            one: {
+              ...expectedTokenShape
             }
           },
-          d: {
-            e: {
-              f: {
-                $value: 'value',
-                $type: 'color'
+          c: {
+            one: {
+              two: {
+                ...expectedTokenShape
               }
             }
           },
-          g: {
-            h: {
-              i: {
-                j: {
-                  $value: 'value',
-                  $type: 'color'
+          d: {
+            one: {
+              two: {
+                three: {
+                  ...expectedTokenShape
                 }
               }
             }
@@ -37,6 +38,33 @@ describe('JSON schema validation', () => {
         }
       }
 
+      expect(validateSchema(data)).toBe(true)
+    })
+
+    it('validates to n depth', () => {
+      const n = 50 // arbitrary number
+      const token: ColorDesignTokenDefinition = {
+        $value: 'value',
+        $type: 'color'
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const buildObj = (obj: {[x: string]: any}, keyPath: string | any[], value: ColorDesignTokenDefinition) => {
+        const lastKeyIndex = keyPath.length - 1
+        for (let i = 0; i < lastKeyIndex; ++i) {
+          const key = keyPath[i]
+          if (!(key in obj)) {
+            obj[key] = {}
+          }
+          obj = obj[key]
+        }
+        obj[keyPath[lastKeyIndex]] = value
+      }
+
+      const data = {}
+      const arr = Array.from(Array(n), (x, i) => (i === 0 ? 'color' : i.toString()))
+
+      buildObj(data, arr, token)
       expect(validateSchema(data)).toBe(true)
     })
 

--- a/config/schema-validators/validate-json-schema.test.ts
+++ b/config/schema-validators/validate-json-schema.test.ts
@@ -1,0 +1,75 @@
+import {validateSchema} from './validate-json-schema'
+import type {ColorProperties} from './validate-json-schema'
+
+describe('JSON schema validation', () => {
+  describe('color', () => {
+    it('should validate successfully with the correct input', async () => {
+      const data: ColorProperties = {
+        color: {
+          a: {
+            $value: 'value',
+            $type: 'color'
+          },
+          b: {
+            c: {
+              $value: 'value',
+              $type: 'color'
+            }
+          },
+          d: {
+            e: {
+              f: {
+                $value: 'value',
+                $type: 'color'
+              }
+            }
+          },
+          g: {
+            h: {
+              i: {
+                j: {
+                  $value: 'value',
+                  $type: 'color'
+                }
+              }
+            }
+          }
+        }
+      }
+
+      expect(validateSchema(data)).toBe(true)
+    })
+
+    it('should fail validation if invalid input data is passed', async () => {
+      const data = {
+        foo: "I'm not an valid DesignToken object"
+      }
+
+      expect(() => validateSchema(data)).toThrow()
+    })
+
+    it('should fail validation if a valid prefix is not provided', async () => {
+      const data = {
+        color: {
+          $value: 'value',
+          $type: 'color'
+        }
+      }
+
+      expect(() => validateSchema(data)).toThrow()
+    })
+
+    it('should pass validation if "base" prefix is provided', async () => {
+      const data = {
+        base: {
+          a: {
+            $value: 'value',
+            $type: 'color'
+          }
+        }
+      }
+
+      expect(validateSchema(data)).toBe(true)
+    })
+  })
+})

--- a/config/schema-validators/validate-json-schema.ts
+++ b/config/schema-validators/validate-json-schema.ts
@@ -1,0 +1,146 @@
+import Ajv, {JSONSchemaType} from 'ajv'
+// eslint-disable-next-line import/no-nodejs-modules
+import fs from 'fs'
+import JSON5 from 'json5'
+
+import type {ColorDesignTokenDefinition} from '../../types/DesignToken'
+
+type Token = ColorDesignTokenDefinition
+
+interface GenericShape {
+  [name: string]: GenericShape | Token
+}
+
+export interface ColorProperties {
+  color: GenericShape
+}
+
+/**
+ * This script is used to validate the JSON schema of design tokens in a folder
+ * @param {object} data - A JSON object containing the design tokens. Should ideally be typed as ColorProperties, but intentionally 'unknown' to allow for validation
+ * @example
+ *  const tokens = {
+ *    base: {
+ *      a: {
+ *        $value: 'value',
+ *        $type: 'color'
+ *      }
+ *    }
+ *  }
+ *  validateSchema(tokens, 'base')
+ */
+export function validateSchema(data: object) {
+  const [prefix] = Object.keys(data)
+  const ajv = new Ajv()
+
+  const schema: JSONSchemaType<ColorProperties> = {
+    type: 'object',
+    required: [prefix],
+    properties: {
+      [prefix]: {
+        type: 'object',
+        required: [],
+        patternProperties: {
+          ['^.*$']: {
+            $ref: '#/$defs/recurse'
+          }
+        },
+        additionalProperties: false
+      }
+    },
+    additionalProperties: false,
+    $defs: {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      recurse: {
+        type: 'object',
+        oneOf: [
+          {
+            required: [],
+            patternProperties: {
+              ['^.*$']: {
+                type: 'object',
+                $ref: '#/$defs/recurse'
+              }
+            }
+          },
+          {
+            type: 'object',
+            $ref: '#/$defs/token'
+          }
+        ]
+      },
+      token: {
+        type: 'object',
+        required: ['$value', '$type'],
+        properties: {
+          $value: {
+            type: 'string',
+            nullable: false
+          },
+          $type: {
+            type: 'string',
+            default: 'color',
+            nullable: false
+          },
+          alpha: {
+            type: 'number',
+            nullable: true
+          },
+          $description: {
+            type: 'string',
+            nullable: true
+          },
+          deprecated: {
+            type: 'string',
+            nullable: true
+          }
+        }
+      }
+    }
+  }
+
+  const validate = ajv.compile(schema)
+  const result = validate(data)
+  const firstError = validate.errors?.[0]
+
+  if (!result) {
+    throw firstError
+  }
+
+  return result
+}
+
+/**
+ * This script is used to validate the JSON schema of design tokens in a folder
+ * @param {string} dir - The dir to the folder containing the design tokens
+ * @example validateSchemaFromDir('./tokens', 'color')
+ */
+export function validateSchemaFromDir(dir: string) {
+  const tokensDir = dir
+  const tokens = fs.readdirSync(tokensDir, {withFileTypes: true})
+  for (const token of tokens) {
+    if (token.isDirectory()) {
+      const tokenDir = `${tokensDir}/${token.name}`
+      const tokenFiles = fs.readdirSync(tokenDir, {withFileTypes: true})
+      for (const tokenFile of tokenFiles) {
+        if (tokenFile.isFile()) {
+          const tokenFilePath = `${tokenDir}/${tokenFile.name}`
+          const tokenFileContent = fs.readFileSync(tokenFilePath, 'utf8')
+          const tokenFileJson = JSON5.parse(tokenFileContent)
+
+          try {
+            // eslint-disable-next-line no-console
+            validateSchema(tokenFileJson)
+            // eslint-disable-next-line no-console
+            console.info(`[info] Successfully validated '${tokenFilePath}' */`)
+          } catch (error) {
+            // eslint-disable-next-line no-console
+            console.error(error) // Important! shows a table of errors
+            throw new Error(`Schema validation failed for '${tokenFilePath}'`)
+          }
+        }
+      }
+    }
+  }
+}

--- a/config/schema-validators/validate-json-schema.ts
+++ b/config/schema-validators/validate-json-schema.ts
@@ -5,6 +5,9 @@ import JSON5 from 'json5'
 
 import type {ColorDesignTokenDefinition} from '../../types/DesignToken'
 
+const validPrefixes = ['base', 'color'] as const
+type ValidPrefixes = typeof validPrefixes[number]
+
 type Token = ColorDesignTokenDefinition
 
 interface GenericShape {
@@ -30,7 +33,10 @@ export interface ColorProperties {
  *  validateSchema(tokens, 'base')
  */
 export function validateSchema(data: object) {
-  const [prefix] = Object.keys(data)
+  const [prefix] = Object.keys(data) as ValidPrefixes[]
+  if (!validPrefixes.includes(prefix)) {
+    throw new Error('Invalid prefix')
+  }
   const ajv = new Ajv()
 
   const schema: JSONSchemaType<ColorProperties> = {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@types/react": "^17.0.50",
     "@typescript-eslint/eslint-plugin": "^5.17.0",
     "@typescript-eslint/parser": "^5.17.0",
+    "ajv": "^8.11.0",
     "camelcase-keys": "^6.2.2",
     "chalk": "^4.1.0",
     "color-blend": "^4.0.0",

--- a/types/DesignToken.d.ts
+++ b/types/DesignToken.d.ts
@@ -1,0 +1,24 @@
+export type DesignTokenTypes = 'color' | 'dimension' | 'shadow' | 'fontFamily' | 'fontWeight' | 'typography'
+
+export type GenericDesignTokenValue = string | number
+
+export type GenericDesignTokenDefinition = {
+  $value: GenericDesignTokenValue
+  $type: DesignTokenTypes
+  $description?: string
+  deprecated?: string
+}
+
+export type ColorDesignTokenDefinition = GenericDesignTokenDefinition & {
+  $value: string
+  $type: 'color'
+  alpha?: number
+}
+
+export type DesignTokenDefinition = ColorDesignTokenDefinition | GenericDesignTokenDefinition
+
+export type DesignTokenGroup = {
+  [name: string]: DesignTokenDefinition | DesignTokenGroup
+}
+
+export type DesignTokenJson = {[name: string]: DesignTokenGroup}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1540,6 +1540,16 @@ ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ajv@^8.11.0:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
+  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 ansi-colors@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz"
@@ -4182,6 +4192,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 json-schema@0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz"
@@ -5368,6 +5383,11 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 require-main-filename@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
🚧  Work in-progress

## Summary

Validates `*.json` and `*.json5` token source files against a pre-defined schema. 

Currently validates color tokens to `n` depth using JSON built-in recursion.

Schema validation and results provided through `ajv`.

### What's changed
- added two functions that will:
  - validate data as an argument
  - validate all files in a local folder, using the above fn
- added some tests to verify functionality works as expected 

### Todo
- [ ] Add a CI check to validate entire folders on the server
- [ ] Wait for this to merge https://github.com/primer/primitives/pull/370, so that shadows validate correctly
- [ ] Add additional schemas for typography, etc (maybe in a future PR)