### PR TITLE
Add prefix to name transformers

### DIFF
--- a/config/transformers/namePathToDotNotation.test.ts
+++ b/config/transformers/namePathToDotNotation.test.ts
@@ -44,4 +44,16 @@ describe('Transformer: namePathToDotNotation', () => {
     const expectedOutput = ['start.pathToToken', 'start.PATHTOToken', 'start.pathToToken']
     expect(input.map(item => namePathToDotNotation.transformer(item))).toStrictEqual(expectedOutput)
   })
+
+  it('adds prefix to token name', () => {
+    const platform = {
+      prefix: 'PRIMER'
+    }
+    const input = getMockToken({
+      name: 'tokenName',
+      path: ['start', 'pathTo', 'token']
+    })
+    const expectedOutput = 'PRIMER.start.pathTo.token'
+    expect(namePathToDotNotation.transformer(input, platform)).toStrictEqual(expectedOutput)
+  })
 })

--- a/config/transformers/namePathToDotNotation.ts
+++ b/config/transformers/namePathToDotNotation.ts
@@ -22,5 +22,13 @@ const camelCase = (string: string): string => {
  */
 export const namePathToDotNotation: StyleDictionary.Transform = {
   type: `name`,
-  transformer: (token: StyleDictionary.TransformedToken) => token.path.map(part => camelCase(part)).join('.')
+  transformer: (token: StyleDictionary.TransformedToken, options?: StyleDictionary.Platform): string => {
+    return (
+      [options?.prefix, ...token.path]
+        // remove undefined if exists
+        .filter((part: unknown): part is string => typeof part === 'string')
+        .map((part: string) => camelCase(part))
+        .join('.')
+    )
+  }
 }

--- a/config/transformers/namePathToKebabCase.test.ts
+++ b/config/transformers/namePathToKebabCase.test.ts
@@ -44,4 +44,16 @@ describe('Transformer: namePathToKebabCase', () => {
     const expectedOutput = ['start-path to token', 'start-PATH_tO-Token', 'start-path+toToken']
     expect(input.map(item => namePathToKebabCase.transformer(item))).toStrictEqual(expectedOutput)
   })
+
+  it('adds prefix to token name', () => {
+    const platform = {
+      prefix: 'PRIMER'
+    }
+    const input = getMockToken({
+      name: 'tokenName',
+      path: ['start', 'pathTo', 'token']
+    })
+    const expectedOutput = 'PRIMER-start-pathTo-token'
+    expect(namePathToKebabCase.transformer(input, platform)).toStrictEqual(expectedOutput)
+  })
 })

--- a/config/transformers/namePathToKebabCase.ts
+++ b/config/transformers/namePathToKebabCase.ts
@@ -8,5 +8,12 @@ import StyleDictionary from 'style-dictionary'
  */
 export const namePathToKebabCase: StyleDictionary.Transform = {
   type: `name`,
-  transformer: (token: StyleDictionary.TransformedToken) => token.path.join('-')
+  transformer: (token: StyleDictionary.TransformedToken, options?: StyleDictionary.Platform): string => {
+    return (
+      [options?.prefix, ...token.path]
+        // remove undefined if exists
+        .filter((part: unknown): part is string => typeof part === 'string')
+        .join('-')
+    )
+  }
 }


### PR DESCRIPTION
## Summary

Incorporate prefix like `product` or `brand` into name transformers so that they are added to output like `.css` variables or in the deprecated json files.

## List of notable changes:

- **added** tests to test if prefix is added
- **updated** `namePathToDotNotation.ts` and `namePathToKebabCase.ts` to add prefix if defined

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
- [ ] Verify the design tokens changed in this PR are expected using the diffing results in this PR
