### PR TITLE
Add postinstall script to install deps storybook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ node_modules
 /dist/
 /tokens-v2-private/
 /primitives/modes/
-/package-lock.json
+package-lock.json
 coverage/

--- a/package.json
+++ b/package.json
@@ -27,9 +27,12 @@
   "homepage": "https://github.com/primer/primitives#readme",
   "scripts": {
     "build": "ts-node ./script/build.ts && tsc --project tsconfig.build.json",
+    "build:color-tokens": "ts-node -r tsconfig-paths/register ./script/tempColorTokenBuild.ts",
     "build:tokens": "node -e \"require('./build')._init()\"",
+    "build:new-tokens": "npm run build:tokens && npm run build:color-tokens",
     "format": "prettier --write  '**/*.{js,jsx,ts,tsx,md,mdx,css}'",
     "format:check": "prettier --check '**/*.{js,jsx,ts,tsx,md,mdx,css}'",
+    "install:storybook": "cd docs/storybook && npm install",
     "lint": "eslint '**/*.{js,ts,tsx,md,mdx}' --max-warnings=0 --config .eslintrc.js",
     "lint:fix": "eslint '**/*.{js,ts,tsx,md,mdx}' --fix --max-warnings=0 --config .eslintrc.js",
     "postbuild": "ts-node ./script/color-contrast.ts",
@@ -37,13 +40,11 @@
     "prebuild:tokens": "rm -rf tokens-v2-private",
     "prebuild:color-tokens": "rm -rf tokens-v2-private/**/**/color",
     "prepack": "yarn build && yarn build:tokens",
-    "prepare": "husky install",
+    "prepare": "husky install && npm run install:storybook",
     "release": "changeset publish",
-    "build:color-tokens": "ts-node -r tsconfig-paths/register ./script/tempColorTokenBuild.ts",
-    "test": "jest --verbose --coverage",
-    "watch": "ls data/**/*.scss script/**/*.ts | entr -s 'yarn build'",
     "start:storybook": "npm run build:color-tokens && cd docs/storybook && npm run storybook",
-    "build:new-tokens": "npm run build:tokens && npm run build:color-tokens"
+    "test": "jest --verbose --coverage",
+    "watch": "ls data/**/*.scss script/**/*.ts | entr -s 'yarn build'"
   },
   "prettier": "@github/prettier-config",
   "devDependencies": {


### PR DESCRIPTION
## Summary

Automatically install storybook deps on `npm i`

## List of notable changes:

- **added** new npm scripts `install:storybook` and `postinstall`
- **updated** package.json to have scripts in alphabetical order