### PR TITLE
Upgrade Doctocat to remove news link

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@github/prettier-config": "^0.0.6",
-        "@primer/gatsby-theme-doctocat": "^4.2.3",
+        "@primer/gatsby-theme-doctocat": "^4.4.0",
         "color2k": "^1.2.4",
         "filter-obj": "^2.0.2",
         "flat": "^5.0.2",
@@ -2758,9 +2758,9 @@
       "license": "MIT"
     },
     "node_modules/@primer/gatsby-theme-doctocat": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-4.3.0.tgz",
-      "integrity": "sha512-ODyKQQf0Jc4sQdc9+er/dGXaqTdjY4DEvCbKxkXJzziQMW46OVDg16aJdSFZsL9nR5sQI1lLE0CBwg1LxfWqJA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-4.4.0.tgz",
+      "integrity": "sha512-Tc+XSXGFLA+S0IsXaZYEsXorZN9jygV7gwEIC2pwma7151ylSQTV+XDm0c2hvsSnTW1sBU/uk0pqsFm6gep4DA==",
       "dependencies": {
         "@babel/preset-env": "^7.5.5",
         "@babel/preset-react": "^7.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -20,17 +20,17 @@
   "prettier": "@github/prettier-config",
   "dependencies": {
     "@github/prettier-config": "^0.0.6",
-    "@primer/gatsby-theme-doctocat": "^4.2.3",
+    "@primer/gatsby-theme-doctocat": "^4.4.0",
     "color2k": "^1.2.4",
     "filter-obj": "^2.0.2",
     "flat": "^5.0.2",
     "gatsby": "^3.7.2",
     "lodash.get": "^4.4.2",
+    "path-browserify": "^1.0.1",
     "prettier": "2.1.2",
     "react": "^16.12.0",
     "react-copy-to-clipboard": "^5.0.4",
     "react-dom": "^16.12.0",
-    "path-browserify": "^1.0.1",
     "sentence-case": "^3.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Upgrades Doctocat to latest release, which removes the 'what's new' link from the header.


## What should reviewers focus on?

- Check deploys are okay
