### PR TITLE
add verbose option to json-nested

### DIFF
--- a/config/formats/jsonNestedPrefixed.test.ts
+++ b/config/formats/jsonNestedPrefixed.test.ts
@@ -40,4 +40,34 @@ describe('Format: Json nested with prefixes', () => {
     )
     expect(jsonNestedPrefixed(input)).toStrictEqual(expectedOutput)
   })
+
+  test('Formats tokens without verbose setting', () => {
+    const input = getMockFormatterArguments({
+      options: {
+        outputVerbose: true
+      }
+    })
+    const expectedOutput = format(
+      `{
+        "tokens": {
+          "subgroup": {
+            "red": {
+               "name": "red",
+               "path": ["tokens", "subgroup", "red"],
+               "original": {
+                 "value": "originalValue",
+                 "attributes": {}
+               },
+               "filePath": "file.json",
+               "isSource": true,
+               "value": "transformedValue",
+               "attributes": {}
+            }
+          }
+        }
+      }`,
+      {parser: 'json', printWidth: 500}
+    )
+    expect(jsonNestedPrefixed(input)).toStrictEqual(expectedOutput)
+  })
 })

--- a/config/formats/jsonNestedPrefixed.ts
+++ b/config/formats/jsonNestedPrefixed.ts
@@ -8,16 +8,15 @@ import {jsonToNestedValue, prefixTokens} from '~/config/utilities'
  * @param StyleDictionary.FormatterArguments
  * @returns formatted json `string`
  */
-export const jsonNestedPrefixed: StyleDictionary.Formatter = ({
-  dictionary,
-  file: _file,
-  options: _options,
-  platform
-}) => {
+export const jsonNestedPrefixed: StyleDictionary.Formatter = ({dictionary, file: _file, options, platform}) => {
+  const {outputVerbose} = options
   // add prefix if defined
-  const tokens = prefixTokens(dictionary.tokens, platform)
+  let tokens = prefixTokens(dictionary.tokens, platform)
+  if (!outputVerbose) {
+    tokens = jsonToNestedValue(tokens)
+  }
   // add file header and convert output
-  const output = JSON.stringify(jsonToNestedValue(tokens), null, 2)
+  const output = JSON.stringify(tokens, null, 2)
   // return prettified
   return format(output, {parser: 'json', printWidth: 500})
 }

--- a/config/platforms/docJson.ts
+++ b/config/platforms/docJson.ts
@@ -15,7 +15,8 @@ export const docJson: PlatformInitializer = (outputFile, prefix, buildPath): Sty
       format: `json/nested-prefixed`,
       filter: isSource,
       options: {
-        outputReferences: false
+        outputReferences: false,
+        outputVerbose: true
       }
     }
   ]

--- a/src/test-utilities/getMockDictionary.ts
+++ b/src/test-utilities/getMockDictionary.ts
@@ -6,7 +6,7 @@ const mockDictionaryDefault = {
     subgroup: {
       red: getMockToken({
         name: 'red',
-        path: ['tokens', 'colors', 'red']
+        path: ['tokens', 'subgroup', 'red']
       })
     }
   }


### PR DESCRIPTION
## Summary

This allows us to set `outputVerbose: true` in the platform options. If true the `json-nested` format will output the entire token object (used for docs). If false it will just output the value.

## List of notable changes:

- **added** `outputVerbose` option and verbose output to `json-nested`
- **added** `outputVerbose: true` to `config/platforms/docJson.ts` 


## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
- [ ] Verify the design tokens changed in this PR are expected using the diffing results in this PR
