### PR TITLE
adding contrast requirement for default text vs link and vs seconday

### DIFF
--- a/script/color-contrast.config.ts
+++ b/script/color-contrast.config.ts
@@ -18,6 +18,9 @@ const baseRequirements: ContrastRequirement[] = [
   [4.5, 'fg.muted', 'canvas.subtle'],
   [4.5, 'fg.default', 'canvas.inset'],
   [4.5, 'fg.muted', 'canvas.inset'],
+  // default text vs link
+  [3, 'fg.default', 'accent.fg'],
+  [3, 'fg.default', 'fg.muted'],
   // default text on role bg
   // TODO: contrast does not work with semi-transparent colors
   [4.5, 'fg.default', 'accent.subtle'],
@@ -126,6 +129,9 @@ const highContrast: ContrastRequirement[] = [
     [7, 'fg.muted', 'canvas.subtle'],
     [7, 'fg.default', 'canvas.inset'],
     [7, 'fg.muted', 'canvas.inset'],
+    // default text vs link
+    [4.5, 'fg.default', 'accent.fg'],
+    [4.5, 'fg.default', 'fg.muted'],
     // default text on role bg
     // TODO: contrast does not work with semi-transparent colors
     [7, 'fg.default', 'accent.subtle'],

--- a/script/color-contrast.ts
+++ b/script/color-contrast.ts
@@ -153,6 +153,8 @@ const renderConsoleTable = (theme: string, results: contrastTestResult[]): void 
   }
   // print table to console
   // eslint-disable-next-line no-console
+  console.log('\n')
+  // eslint-disable-next-line no-console
   console.log(contrastTable.render())
 }
 


### PR DESCRIPTION
## Summary

Just adding contrast check for `fg.default` vs. link and secondary text

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
- [ ] Verify the design tokens changed in this PR are expected using the diffing results in this PR
