### PR TITLE
remove ui prefix for primer primitives

### DIFF
--- a/scripts/buildV3.ts
+++ b/scripts/buildV3.ts
@@ -284,5 +284,4 @@ export const buildDesignTokens = (buildOptions: ConfigGeneratorOptions): void =>
  * ----------------------------------- */
 buildDesignTokens({
   buildPath: 'tokens-v3-private/',
-  prefix: 'ui',
 })


### PR DESCRIPTION
## Summary

Removes the `ui` prefix form primer primitives as discussed here: https://github.com/github/primer/pull/1545/files#diff-d2bc30263ef9862ad5c97eca1e28e15024e9de8c1fa6a7f3f0897c58874a0f90R73

For tokens that need a prefix e.g. `brand`, the prefix can be added to the `buildDesignTokens` function when it is used:

```js
buildDesignTokens({
  buildPath: 'design-tokens/',
  prefix: 'brand',
})
```