### PR TITLE
added warning when setting alpha on a color that already has an alpha value

### DIFF
--- a/src/transformers/colorToHexAlpha.ts
+++ b/src/transformers/colorToHexAlpha.ts
@@ -13,5 +13,5 @@ export const colorToHexAlpha: StyleDictionary.Transform = {
   type: `value`,
   transitive: true,
   matcher: isColorWithAlpha,
-  transformer: (token: StyleDictionary.TransformedToken) => toHex(alpha(getTokenValue(token), token.alpha)),
+  transformer: (token: StyleDictionary.TransformedToken) => toHex(alpha(getTokenValue(token), token.alpha, token)),
 }

--- a/src/transformers/colorToRgbAlpha.ts
+++ b/src/transformers/colorToRgbAlpha.ts
@@ -12,5 +12,5 @@ export const colorToRgbAlpha: StyleDictionary.Transform = {
   type: `value`,
   transitive: true,
   matcher: isColorWithAlpha,
-  transformer: (token: StyleDictionary.TransformedToken) => alpha(getTokenValue(token), token.alpha),
+  transformer: (token: StyleDictionary.TransformedToken) => alpha(getTokenValue(token), token.alpha, token),
 }

--- a/src/transformers/shadowToCss.ts
+++ b/src/transformers/shadowToCss.ts
@@ -30,7 +30,7 @@ export const shadowToCss: StyleDictionary.Transform = {
         /*css box shadow:  inset? | offset-x | offset-y | blur-radius | spread-radius | color */
         return `${shadow.inset === true ? 'inset ' : ''}${shadow.offsetX} ${shadow.offsetY} ${shadow.blur} ${
           shadow.spread
-        } ${toHex(alpha(getTokenValue({...token, ...{value: shadow}}, 'color'), shadow.alpha || 1))}`
+        } ${toHex(alpha(getTokenValue({...token, ...{value: shadow}}, 'color'), shadow.alpha || 1, token))}`
       })
       .join(', ')
   },

--- a/src/transformers/utilities/alpha.ts
+++ b/src/transformers/utilities/alpha.ts
@@ -1,4 +1,5 @@
 import {rgba, parseToRgba} from 'color2k'
+import type {TransformedToken} from 'style-dictionary'
 /**
  * alpha
  * @description takes a colors string like hex or rgba and returns an rgba color with the specified alpha value
@@ -6,7 +7,17 @@ import {rgba, parseToRgba} from 'color2k'
  * @param desiredAlpha number
  * @returns rgba value
  */
-export const alpha = (color: string, desiredAlpha: number): string => {
-  const [r, g, b] = parseToRgba(color)
+export const alpha = (color: string, desiredAlpha: number, token?: TransformedToken): string => {
+  const [r, g, b, a] = parseToRgba(color)
+
+  if (a < 1 && desiredAlpha < 1) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `🚨 You are setting an alpha value of "${desiredAlpha}" for a color with an alpha value (${color}). The previous alpha value will be disregarded as if the color would have been 100% opaque.${
+        token !== undefined ? `\n ↳ Token: "${token.name}" in file: "${token.filePath}"` : ''
+      }`,
+    )
+  }
+
   return rgba(r, g, b, desiredAlpha)
 }


### PR DESCRIPTION
## Summary

Prints a warning to the console whenever a color that already has an alpha value (smaller than 1) gets assigned a new alpha value (smaller than 1).

The script still runs through and colors are all transformed as desired.
For colors with alpha the original alpha is disregarded and the new alpha is added to the color instead, like before.