### PR TITLE
Fix ts-ignore in flattenObject

### DIFF
--- a/script/utilities/flattenObject.test.ts
+++ b/script/utilities/flattenObject.test.ts
@@ -1,0 +1,79 @@
+import {flattenObject} from './flattenObject'
+
+describe('Utilities: flattenObject', () => {
+  it('flattens an object with dot separator by default', () => {
+    const mockObject = {
+      a: 'foo',
+      b: {
+        c: 'bar'
+      }
+    }
+
+    const expectedOutput = {
+      a: 'foo',
+      ['b.c']: 'bar'
+    }
+
+    expect(flattenObject(mockObject)).toStrictEqual(expectedOutput)
+  })
+
+  it('flattens an object with an optional custom separator', () => {
+    const mockObject = {
+      a: 'foo',
+      b: {
+        c: 'bar'
+      }
+    }
+
+    const expectedOutput = {
+      a: 'foo',
+      ['b-c']: 'bar'
+    }
+
+    expect(flattenObject(mockObject, undefined, '-')).toStrictEqual(expectedOutput)
+  })
+
+  it('flattens a nested object and applies a prefix to each key', () => {
+    const mockObject = {
+      a: 'foo',
+      b: {
+        c: 'bar'
+      }
+    }
+
+    const expectedOutput = {
+      ['test.a']: 'foo',
+      ['test.b.c']: 'bar'
+    }
+
+    expect(flattenObject(mockObject, 'test')).toStrictEqual(expectedOutput)
+  })
+
+  it('flattens to n depth', () => {
+    const n = 50 // arbitrary number
+    const arr = Array.from(Array(n), (x, i) => i.toString())
+    const mockObject = {}
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const buildObject = (obj: {[x: string]: any}, keyPath: string | any[]) => {
+      const lastKeyIndex = keyPath.length - 1
+      for (let i = 0; i < lastKeyIndex; ++i) {
+        const key = keyPath[i]
+        if (!(key in obj)) {
+          obj[key] = {}
+        }
+        obj = obj[key]
+      }
+      obj[keyPath[lastKeyIndex]] = 'foo'
+    }
+
+    buildObject(mockObject, arr)
+
+    const expectedOutput = {
+      '0.1.2.3.4.5.6.7.8.9.10.11.12.13.14.15.16.17.18.19.20.21.22.23.24.25.26.27.28.29.30.31.32.33.34.35.36.37.38.39.40.41.42.43.44.45.46.47.48.49':
+        'foo'
+    }
+
+    expect(flattenObject(mockObject)).toStrictEqual(expectedOutput)
+  })
+})

--- a/script/utilities/flattenObject.ts
+++ b/script/utilities/flattenObject.ts
@@ -1,21 +1,23 @@
+type NestedObject = {
+  [key: string]: string | NestedObject
+}
+
 /**
  * flattenObject
- * @description turns a nested object into a one-dimensional object and joins names with dots
- * @param obj
- * @param prefix
- * @returns flattend objects
+ * @description turns a nested object into a one-dimensional object and joins names
+ * @param obj - the object to flatten
+ * @param prefix - applied to the key name
+ * @param separator - defaults to '.'
+ * @returns flattened objects
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const flattenObject = (obj: any, prefix = '') =>
-  Object.keys(obj).reduce((acc, k) => {
-    const pre = prefix.length ? `${prefix}.` : ''
+export const flattenObject = (obj: NestedObject, prefix = '', separator = '.') =>
+  Object.keys(obj).reduce<Record<string, string>>((acc, k) => {
+    const pre = prefix.length ? `${prefix}${separator}` : ''
     if (typeof obj[k] === 'object') {
-      // purposly mutating acc
-      Object.assign(acc, flattenObject(obj[k], pre + k))
-    } else {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore: implicit any
-      acc[pre + k] = obj[k]
+      // purposely mutating acc
+      Object.assign(acc, flattenObject(obj[k] as NestedObject, pre + k, separator))
+    } else if (typeof obj[k] === 'string') {
+      acc[pre + k] = obj[k] as string
     }
     return acc
   }, {})


### PR DESCRIPTION
## Summary

Fixes the ts-ignore in `flattenObject` and backfills test coverage. 

Added the ability to provide an optional separator, as this seemed like it would be useful.

Part of a wider effort to remove ts-ignores across the codebase

<img width="573" alt="Screenshot 2022-11-30 at 11 07 20" src="https://user-images.githubusercontent.com/13340707/204781313-e8ae7eac-d04f-4c8e-ab87-480fd53c9e40.png">


## What should reviewers focus on?

-

## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

1. Open the preview documentation that has been deployed in this pull request
2. Go to # page
3. Verify that # behaves as described in the pull request description

1. npm run test
1. npm run build:tokens


## Supporting resources (related issues, external links, etc):

- n/a

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
- [ ] Verify the design tokens changed in this PR are expected using the diffing results in this PR
