### PR TITLE
add types for sizes

### DIFF
--- a/config/formats/typescriptExportDefinition.test.ts
+++ b/config/formats/typescriptExportDefinition.test.ts
@@ -31,6 +31,62 @@ describe('Format: TypeScript definitions', () => {
     }
   })
 
+  it('Formats dimension tokens', () => {
+    const input = getMockFormatterArguments({
+      dictionary: getMockDictionary({
+        tokens: {
+          subgroup: {
+            size: {
+              px: getMockToken({
+                $type: 'dimension',
+                value: '100px'
+              }),
+              rem: getMockToken({
+                $type: 'dimension',
+                value: '10rem'
+              }),
+              em: getMockToken({
+                $type: 'dimension',
+                value: '10em'
+              })
+            }
+          }
+        }
+      })
+    })
+    const expectedOutput = format(
+      `/**
+        * @description size in px
+        */
+        type SizePx = \`\${number}px\`
+
+      /**
+        * @description size in rem
+        */
+        type SizeRem = \`\${number}rem\`
+
+      /**
+        * @description size in em
+        */
+        type SizeEm = \`\${number}em\`
+
+      export type tokens = {
+        tokens: {
+          subgroup: {
+            size: {
+              px: SizePx;
+              rem: SizeRem;
+              em: SizeEm;
+            };
+          };
+        };
+      };`,
+      {parser: 'typescript', printWidth: 500}
+    )
+
+    expect(typescriptExportDefinition(input)).toStrictEqual(expectedOutput)
+  })
+
   it('Formats tokens adding prefix', () => {
     const input = getMockFormatterArguments({
       dictionary,

--- a/config/formats/typescriptExportDefinition.ts
+++ b/config/formats/typescriptExportDefinition.ts
@@ -64,6 +64,7 @@ const convertPropToType = (tree: w3cTransformedToken): string => {
       return invalidTokenValueError(tree)
     case 'dimension':
       if (typeof tree.value === 'string' && tree.value.substring(tree.value.length - 3) === 'rem') return 'SizeRem'
+      if (typeof tree.value === 'string' && tree.value.substring(tree.value.length - 2) === 'em') return 'SizeEm'
       if (typeof tree.value === 'string' && tree.value.substring(tree.value.length - 2) === 'px') return 'SizePx'
       return invalidTokenValueError(tree)
     case 'shadow':
@@ -130,7 +131,7 @@ const getTypeDefinition = (
   moduleName: string,
   tokenTypesPath: string
 ): string => {
-  const usedTypes = getUsedTokenTypes(tokens, ['ColorHex', 'Shadow', 'Border', 'Size', 'SizeRem'])
+  const usedTypes = getUsedTokenTypes(tokens, ['ColorHex', 'Shadow', 'Border', 'SizeEm', 'SizeRem', 'SizePx'])
   const tokenObjectWithTypes = getTokenObjectWithTypes(tokens)
   // get token type declaration from file
   const designTokenTypes: string[] = []

--- a/config/types/SizeEm.d.ts
+++ b/config/types/SizeEm.d.ts
@@ -1,0 +1,4 @@
+/**
+ * @description size in em
+ */
+type SizeEm = `${number}em`

--- a/config/types/SizePx.d.ts
+++ b/config/types/SizePx.d.ts
@@ -1,0 +1,4 @@
+/**
+ * @description size in px
+ */
+type SizePx = `${number}px`

--- a/config/types/SizeRem.d.ts
+++ b/config/types/SizeRem.d.ts
@@ -1,0 +1,4 @@
+/**
+ * @description size in rem
+ */
+type SizeRem = `${number}rem`


### PR DESCRIPTION
## Summary

This PR adds type definitions for `SizePx`, `SizeEm` and `SizeRem`

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
- [ ] Verify the design tokens changed in this PR are expected using the diffing results in this PR
