### PR TITLE
Border transformation

### DIFF
--- a/config/PrimerStyleDictionary.ts
+++ b/config/PrimerStyleDictionary.ts
@@ -16,6 +16,7 @@ import {
   jsonNestedPrefixed,
   cssThemed
 } from './formats'
+import {borderToCss} from './transformers/borderToCss'
 
 /**
  * Parsers
@@ -89,6 +90,11 @@ StyleDictionary.registerTransform({
 StyleDictionary.registerTransform({
   name: 'shadow/css',
   ...shadowToCss
+})
+
+StyleDictionary.registerTransform({
+  name: 'border/css',
+  ...borderToCss
 })
 
 /**

--- a/config/filters/isBorder.test.ts
+++ b/config/filters/isBorder.test.ts
@@ -1,0 +1,18 @@
+import {getMockToken} from '~/src/test-utilities'
+import {isBorder} from './isBorder'
+
+describe('Filter: isBorder', () => {
+  it('returns true if $type property is `border`', () => {
+    expect(isBorder(getMockToken({$type: 'border'}))).toStrictEqual(true)
+  })
+
+  it('returns false if $type property is not `border`', () => {
+    expect(isBorder(getMockToken({$type: 'pumpkin'}))).toStrictEqual(false)
+  })
+
+  it('returns false if $type property is falsy', () => {
+    expect(isBorder(getMockToken({$type: false}))).toStrictEqual(false)
+    expect(isBorder(getMockToken({$type: undefined}))).toStrictEqual(false)
+    expect(isBorder(getMockToken({$type: null}))).toStrictEqual(false)
+  })
+})

--- a/config/filters/isBorder.ts
+++ b/config/filters/isBorder.ts
@@ -1,0 +1,10 @@
+import StyleDictionary from 'style-dictionary'
+
+/**
+ * @description Checks if token is of $type `border`
+ * @param arguments [StyleDictionary.TransformedToken](https://github.com/amzn/style-dictionary/blob/main/types/TransformedToken.d.ts)
+ * @returns boolean
+ */
+export const isBorder = (token: StyleDictionary.TransformedToken): boolean => {
+  return token.$type === 'border'
+}

--- a/config/formats/typescriptExportDefinition.test.ts
+++ b/config/formats/typescriptExportDefinition.test.ts
@@ -14,6 +14,14 @@ describe('Format: TypeScript definitions', () => {
         yellow: getMockToken({
           value: '#FF0000'
         }),
+        border: getMockToken({
+          $type: 'border',
+          value: {
+            color: '#FF0000',
+            style: 'solid',
+            width: '1px'
+          }
+        }),
         // default: getMockToken({
         //   value: 16,
         //   $type: 'dimension'
@@ -39,12 +47,19 @@ describe('Format: TypeScript definitions', () => {
        */
       type ColorHex = string;
 
+      /**
+       * @description a css border string
+       * @format color | style | width
+       */
+      type Border = \`\${ColorHex} \${string} \${string}\`;
+
       export type tokens = {
         test: {
           tokens: {
             subgroup: {
               red: ColorHex;
               yellow: string;
+              border: Border;
               complex: {
                 top: number;
                 bottom: any;
@@ -67,11 +82,18 @@ describe('Format: TypeScript definitions', () => {
       */
       type ColorHex = string;
 
+      /**
+       * @description a css border string
+       * @format color | style | width
+       */
+      type Border = \`\${ColorHex} \${string} \${string}\`;
+
       export type tokens = {
         tokens: {
           subgroup: {
             red: ColorHex;
             yellow: string;
+            border: Border;
             complex: {
               top: number;
               bottom: any;

--- a/config/formats/typescriptExportDefinition.ts
+++ b/config/formats/typescriptExportDefinition.ts
@@ -56,6 +56,8 @@ const convertPropToType = (value: unknown, type?: string): string => {
       return 'string'
     case 'shadow':
       return 'Shadow'
+    case 'border':
+      return 'Border'
     default:
       if (typeof value === 'number') return 'number'
       if (typeof value === 'string') return 'string'
@@ -110,7 +112,7 @@ const getTypeDefinition = (
   const tokenWithTypes = toType(tokens, usedTypes)
   // clean up types
   for (const type of usedTypes) {
-    if (!['ColorHex', 'Shadow', 'Size', 'SizeRem'].includes(type)) {
+    if (!['ColorHex', 'Shadow', 'Border', 'Size', 'SizeRem'].includes(type)) {
       usedTypes.delete(type)
     }
   }

--- a/config/platforms/css.ts
+++ b/config/platforms/css.ts
@@ -21,7 +21,7 @@ export const css: PlatformInitializer = (outputFile, prefix, buildPath, _options
   return {
     prefix,
     buildPath,
-    transforms: ['name/cti/kebab', 'color/hex', 'color/hexAlpha', 'shadow/css'],
+    transforms: ['name/cti/kebab', 'color/hex', 'color/hexAlpha', 'shadow/css', 'border/css'],
     options: {
       basePxFontSize: 16
     },

--- a/config/platforms/docJson.ts
+++ b/config/platforms/docJson.ts
@@ -5,7 +5,7 @@ import {isSource} from '~/config/filters'
 export const docJson: PlatformInitializer = (outputFile, prefix, buildPath): StyleDictionary.Platform => ({
   prefix,
   buildPath,
-  transforms: ['color/hex', 'color/hexAlpha', 'shadow/css'],
+  transforms: ['color/hex', 'color/hexAlpha', 'shadow/css', 'border/css'],
   options: {
     basePxFontSize: 16
   },

--- a/config/platforms/javascript.ts
+++ b/config/platforms/javascript.ts
@@ -5,7 +5,7 @@ import {isSource} from '~/config/filters'
 export const javascript: PlatformInitializer = (outputFile, prefix, buildPath): StyleDictionary.Platform => ({
   prefix,
   buildPath,
-  transforms: ['name/cti/camel', 'color/hex', 'color/rgbAlpha', 'shadow/css'],
+  transforms: ['name/cti/camel', 'color/hex', 'color/rgbAlpha', 'shadow/css', 'border/css'],
   options: {
     basePxFontSize: 16
   },

--- a/config/platforms/json.ts
+++ b/config/platforms/json.ts
@@ -5,7 +5,7 @@ import {isSource} from '~/config/filters'
 export const json: PlatformInitializer = (outputFile, prefix, buildPath): StyleDictionary.Platform => ({
   prefix,
   buildPath,
-  transforms: ['color/hex', 'color/hexAlpha', 'shadow/css'],
+  transforms: ['color/hex', 'color/hexAlpha', 'shadow/css', 'border/css'],
   options: {
     basePxFontSize: 16
   },

--- a/config/platforms/scss.ts
+++ b/config/platforms/scss.ts
@@ -18,7 +18,7 @@ export const scss: PlatformInitializer = (outputFile, prefix, buildPath): StyleD
   return {
     prefix,
     buildPath,
-    transforms: ['name/cti/kebab', 'color/hex', 'color/hexAlpha', 'shadow/css'],
+    transforms: ['name/cti/kebab', 'color/hex', 'color/hexAlpha', 'shadow/css', 'border/css'],
     options: {
       basePxFontSize: 16
     },

--- a/config/platforms/typeDefinitions.ts
+++ b/config/platforms/typeDefinitions.ts
@@ -6,7 +6,7 @@ import {upperCaseFirstCharacter} from '~/config/utilities'
 export const typeDefinitions: PlatformInitializer = (outputFile, prefix, buildPath): StyleDictionary.Platform => ({
   prefix,
   buildPath,
-  transforms: ['name/cti/camel', 'color/hex', 'color/hexAlpha', 'shadow/css'],
+  transforms: ['name/cti/camel', 'color/hex', 'color/hexAlpha', 'shadow/css', 'border/css'],
   files: [
     {
       format: 'typescript/export-definition',

--- a/config/platforms/typescript.ts
+++ b/config/platforms/typescript.ts
@@ -5,7 +5,7 @@ import {isSource} from '~/config/filters'
 export const typescript: PlatformInitializer = (outputFile, prefix, buildPath): StyleDictionary.Platform => ({
   prefix,
   buildPath,
-  transforms: ['name/cti/camel', 'color/hex', 'color/hexAlpha', 'shadow/css'],
+  transforms: ['name/cti/camel', 'color/hex', 'color/hexAlpha', 'shadow/css', 'border/css'],
   options: {
     basePxFontSize: 16
   },

--- a/config/transformers/borderToCss.test.ts
+++ b/config/transformers/borderToCss.test.ts
@@ -1,0 +1,55 @@
+import {getMockToken} from '~/src/test-utilities'
+import {borderToCss} from './borderToCss'
+
+describe('Transformer: borderToCss', () => {
+  it('transforms `border` token to css border string', () => {
+    const input = getMockToken({
+      value: {
+        color: '#000000',
+        style: 'solid',
+        width: '1px'
+      }
+    })
+
+    const expectedOutput = '#000000 solid 1px'
+    expect(borderToCss.transformer(input)).toStrictEqual(expectedOutput)
+  })
+
+  it('throws an error when required values are missing', () => {
+    // missing blur
+    expect(() =>
+      borderToCss.transformer(
+        getMockToken({
+          value: {
+            color: '#000000',
+            style: 'solid'
+          }
+        })
+      )
+    ).toThrowError()
+
+    // missing spread
+    expect(() =>
+      borderToCss.transformer(
+        getMockToken({
+          value: {
+            color: '#000000',
+            width: '1px'
+          }
+        })
+      )
+    ).toThrowError()
+
+    // missing offsets
+    expect(() =>
+      borderToCss.transformer(
+        getMockToken({
+          value: {
+            style: 'solid',
+            width: '1px'
+          }
+        })
+      )
+    ).toThrowError()
+  })
+})

--- a/config/transformers/borderToCss.ts
+++ b/config/transformers/borderToCss.ts
@@ -1,0 +1,38 @@
+import StyleDictionary from 'style-dictionary'
+import {BorderTokenValue} from '../../types/BorderTokenValue'
+import {isBorder} from '../filters/isBorder'
+
+/**
+ * checks if all required properties exist on shadow token
+ * @param object - ShadowTokenValue
+ * @returns void or throws error
+ */
+const checkForBorderTokenProperties = (border: BorderTokenValue) => {
+  const requiredProperties = ['color', 'width', 'style']
+  for (const prop of requiredProperties) {
+    if (prop in border === false) {
+      throw new Error(`Missing propery: ${prop} on shadow token ${JSON.stringify(border)}`)
+    }
+  }
+}
+/**
+ * @description converts w3c border tokens in css border string
+ * @type value transformer — [StyleDictionary.ValueTransform](https://github.com/amzn/style-dictionary/blob/main/types/Transform.d.ts)
+ * @matcher matches all tokens of $type `border`
+ * @transformer returns css border `string`
+ */
+export const borderToCss: StyleDictionary.Transform = {
+  type: `value`,
+  transitive: true,
+  matcher: isBorder,
+  transformer: ({value}: {value: BorderTokenValue}) => {
+    //
+    checkForBorderTokenProperties(value)
+    // if value === string it was probably already transformed
+    if (typeof value === 'string') {
+      return value
+    }
+    /* color | style | width */
+    return `${value.color} ${value.style} ${value.width}`
+  }
+}

--- a/config/transformers/shadowToCss.ts
+++ b/config/transformers/shadowToCss.ts
@@ -10,8 +10,8 @@ import {alpha} from '../utilities'
  * @returns void or throws error
  */
 const checkForShadowTokenProperties = (shadow: ShadowTokenValue) => {
-  const requiredShadowProperties = ['color', 'offsetX', 'offsetY', 'blur', 'spread']
-  for (const prop of requiredShadowProperties) {
+  const requiredProperties = ['color', 'offsetX', 'offsetY', 'blur', 'spread']
+  for (const prop of requiredProperties) {
     if (prop in shadow === false) {
       throw new Error(`Missing propery: ${prop} on shadow token ${JSON.stringify(shadow)}`)
     }
@@ -30,11 +30,11 @@ export const shadowToCss: StyleDictionary.Transform = {
   transformer: ({value}: {value: ShadowTokenValue | ShadowTokenValue[]}) => {
     // turn value into array
     const shadowValues = !Array.isArray(value) ? [value] : value
+
     return shadowValues
       .map((shadow: ShadowTokenValue) => {
         // if value === string it was probably already transformed
         if (typeof shadow === 'string') return shadow
-
         checkForShadowTokenProperties(shadow)
         /*css box shadow:  inset? | offset-x | offset-y | blur-radius | spread-radius | color */
         return `${shadow.inset === true ? 'inset ' : ''}${shadow.offsetX} ${shadow.offsetY} ${shadow.blur} ${

--- a/config/types/Border.d.ts
+++ b/config/types/Border.d.ts
@@ -1,0 +1,5 @@
+/**
+ * @description a css border string
+ * @format color | style | width
+ */
+type Border = `${ColorHex} ${string} ${string}`

--- a/script/tempColorTokenBuild.ts
+++ b/script/tempColorTokenBuild.ts
@@ -9,7 +9,11 @@ export const buildDesignTokens = (buildOptions: ConfigGeneratorOptions): void =>
   const themes: TokenBuildInput[] = [
     {
       filename: 'light',
-      source: [`tokens/functional/color/light/*.json5`, `tokens/functional/shadow/light.json5`],
+      source: [
+        `tokens/functional/color/light/*.json5`,
+        `tokens/functional/shadow/light.json5`,
+        `tokens/functional/border/light.json5`
+      ],
       include: [`tokens/base/color/light/light.json5`]
     },
     {
@@ -17,7 +21,8 @@ export const buildDesignTokens = (buildOptions: ConfigGeneratorOptions): void =>
       source: [
         `tokens/functional/color/light/*.json5`,
         `tokens/functional/color/light/overrides/light.tritanopia.json5`,
-        `tokens/functional/shadow/light.json5`
+        `tokens/functional/shadow/light.json5`,
+        `tokens/functional/border/light.json5`
       ],
       include: [`tokens/base/color/light/light.json5`, `tokens/base/color/light/light.tritanopia.json5`]
     },
@@ -26,7 +31,8 @@ export const buildDesignTokens = (buildOptions: ConfigGeneratorOptions): void =>
       source: [
         `tokens/functional/color/light/*.json5`,
         `tokens/functional/color/light/overrides/light.protanopia-deuteranopia.json5`,
-        `tokens/functional/shadow/light.json5`
+        `tokens/functional/shadow/light.json5`,
+        `tokens/functional/border/light.json5`
       ],
       include: [`tokens/base/color/light/light.json5`, `tokens/base/color/light/light.protanopia-deuteranopia.json5`]
     },
@@ -35,13 +41,18 @@ export const buildDesignTokens = (buildOptions: ConfigGeneratorOptions): void =>
       source: [
         `tokens/functional/color/light/*.json5`,
         `tokens/functional/color/light/overrides/light.high-contrast.json5`,
-        `tokens/functional/shadow/light.json5`
+        `tokens/functional/shadow/light.json5`,
+        `tokens/functional/border/light.json5`
       ],
       include: [`tokens/base/color/light/light.json5`, `tokens/base/color/light/light.high-contrast.json5`]
     },
     {
       filename: 'dark',
-      source: [`tokens/functional/color/dark/*.json5`, `tokens/functional/shadow/dark.json5`],
+      source: [
+        `tokens/functional/color/dark/*.json5`,
+        `tokens/functional/shadow/dark.json5`,
+        `tokens/functional/border/dark.json5`
+      ],
       include: [`tokens/base/color/dark/dark.json5`]
     },
     {
@@ -49,7 +60,8 @@ export const buildDesignTokens = (buildOptions: ConfigGeneratorOptions): void =>
       source: [
         `tokens/functional/color/dark/*.json5`,
         `tokens/functional/color/dark/overrides/dark.dimmed.json5`,
-        `tokens/functional/shadow/dark.json5`
+        `tokens/functional/shadow/dark.json5`,
+        `tokens/functional/border/dark.json5`
       ],
       include: [`tokens/base/color/dark/dark.json5`, `tokens/base/color/dark/dark.dimmed.json5`]
     },
@@ -58,7 +70,8 @@ export const buildDesignTokens = (buildOptions: ConfigGeneratorOptions): void =>
       source: [
         `tokens/functional/color/dark/*.json5`,
         `tokens/functional/color/dark/overrides/dark.tritanopia.json5`,
-        `tokens/functional/shadow/dark.json5`
+        `tokens/functional/shadow/dark.json5`,
+        `tokens/functional/border/dark.json5`
       ],
       include: [`tokens/base/color/dark/dark.json5`, `tokens/base/color/dark/dark.tritanopia.json5`]
     },
@@ -67,7 +80,8 @@ export const buildDesignTokens = (buildOptions: ConfigGeneratorOptions): void =>
       source: [
         `tokens/functional/color/dark/*.json5`,
         `tokens/functional/color/dark/overrides/dark.protanopia-deuteranopia.json5`,
-        `tokens/functional/shadow/dark.json5`
+        `tokens/functional/shadow/dark.json5`,
+        `tokens/functional/border/dark.json5`
       ],
       include: [`tokens/base/color/dark/dark.json5`, `tokens/base/color/dark/dark.protanopia-deuteranopia.json5`]
     },
@@ -76,7 +90,8 @@ export const buildDesignTokens = (buildOptions: ConfigGeneratorOptions): void =>
       source: [
         `tokens/functional/color/dark/*.json5`,
         `tokens/functional/color/dark/overrides/dark.high-contrast.json5`,
-        `tokens/functional/shadow/dark.json5`
+        `tokens/functional/shadow/dark.json5`,
+        `tokens/functional/border/dark.json5`
       ],
       include: [`tokens/base/color/dark/dark.json5`, `tokens/base/color/dark/dark.high-contrast.json5`]
     }

--- a/tokens/functional/border/dark.json5
+++ b/tokens/functional/border/dark.json5
@@ -1,0 +1,12 @@
+{
+  outline: {
+    focus: {
+      $value: {
+        color: '{color.focus}',
+        style: 'solid',
+        width: '1px'
+      },
+      $type: 'border'
+    }
+  }
+}

--- a/tokens/functional/border/light.json5
+++ b/tokens/functional/border/light.json5
@@ -1,0 +1,12 @@
+{
+  outline: {
+    focus: {
+      $value: {
+        color: '{color.focus}',
+        style: 'solid',
+        width: '1px'
+      },
+      $type: 'border'
+    }
+  }
+}

--- a/tokens/functional/shadow/light.json5
+++ b/tokens/functional/shadow/light.json5
@@ -88,7 +88,7 @@
         blur: '3px',
         spread: "0px"
       },{
-        color: '{shadow.color.semiBlack}',
+        color: '{shadow.color.semiBlack.12}',
         offsetX: '0px',
         offsetY: '8px',
         blur: '24px',

--- a/tokens/functional/size/border.json
+++ b/tokens/functional/size/border.json
@@ -36,5 +36,13 @@
         "value": "100vh"
       }
     }
+  },
+  "outline": {
+    "focus": {
+      "offset": {
+        "$value": "1px",
+        "$type": "dimension"
+      }
+    }
   }
 }

--- a/types/BorderTokenValue.d.ts
+++ b/types/BorderTokenValue.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Type definition for w3c border composite token value
+ * @link https://design-tokens.github.io/community-group/format/#border
+ */
+export type StrokeStyleString = 'solid' | 'dashed' | 'dotted' | 'double' | 'groove' | 'ridge' | 'outset' | 'inset'
+export type BorderTokenValue = {
+  color: string
+  width: string
+  style: StrokeStyleString
+}


### PR DESCRIPTION
## Summary

Adds transformer and filter to transform borders to css string.
This fixes https://github.com/github/primer/issues/1512

## Todo
- [x] add outline offset
- [x] use `color.focus`
- [x] add outline as top level to get `--ui-outline-focus` and  `--ui-outline-focus-offset`

## List of notable changes:

- **added** `config/filters/isBorder.ts`
- **added** `config/transformers/borderToCss.ts`

## What should reviewers focus on?

- does it work?
- is it okay to add borders to theme output file (they use colors so they must be tied to color modes)

## Steps to test:

1. Clone branch
1. run `npm run build:color-tokens`

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
- [ ] Verify the design tokens changed in this PR are expected using the diffing results in this PR
