### PR TITLE
Added name/pathToKebabCase

### DIFF
--- a/config/PrimerStyleDictionary.ts
+++ b/config/PrimerStyleDictionary.ts
@@ -17,6 +17,7 @@ import {
   cssThemed
 } from './formats'
 import {borderToCss} from './transformers/borderToCss'
+import {namePathToKebabCase} from './transformers/namePathToKebabCase'
 
 /**
  * Parsers
@@ -85,6 +86,11 @@ StyleDictionary.registerTransform({
 StyleDictionary.registerTransform({
   name: 'name/pathToDotNotation',
   ...namePathToDotNotation
+})
+
+StyleDictionary.registerTransform({
+  name: 'name/pathToKebabCase',
+  ...namePathToKebabCase
 })
 
 StyleDictionary.registerTransform({

--- a/config/platforms/css.ts
+++ b/config/platforms/css.ts
@@ -21,7 +21,7 @@ export const css: PlatformInitializer = (outputFile, prefix, buildPath, _options
   return {
     prefix,
     buildPath,
-    transforms: ['name/cti/kebab', 'color/hex', 'color/hexAlpha', 'shadow/css', 'border/css'],
+    transforms: ['name/pathToKebabCase', 'color/hex', 'color/hexAlpha', 'shadow/css', 'border/css'],
     options: {
       basePxFontSize: 16
     },

--- a/config/platforms/scss.ts
+++ b/config/platforms/scss.ts
@@ -18,7 +18,7 @@ export const scss: PlatformInitializer = (outputFile, prefix, buildPath): StyleD
   return {
     prefix,
     buildPath,
-    transforms: ['name/cti/kebab', 'color/hex', 'color/hexAlpha', 'shadow/css', 'border/css'],
+    transforms: ['name/pathToKebabCase', 'color/hex', 'color/hexAlpha', 'shadow/css', 'border/css'],
     options: {
       basePxFontSize: 16
     },

--- a/config/transformers/namePathToKebabCase.test.ts
+++ b/config/transformers/namePathToKebabCase.test.ts
@@ -1,0 +1,47 @@
+import {getMockToken} from '~/src/test-utilities'
+import {namePathToKebabCase} from './namePathToKebabCase'
+
+describe('Transformer: namePathToKebabCase', () => {
+  it('converts path elements to dot.notation and ignores name proprty', () => {
+    const input = [
+      getMockToken({
+        name: 'tokenName',
+        path: ['path', 'to', 'token']
+      }),
+      getMockToken({
+        name: 'tokenName',
+        path: ['PATH', 'tO', 'Token']
+      }),
+      getMockToken({
+        name: 'tokenName',
+        path: ['path', 'toToken']
+      }),
+      getMockToken({
+        name: 'tokenName',
+        path: ['pathtoToken']
+      })
+    ]
+    const expectedOutput = ['path-to-token', 'PATH-tO-Token', 'path-toToken', 'pathtoToken']
+
+    expect(input.map(item => namePathToKebabCase.transformer(item))).toStrictEqual(expectedOutput)
+  })
+
+  it('replaces spaces, `-`, `_` and `+` within path elements and joins with camelCase, but does not change the rest of the word', () => {
+    const input = [
+      getMockToken({
+        name: 'tokenName',
+        path: ['start', 'path to token']
+      }),
+      getMockToken({
+        name: 'tokenName',
+        path: ['start', 'PATH_tO-Token']
+      }),
+      getMockToken({
+        name: 'tokenName',
+        path: ['start', 'path+toToken']
+      })
+    ]
+    const expectedOutput = ['start-path to token', 'start-PATH_tO-Token', 'start-path+toToken']
+    expect(input.map(item => namePathToKebabCase.transformer(item))).toStrictEqual(expectedOutput)
+  })
+})

--- a/config/transformers/namePathToKebabCase.ts
+++ b/config/transformers/namePathToKebabCase.ts
@@ -1,0 +1,12 @@
+import StyleDictionary from 'style-dictionary'
+
+/**
+ * @description converts the [TransformedToken's](https://github.com/amzn/style-dictionary/blob/main/types/TransformedToken.d.ts) `.path` array to a kebab-case string, preserves casing of parts
+ * @type name transformer — [StyleDictionary.NameTransform](https://github.com/amzn/style-dictionary/blob/main/types/Transform.d.ts)
+ * @matcher omitted to match all tokens
+ * @transformer returns `string` kebab-case
+ */
+export const namePathToKebabCase: StyleDictionary.Transform = {
+  type: `name`,
+  transformer: (token: StyleDictionary.TransformedToken) => token.path.join('-')
+}


### PR DESCRIPTION
## Summary

Added new name transformer `name/pathToKebabCase` + tests.

In contrast to the built-in one, it leaves the parts as is, so `commitMessage` + `hover` becomes `commitMessage-hover` instead of `commitmessage-hover`.

This is to preserve camelCase in token names that is necessary.

## List of notable changes:

- **added** namePathToKebabCase.ts and namePathToKebabCase.test.ts
- **updated** `name/cti/kebab` to `name/pathToKebabCase` in `css` and `scss` platform

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
- [ ] Verify the design tokens changed in this PR are expected using the diffing results in this PR
