### PR TITLE
Add eslint import type with type keyword rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -92,6 +92,7 @@ module.exports = {
         '@typescript-eslint/no-explicit-any': 2,
         '@typescript-eslint/no-unnecessary-condition': 2,
         '@typescript-eslint/explicit-module-boundary-types': 0,
+        '@typescript-eslint/consistent-type-imports': 'warn',
         '@typescript-eslint/no-unused-vars': [
           'error',
           {

--- a/config/filters/isBorder.ts
+++ b/config/filters/isBorder.ts
@@ -1,4 +1,4 @@
-import StyleDictionary from 'style-dictionary'
+import type StyleDictionary from 'style-dictionary'
 
 /**
  * @description Checks if token is of $type `border`

--- a/config/filters/isColor.ts
+++ b/config/filters/isColor.ts
@@ -1,4 +1,4 @@
-import StyleDictionary from 'style-dictionary'
+import type StyleDictionary from 'style-dictionary'
 
 /**
  * @description Checks if token is of $type `color`

--- a/config/filters/isColorWithAlpha.ts
+++ b/config/filters/isColorWithAlpha.ts
@@ -1,4 +1,4 @@
-import StyleDictionary from 'style-dictionary'
+import type StyleDictionary from 'style-dictionary'
 import {isColor} from './isColor'
 
 /**

--- a/config/filters/isDeprecated.ts
+++ b/config/filters/isDeprecated.ts
@@ -1,4 +1,4 @@
-import StyleDictionary from 'style-dictionary'
+import type StyleDictionary from 'style-dictionary'
 
 /**
  * @description Checks if token has a valid `deprecated` property

--- a/config/filters/isShadow.ts
+++ b/config/filters/isShadow.ts
@@ -1,4 +1,4 @@
-import StyleDictionary from 'style-dictionary'
+import type StyleDictionary from 'style-dictionary'
 
 /**
  * @description Checks if token is of $type `shadow`

--- a/config/filters/isSource.test.ts
+++ b/config/filters/isSource.test.ts
@@ -1,4 +1,4 @@
-import StyleDictionary from 'style-dictionary'
+import type StyleDictionary from 'style-dictionary'
 import {getMockToken} from '~/src/test-utilities'
 import {isSource} from './isSource'
 

--- a/config/filters/isSource.ts
+++ b/config/filters/isSource.ts
@@ -1,4 +1,4 @@
-import StyleDictionary from 'style-dictionary'
+import type StyleDictionary from 'style-dictionary'
 
 /**
  * @description Checks if token is source token

--- a/config/formats/cssThemed.ts
+++ b/config/formats/cssThemed.ts
@@ -1,5 +1,5 @@
 import StyleDictionary from 'style-dictionary'
-import {FormatterArguments} from 'style-dictionary/types/Format'
+import type {FormatterArguments} from 'style-dictionary/types/Format'
 import {format} from 'prettier'
 const {fileHeader, formattedVariables} = StyleDictionary.formatHelpers
 

--- a/config/formats/javascriptCommonJs.ts
+++ b/config/formats/javascriptCommonJs.ts
@@ -1,5 +1,5 @@
 import StyleDictionary from 'style-dictionary'
-import {FormatterArguments} from 'style-dictionary/types/Format'
+import type {FormatterArguments} from 'style-dictionary/types/Format'
 import {format} from 'prettier'
 import {jsonToNestedValue, prefixTokens} from '~/config/utilities'
 

--- a/config/formats/javascriptEsm.ts
+++ b/config/formats/javascriptEsm.ts
@@ -1,7 +1,7 @@
 import StyleDictionary from 'style-dictionary'
 import {format} from 'prettier'
 import {jsonToNestedValue, prefixTokens} from '~/config/utilities'
-import {FormatterArguments} from 'style-dictionary/types/Format'
+import type {FormatterArguments} from 'style-dictionary/types/Format'
 
 const {fileHeader} = StyleDictionary.formatHelpers
 

--- a/config/formats/jsonNestedPrefixed.ts
+++ b/config/formats/jsonNestedPrefixed.ts
@@ -1,4 +1,4 @@
-import StyleDictionary from 'style-dictionary'
+import type StyleDictionary from 'style-dictionary'
 import {format} from 'prettier'
 import {jsonToNestedValue, prefixTokens} from '~/config/utilities'
 

--- a/config/formats/scssMixinCssVariables.ts
+++ b/config/formats/scssMixinCssVariables.ts
@@ -1,6 +1,6 @@
 import StyleDictionary from 'style-dictionary'
 import {format} from 'prettier'
-import {FormatterArguments} from 'style-dictionary/types/Format'
+import type {FormatterArguments} from 'style-dictionary/types/Format'
 
 const {fileHeader, formattedVariables} = StyleDictionary.formatHelpers
 

--- a/config/formats/typescriptExportDefinition.ts
+++ b/config/formats/typescriptExportDefinition.ts
@@ -3,7 +3,7 @@ import {format} from 'prettier'
 import fs = require('fs')
 import path = require('path')
 import {prefixTokens} from '~/config/utilities'
-import {FormatterArguments} from 'style-dictionary/types/Format'
+import type {FormatterArguments} from 'style-dictionary/types/Format'
 
 const {fileHeader} = StyleDictionary.formatHelpers
 

--- a/config/parsers/w3cJsonParser.ts
+++ b/config/parsers/w3cJsonParser.ts
@@ -1,5 +1,5 @@
 import {parse as json5Parse} from 'json5'
-import StyleDictionary from 'style-dictionary'
+import type StyleDictionary from 'style-dictionary'
 
 /**
  * @description Parses a valid [json5](https://json5.org) file and replaces `$value` with `value` and `$description` with `comment` to make a w3c standard file compatible with style dictionary

--- a/config/platforms/css.ts
+++ b/config/platforms/css.ts
@@ -1,5 +1,5 @@
-import StyleDictionary from 'style-dictionary'
-import {PlatformInitializer} from '~/types/PlatformInitializer'
+import type StyleDictionary from 'style-dictionary'
+import type {PlatformInitializer} from '~/types/PlatformInitializer'
 import {isSource} from '~/config/filters'
 
 const getCssSelectors = (outputFile: string): {selector: string; selectorLight: string; selectorDark: string} => {

--- a/config/platforms/deprecatedJson.ts
+++ b/config/platforms/deprecatedJson.ts
@@ -1,5 +1,5 @@
-import StyleDictionary from 'style-dictionary'
-import {PlatformInitializer} from '~/types/PlatformInitializer'
+import type StyleDictionary from 'style-dictionary'
+import type {PlatformInitializer} from '~/types/PlatformInitializer'
 import {isDeprecated} from '~/config/filters'
 
 export const deprecatedJson: PlatformInitializer = (outputFile, prefix, buildPath): StyleDictionary.Platform => ({

--- a/config/platforms/docJson.ts
+++ b/config/platforms/docJson.ts
@@ -1,5 +1,5 @@
-import StyleDictionary from 'style-dictionary'
-import {PlatformInitializer} from '~/types/PlatformInitializer'
+import type StyleDictionary from 'style-dictionary'
+import type {PlatformInitializer} from '~/types/PlatformInitializer'
 import {isSource} from '~/config/filters'
 
 export const docJson: PlatformInitializer = (outputFile, prefix, buildPath): StyleDictionary.Platform => ({

--- a/config/platforms/javascript.ts
+++ b/config/platforms/javascript.ts
@@ -1,5 +1,5 @@
-import StyleDictionary from 'style-dictionary'
-import {PlatformInitializer} from '~/types/PlatformInitializer'
+import type StyleDictionary from 'style-dictionary'
+import type {PlatformInitializer} from '~/types/PlatformInitializer'
 import {isSource} from '~/config/filters'
 
 export const javascript: PlatformInitializer = (outputFile, prefix, buildPath): StyleDictionary.Platform => ({

--- a/config/platforms/json.ts
+++ b/config/platforms/json.ts
@@ -1,5 +1,5 @@
-import StyleDictionary from 'style-dictionary'
-import {PlatformInitializer} from '~/types/PlatformInitializer'
+import type StyleDictionary from 'style-dictionary'
+import type {PlatformInitializer} from '~/types/PlatformInitializer'
 import {isSource} from '~/config/filters'
 
 export const json: PlatformInitializer = (outputFile, prefix, buildPath): StyleDictionary.Platform => ({

--- a/config/platforms/scss.ts
+++ b/config/platforms/scss.ts
@@ -1,5 +1,5 @@
-import StyleDictionary from 'style-dictionary'
-import {PlatformInitializer} from '~/types/PlatformInitializer'
+import type StyleDictionary from 'style-dictionary'
+import type {PlatformInitializer} from '~/types/PlatformInitializer'
 import {isSource} from '~/config/filters'
 
 const getFilenameFromPath = (path: string): string => {

--- a/config/platforms/typeDefinitions.ts
+++ b/config/platforms/typeDefinitions.ts
@@ -1,5 +1,5 @@
-import StyleDictionary from 'style-dictionary'
-import {PlatformInitializer} from '~/types/PlatformInitializer'
+import type StyleDictionary from 'style-dictionary'
+import type {PlatformInitializer} from '~/types/PlatformInitializer'
 import {isSource} from '~/config/filters'
 import {upperCaseFirstCharacter} from '~/config/utilities'
 

--- a/config/platforms/typescript.ts
+++ b/config/platforms/typescript.ts
@@ -1,5 +1,5 @@
-import StyleDictionary from 'style-dictionary'
-import {PlatformInitializer} from '~/types/PlatformInitializer'
+import type StyleDictionary from 'style-dictionary'
+import type {PlatformInitializer} from '~/types/PlatformInitializer'
 import {isSource} from '~/config/filters'
 
 export const typescript: PlatformInitializer = (outputFile, prefix, buildPath): StyleDictionary.Platform => ({

--- a/config/transformers/borderToCss.ts
+++ b/config/transformers/borderToCss.ts
@@ -1,6 +1,6 @@
-import StyleDictionary from 'style-dictionary'
-import {BorderTokenValue} from '../../types/BorderTokenValue'
 import {isBorder} from '../filters/isBorder'
+import type StyleDictionary from 'style-dictionary'
+import type {BorderTokenValue} from '../../types/BorderTokenValue'
 
 /**
  * checks if all required properties exist on shadow token

--- a/config/transformers/colorToHex.ts
+++ b/config/transformers/colorToHex.ts
@@ -1,6 +1,6 @@
-import StyleDictionary from 'style-dictionary'
 import {toHex} from 'color2k'
 import {isColor} from '~/config/filters'
+import type StyleDictionary from 'style-dictionary'
 /**
  * @description converts color tokens value to `hex6` or `hex8`
  * @type value transformer — [StyleDictionary.ValueTransform](https://github.com/amzn/style-dictionary/blob/main/types/Transform.d.ts)

--- a/config/transformers/colorToHexAlpha.ts
+++ b/config/transformers/colorToHexAlpha.ts
@@ -1,7 +1,7 @@
 import {toHex} from 'color2k'
 import {alpha} from '~/config/utilities'
-import StyleDictionary from 'style-dictionary'
 import {isColorWithAlpha} from '~/config/filters'
+import type StyleDictionary from 'style-dictionary'
 /**
  * @description replaces tokens value with `hex8` color using the tokens `alpha` property to specify the value used for alpha
  * @type value transformer — [StyleDictionary.ValueTransform](https://github.com/amzn/style-dictionary/blob/main/types/Transform.d.ts)

--- a/config/transformers/colorToRgbAlpha.ts
+++ b/config/transformers/colorToRgbAlpha.ts
@@ -1,6 +1,6 @@
-import StyleDictionary from 'style-dictionary'
 import {isColorWithAlpha} from '~/config/filters'
 import {alpha} from '~/config/utilities'
+import type StyleDictionary from 'style-dictionary'
 /**
  * @description replaces tokens value with `rgba` color using the tokens `alpha` property to specify the value used for alpha
  * @type value transformer — [StyleDictionary.ValueTransform](https://github.com/amzn/style-dictionary/blob/main/types/Transform.d.ts)

--- a/config/transformers/jsonDeprecated.ts
+++ b/config/transformers/jsonDeprecated.ts
@@ -1,5 +1,5 @@
-import StyleDictionary from 'style-dictionary'
 import {isDeprecated} from '~/config/filters'
+import type StyleDictionary from 'style-dictionary'
 /**
  * @description replaces tokens value with content of tokens `deprecated` property
  * @type value transformer — [StyleDictionary.ValueTransform](https://github.com/amzn/style-dictionary/blob/main/types/Transform.d.ts)

--- a/config/transformers/namePathToDotNotation.ts
+++ b/config/transformers/namePathToDotNotation.ts
@@ -1,5 +1,5 @@
-import StyleDictionary from 'style-dictionary'
 import {upperCaseFirstCharacter} from '~/config/utilities'
+import type StyleDictionary from 'style-dictionary'
 
 /**
  * camelCase

--- a/config/transformers/namePathToKebabCase.ts
+++ b/config/transformers/namePathToKebabCase.ts
@@ -1,4 +1,4 @@
-import StyleDictionary from 'style-dictionary'
+import type StyleDictionary from 'style-dictionary'
 
 /**
  * @description converts the [TransformedToken's](https://github.com/amzn/style-dictionary/blob/main/types/TransformedToken.d.ts) `.path` array to a kebab-case string, preserves casing of parts

--- a/config/transformers/shadowToCss.ts
+++ b/config/transformers/shadowToCss.ts
@@ -1,8 +1,8 @@
 import {toHex} from 'color2k'
-import StyleDictionary from 'style-dictionary'
-import {ShadowTokenValue} from '../../types/ShadowTokenValue'
+import type StyleDictionary from 'style-dictionary'
 import {isShadow} from '../filters/isShadow'
 import {alpha, checkRequiredTokenProperties} from '../utilities'
+import type {ShadowTokenValue} from '../../types/ShadowTokenValue'
 
 /**
  * @description converts w3c shadow tokens in css shadow string

--- a/config/utilities/jsonToNestedValue.ts
+++ b/config/utilities/jsonToNestedValue.ts
@@ -1,4 +1,4 @@
-import StyleDictionary from 'style-dictionary'
+import type StyleDictionary from 'style-dictionary'
 /**
  * jsonToNestedValue
  * @description creates a nested json three where every final value is the `.value` prop

--- a/config/utilities/prefixTokens.ts
+++ b/config/utilities/prefixTokens.ts
@@ -1,4 +1,4 @@
-import StyleDictionary from 'style-dictionary'
+import type StyleDictionary from 'style-dictionary'
 /**
  * @description extract prefix from platform and add to tokens array if defined
  * @param tokens StyleDictionary.TransformedTokens

--- a/docs/src/components/ControlStack.tsx
+++ b/docs/src/components/ControlStack.tsx
@@ -1,4 +1,5 @@
-import React, {Fragment, FC} from 'react'
+import type React from 'react'
+import {Fragment} from 'react'
 import {Box} from '@primer/components'
 
 interface ControlStackVisualProps {
@@ -8,7 +9,7 @@ interface ControlStackVisualProps {
   variant?: string
 }
 
-const ControlStackVisual: FC<ControlStackVisualProps> = ({modifier, variant}) => {
+const ControlStackVisual: React.FC<ControlStackVisualProps> = ({modifier, variant}) => {
   return (
     <Fragment>
       <Box

--- a/docs/src/components/ControlStack.tsx
+++ b/docs/src/components/ControlStack.tsx
@@ -1,5 +1,5 @@
-import type React from 'react'
-import {Fragment} from 'react'
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+import React, {Fragment} from 'react'
 import {Box} from '@primer/components'
 
 interface ControlStackVisualProps {

--- a/docs/src/components/Stack.tsx
+++ b/docs/src/components/Stack.tsx
@@ -1,5 +1,5 @@
-import type React from 'react'
-import {Fragment} from 'react'
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+import React, {Fragment} from 'react'
 import {Box} from '@primer/components'
 
 interface StackVisualProps {

--- a/docs/src/components/Stack.tsx
+++ b/docs/src/components/Stack.tsx
@@ -1,4 +1,5 @@
-import React, {Fragment, FC} from 'react'
+import type React from 'react'
+import {Fragment} from 'react'
 import {Box} from '@primer/components'
 
 interface StackVisualProps {
@@ -7,7 +8,7 @@ interface StackVisualProps {
   modifier?: string
 }
 
-const StackVisual: FC<StackVisualProps> = ({gap, padding, modifier}) => {
+const StackVisual: React.FC<StackVisualProps> = ({gap, padding, modifier}) => {
   return (
     <Fragment>
       {gap && (

--- a/docs/src/components/color-theme-context.tsx
+++ b/docs/src/components/color-theme-context.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import colors from '../../../dist/js/colors'
+import type colors from '../../../dist/js/colors'
 
 const ColorThemeContext = React.createContext<
   [keyof typeof colors, React.Dispatch<React.SetStateAction<keyof typeof colors>>]

--- a/docs/src/components/control.tsx
+++ b/docs/src/components/control.tsx
@@ -1,4 +1,5 @@
-import React, {Fragment, FC} from 'react'
+import type React from 'react'
+import {Fragment} from 'react'
 import {Box} from '@primer/components'
 
 interface ControlVisualProps {
@@ -19,7 +20,7 @@ interface ControlVisualProps {
   highlightHeight?: boolean
 }
 
-const ControlVisual: FC<ControlVisualProps> = ({
+const ControlVisual: React.FC<ControlVisualProps> = ({
   paddingLeft,
   paddingRight,
   paddingTop,

--- a/docs/src/components/control.tsx
+++ b/docs/src/components/control.tsx
@@ -1,5 +1,5 @@
-import type React from 'react'
-import {Fragment} from 'react'
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+import React, {Fragment} from 'react'
 import {Box} from '@primer/components'
 
 interface ControlVisualProps {

--- a/docs/src/components/tables/BaseSizeTable.tsx
+++ b/docs/src/components/tables/BaseSizeTable.tsx
@@ -1,4 +1,4 @@
-import React, {FC} from 'react'
+import type React from 'react'
 import {Box} from '@primer/components'
 import FrameworkVariableTable from './FrameworkVariableTable'
 import TokenInlineCode from '../TokenInlineCode'
@@ -11,7 +11,7 @@ interface BaseSizeTableProps {
   showExample?: boolean
 }
 
-const BaseSizeTable: FC<BaseSizeTableProps> = ({filePath, showExample}) => {
+const BaseSizeTable: React.FC<BaseSizeTableProps> = ({filePath, showExample}) => {
   return (
     <Box as="div" sx={{overflow: 'auto'}}>
       <TokenTable>

--- a/docs/src/components/tables/BaseSizeTable.tsx
+++ b/docs/src/components/tables/BaseSizeTable.tsx
@@ -1,4 +1,5 @@
-import type React from 'react'
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+import React from 'react'
 import {Box} from '@primer/components'
 import FrameworkVariableTable from './FrameworkVariableTable'
 import TokenInlineCode from '../TokenInlineCode'

--- a/docs/src/components/tables/BorderTable.tsx
+++ b/docs/src/components/tables/BorderTable.tsx
@@ -1,5 +1,5 @@
-import type React from 'react'
-import {Fragment} from 'react'
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+import React, {Fragment} from 'react'
 import {Box} from '@primer/components'
 import TokenTable from '../TokenTable'
 import TokenInlineCode from '../TokenInlineCode'

--- a/docs/src/components/tables/BorderTable.tsx
+++ b/docs/src/components/tables/BorderTable.tsx
@@ -1,4 +1,5 @@
-import React, {Fragment, FC} from 'react'
+import type React from 'react'
+import {Fragment} from 'react'
 import {Box} from '@primer/components'
 import TokenTable from '../TokenTable'
 import TokenInlineCode from '../TokenInlineCode'
@@ -10,7 +11,7 @@ interface BorderTableProps {
   borderWidth?: boolean
 }
 
-const BorderTable: FC<BorderTableProps> = ({filePath, borderWidth}) => {
+const BorderTable: React.FC<BorderTableProps> = ({filePath, borderWidth}) => {
   return (
     <Box as="div" sx={{overflow: 'auto'}}>
       <TokenTable>

--- a/docs/src/components/tables/Swatch.tsx
+++ b/docs/src/components/tables/Swatch.tsx
@@ -1,4 +1,4 @@
-import React, {FC} from 'react'
+import type React from 'react'
 import {Box} from '@primer/components'
 
 interface SwatchProps {
@@ -8,7 +8,7 @@ interface SwatchProps {
   color?: string
 }
 
-const Swatch: FC<SwatchProps> = ({height, width, color}) => {
+const Swatch: React.FC<SwatchProps> = ({height, width, color}) => {
   return <Box borderRadius={2} height={height} width={width} backgroundColor={color}></Box>
 }
 

--- a/docs/src/components/tables/Swatch.tsx
+++ b/docs/src/components/tables/Swatch.tsx
@@ -1,4 +1,5 @@
-import type React from 'react'
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+import React from 'react'
 import {Box} from '@primer/components'
 
 interface SwatchProps {

--- a/docs/src/components/tables/UIControlStackTable.tsx
+++ b/docs/src/components/tables/UIControlStackTable.tsx
@@ -1,4 +1,5 @@
-import React, {Fragment, FC} from 'react'
+import type React from 'react'
+import {Fragment} from 'react'
 import {Box} from '@primer/components'
 import TokenTable from '../TokenTable'
 import TokenInlineCode from '../TokenInlineCode'
@@ -11,7 +12,7 @@ interface UIControlStackTableProps {
   tokenVariant?: string
 }
 
-const UIControlStackTable: FC<UIControlStackTableProps> = ({filePath, tokenVariant}) => {
+const UIControlStackTable: React.FC<UIControlStackTableProps> = ({filePath, tokenVariant}) => {
   return (
     <Box as="div" sx={{overflow: 'auto'}}>
       <TokenTable>

--- a/docs/src/components/tables/UIControlStackTable.tsx
+++ b/docs/src/components/tables/UIControlStackTable.tsx
@@ -1,5 +1,5 @@
-import type React from 'react'
-import {Fragment} from 'react'
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+import React, {Fragment} from 'react'
 import {Box} from '@primer/components'
 import TokenTable from '../TokenTable'
 import TokenInlineCode from '../TokenInlineCode'

--- a/docs/src/components/tables/UIControlTable.tsx
+++ b/docs/src/components/tables/UIControlTable.tsx
@@ -1,4 +1,5 @@
-import React, {Fragment, FC} from 'react'
+import type React from 'react'
+import {Fragment} from 'react'
 import {Box} from '@primer/components'
 import TokenTable from '../TokenTable'
 import TokenInlineCode from '../TokenInlineCode'
@@ -11,7 +12,7 @@ interface UIControlTableProps {
   tokenVariant?: string
 }
 
-const UIControlTable: FC<UIControlTableProps> = ({filePath, tokenVariant}) => {
+const UIControlTable: React.FC<UIControlTableProps> = ({filePath, tokenVariant}) => {
   return (
     <Box as="div" sx={{overflow: 'auto'}}>
       <TokenTable>

--- a/docs/src/components/tables/UIControlTable.tsx
+++ b/docs/src/components/tables/UIControlTable.tsx
@@ -1,5 +1,5 @@
-import type React from 'react'
-import {Fragment} from 'react'
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+import React, {Fragment} from 'react'
 import {Box} from '@primer/components'
 import TokenTable from '../TokenTable'
 import TokenInlineCode from '../TokenInlineCode'

--- a/docs/src/components/tables/UIStackTable.tsx
+++ b/docs/src/components/tables/UIStackTable.tsx
@@ -1,4 +1,5 @@
-import React, {Fragment, FC} from 'react'
+import type React from 'react'
+import {Fragment} from 'react'
 import {Box} from '@primer/components'
 import TokenTable from '../TokenTable'
 import TokenInlineCode from '../TokenInlineCode'
@@ -11,7 +12,7 @@ interface UIStackTableProps {
   tokenVariant?: string
 }
 
-const UIStackTable: FC<UIStackTableProps> = ({filePath, tokenVariant}) => {
+const UIStackTable: React.FC<UIStackTableProps> = ({filePath, tokenVariant}) => {
   return (
     <Box as="div" sx={{overflow: 'auto'}}>
       <TokenTable>

--- a/docs/src/components/tables/UIStackTable.tsx
+++ b/docs/src/components/tables/UIStackTable.tsx
@@ -1,5 +1,5 @@
-import type React from 'react'
-import {Fragment} from 'react'
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+import React, {Fragment} from 'react'
 import {Box} from '@primer/components'
 import TokenTable from '../TokenTable'
 import TokenInlineCode from '../TokenInlineCode'

--- a/docs/src/components/typography-block.tsx
+++ b/docs/src/components/typography-block.tsx
@@ -1,4 +1,5 @@
-import React, {Fragment, FC} from 'react'
+import type React from 'react'
+import {Fragment} from 'react'
 import {Box} from '@primer/components'
 
 interface TypographyBlockProps {
@@ -12,7 +13,7 @@ interface TypographyBlockProps {
   children?: string
 }
 
-const TypographyBlock: FC<TypographyBlockProps> = ({
+const TypographyBlock: React.FC<TypographyBlockProps> = ({
   variant,
   modifier = '',
   fontSize,

--- a/docs/src/components/typography-block.tsx
+++ b/docs/src/components/typography-block.tsx
@@ -1,5 +1,5 @@
-import type React from 'react'
-import {Fragment} from 'react'
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+import React, {Fragment} from 'react'
 import {Box} from '@primer/components'
 
 interface TypographyBlockProps {

--- a/docs/storybook/stories/Functional/Text.stories.tsx
+++ b/docs/storybook/stories/Functional/Text.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 // eslint-disable-next-line import/no-unresolved
-import {ComponentMeta, ComponentStory} from '@storybook/react'
+import type {ComponentMeta, ComponentStory} from '@storybook/react'
 import {ColorPreview} from '../ColorPreview'
 
 export default {

--- a/script/color-contrast.ts
+++ b/script/color-contrast.ts
@@ -1,4 +1,5 @@
-import {ContrastRequirement, contrastRequirements, canvasColors} from './color-contrast.config'
+import type {ContrastRequirement} from './color-contrast.config'
+import {contrastRequirements, canvasColors} from './color-contrast.config'
 import {Table} from 'console-table-printer'
 import {flattenObject} from './utilities/flattenObject'
 import colors from '../dist/ts'

--- a/script/tempColorTokenBuild.ts
+++ b/script/tempColorTokenBuild.ts
@@ -2,8 +2,8 @@ import type StyleDictionary from 'style-dictionary'
 import {PrimerStyleDictionary} from '../config/PrimerStyleDictionary'
 import {copyFilesAndFolders} from '../config/utilities/copyFilesAndFolders'
 import {typeDefinitions, deprecatedJson, css, docJson, scss, javascript, typescript, json} from '../config/platforms'
-import {ConfigGeneratorOptions, StyleDictionaryConfigGenerator} from '../types/StyleDictionaryConfigGenerator'
-import {TokenBuildInput} from '../types/TokenBuildInput'
+import type {ConfigGeneratorOptions, StyleDictionaryConfigGenerator} from '../types/StyleDictionaryConfigGenerator'
+import type {TokenBuildInput} from '../types/TokenBuildInput'
 
 export const buildDesignTokens = (buildOptions: ConfigGeneratorOptions): void => {
   const themes: TokenBuildInput[] = [

--- a/src/test-utilities/getMockDictionary.ts
+++ b/src/test-utilities/getMockDictionary.ts
@@ -1,4 +1,4 @@
-import StyleDictionary from 'style-dictionary'
+import type StyleDictionary from 'style-dictionary'
 import {getMockToken} from './getMockToken'
 
 const mockDictionaryDefault = {

--- a/src/test-utilities/getMockFormatterArguments.ts
+++ b/src/test-utilities/getMockFormatterArguments.ts
@@ -1,4 +1,4 @@
-import {FormatterArguments} from 'style-dictionary/types/Format'
+import type {FormatterArguments} from 'style-dictionary/types/Format'
 import {getMockDictionary} from './'
 
 const defaultFormatterArguments: FormatterArguments = {

--- a/src/test-utilities/getMockToken.ts
+++ b/src/test-utilities/getMockToken.ts
@@ -1,4 +1,4 @@
-import StyleDictionary from 'style-dictionary'
+import type StyleDictionary from 'style-dictionary'
 
 const mockTokenDefaults = {
   name: 'tokenName',


### PR DESCRIPTION
## Summary

This PR adds this eslint rule: [`consistent-type-imports`](https://typescript-eslint.io/rules/consistent-type-imports/) to our eslint file and fixes the linting bugs.

Reason: Importing WITH the type keyboard makes it very clear that an import is just a type and not a function.

## List of notable changes:
- **added** eslint rule: [`consistent-type-imports`](https://typescript-eslint.io/rules/consistent-type-imports/

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
- [ ] Verify the design tokens changed in this PR are expected using the diffing results in this PR
