### PR TITLE
add control border emphasis

### DIFF
--- a/.changeset/clean-weeks-taste.md
+++ b/.changeset/clean-weeks-taste.md
@@ -1,0 +1,5 @@
+---
+'@primer/primitives': minor
+---
+
+Adds control.borderColor.emphasis color token

--- a/data/colors/themes/dark_high_contrast.ts
+++ b/data/colors/themes/dark_high_contrast.ts
@@ -229,6 +229,11 @@ const exceptions = {
       hoverBg: get('scale.gray.6'),
     }
   },
+  control: {
+    borderColor: {
+      emphasis: get('scale.gray.4')
+    }
+  },
 }
 
 export default merge(dark, exceptions, {scale})

--- a/data/colors/themes/light_high_contrast.ts
+++ b/data/colors/themes/light_high_contrast.ts
@@ -236,6 +236,11 @@ const exceptions = {
       hoverBg: get('scale.gray.2'),
     }
   },
+  control: {
+    borderColor: {
+      emphasis: get('border.default')
+    }
+  }
 }
 
 export default merge(light, exceptions, {scale})

--- a/data/colors/vars/component_dark.ts
+++ b/data/colors/vars/component_dark.ts
@@ -1,6 +1,11 @@
 import {alpha, darken, get} from '../../../src/utils-v1'
 
 export default {
+  control: {
+    borderColor: {
+      emphasis: '#606771'
+    }
+  },
   avatar: {
     bg: alpha(get('scale.white'), 0.1),
     border: get('border.subtle'),

--- a/data/colors/vars/component_light.ts
+++ b/data/colors/vars/component_light.ts
@@ -1,6 +1,11 @@
 import {alpha, darken, get} from '../../../src/utils-v1'
 
 export default {
+  control: {
+    borderColor: {
+      emphasis: '#858F99'
+    }
+  },
   avatar: {
     bg: get('scale.white'),
     border: get('border.subtle'),

--- a/scripts/color-contrast.config.ts
+++ b/scripts/color-contrast.config.ts
@@ -95,6 +95,8 @@ const baseRequirements: ContrastRequirement[] = [
   // borders
   [3, 'border.default', 'canvas.default'],
   [3, 'border.default', 'canvas.subtle'],
+  [3, 'control.borderColor.emphasis', 'canvas.default'],
+  [3, 'control.borderColor.emphasis', 'canvas.subtle'],
   // TODO: there are no specific border colors for roles
 ]
 
@@ -174,6 +176,8 @@ const highContrast: ContrastRequirement[] = [
   // borders
   [4.5, 'border.default', 'canvas.default'],
   [4.5, 'border.default', 'canvas.subtle'],
+  [4.5, 'control.borderColor.emphasis', 'canvas.default'],
+  [4.5, 'control.borderColor.emphasis', 'canvas.subtle'],
 ] as ContrastRequirement[]
 
 export const canvasColors: string[] = ['canvas.default', 'canvas.subtle']


### PR DESCRIPTION
## Summary

Adding a new border that has a `3:1` contrast ratio against the background.

@langermank the token name does not work 100%. It will now be: `--color-control-border-color-emphasis` because this is how the old script converts the name.

I set it up as this in json:

```json
{
  "control": {
    "borderColor": {
      "emphasis": "#858F99"
    }
  }
}
```

## List of notable changes:

- **added** `control.borderColor.emphasis`
