### PR TITLE
Fix failing main branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 14.x
 
       - name: Install dependencies
-        run: yarn
+        run: yarn && pushd docs; yarn; popd
 
       - name: Build tokens
         run: yarn build


### PR DESCRIPTION
## Summary

`main` is currently failing a CI check, which is preventing the creation of a release tracking branch.

![CI check status on repo home showing as failing](https://user-images.githubusercontent.com/13340707/203527653-b82353ac-92d2-4671-bf86-a4c1f1f80ba1.png)

Fixes issue that relates to the linter being unable to resolve dependencies in the docs folder. 

Issue occurs because the changets action attempts to commit new markdown files, which triggers the pre-commit hook. 

## List of notable changes:

<!--
E.g.

- **added** new design token for # because #
- **deprecated**  design token for # because #
- **updated** documentation for # because #
-->

- added additional install step for /docs folder to resolve imports


## Steps to test:

- Merge to main and check workflow passes (🤞 YOLO )
or
- Pull down locally and test the new commands. Should pass now.

## Supporting resources (related issues, external links, etc):

-

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
- [ ] Verify the design tokens changed in this PR are expected using the diffing results in this PR
