### PR TITLE
add isDimension filter in prep for iOS

### DIFF
--- a/config/filters/index.ts
+++ b/config/filters/index.ts
@@ -1,6 +1,7 @@
 export {isBorder} from './isBorder'
 export {isColor} from './isColor'
 export {isColorWithAlpha} from './isColorWithAlpha'
+export {isDimension} from './isDimension'
 export {isDeprecated} from './isDeprecated'
 export {isFontFamily} from './isFontFamily'
 export {isFontWeight} from './isFontWeight'

--- a/config/filters/isDimension.test.ts
+++ b/config/filters/isDimension.test.ts
@@ -1,0 +1,22 @@
+import {getMockToken} from '~/src/test-utilities'
+import {isDimension} from './isDimension'
+
+describe('Filter: isDimension', () => {
+  it('returns true if $type property is `dimension`', () => {
+    expect(isDimension(getMockToken({$type: 'dimension'}))).toStrictEqual(true)
+  })
+
+  it('returns false if $type property is not `dimension`', () => {
+    expect(isDimension(getMockToken({$type: 'pumpkin'}))).toStrictEqual(false)
+  })
+
+  it('returns false if $type property is missing', () => {
+    expect(isDimension(getMockToken({alpha: 0.4}))).toStrictEqual(false)
+  })
+
+  it('returns false if $type property is falsy', () => {
+    expect(isDimension(getMockToken({$type: false}))).toStrictEqual(false)
+    expect(isDimension(getMockToken({$type: undefined}))).toStrictEqual(false)
+    expect(isDimension(getMockToken({$type: null}))).toStrictEqual(false)
+  })
+})

--- a/config/filters/isDimension.ts
+++ b/config/filters/isDimension.ts
@@ -1,0 +1,10 @@
+import type StyleDictionary from 'style-dictionary'
+
+/**
+ * @description Checks if token is of $type `dimension`
+ * @param arguments [StyleDictionary.TransformedToken](https://github.com/amzn/style-dictionary/blob/main/types/TransformedToken.d.ts)
+ * @returns boolean
+ */
+export const isDimension = (token: StyleDictionary.TransformedToken): boolean => {
+  return token.$type === 'dimension'
+}


### PR DESCRIPTION
## Summary

add isDimension filter in prep for iOS

This filter only allows tokens that are of `$type` `dimension`