### PR TITLE
add utility to transform string or array of strings to PascalCase

### DIFF
--- a/src/utilities/toPascalCase.ts
+++ b/src/utilities/toPascalCase.ts
@@ -1,0 +1,19 @@
+import {upperCaseFirstCharacter} from './upperCaseFirstCharacter'
+
+export const toPascalCase = (string: string | string[]) => {
+  if (!Array.isArray(string)) {
+    string = [string]
+  }
+  // match unsupported characters
+  const regex = /[^a-zA-Z0-9]+/g
+  // replace any non-letter and non-number character and split into word array
+  const stringArray = string.join(' ').replace(regex, ' ').split(' ')
+  return (
+    stringArray
+      // remove undefined if exists
+      .filter((part: unknown): part is string => typeof part === 'string')
+      // ucFirst all but first part
+      .map(upperCaseFirstCharacter)
+      .join('')
+  )
+}

--- a/src/utilities/toPascalcase.test.ts
+++ b/src/utilities/toPascalcase.test.ts
@@ -1,0 +1,27 @@
+import {toPascalCase} from './toPascalCase'
+
+describe('Utilities: toPascalCase', () => {
+  it('it transforms all lowercase word', () => {
+    expect(toPascalCase('primer')).toStrictEqual('Primer')
+  })
+
+  it('it transforms all lowercase sentence (words with spaces)', () => {
+    expect(toPascalCase('primer design token')).toStrictEqual('PrimerDesignToken')
+  })
+
+  it('it transforms all words with special chars', () => {
+    expect(toPascalCase('primer_design-token+edition')).toStrictEqual('PrimerDesignTokenEdition')
+  })
+
+  it('it preserves casing for words that are already all uppercased', () => {
+    expect(toPascalCase('PRIMER')).toStrictEqual('PRIMER')
+  })
+
+  it('it transforms all camelCase word', () => {
+    expect(toPascalCase('camelCase')).toStrictEqual('CamelCase')
+  })
+
+  it('it transforms array of words', () => {
+    expect(toPascalCase(['primer', 'design', 'token'])).toStrictEqual('PrimerDesignToken')
+  })
+})


### PR DESCRIPTION
## Summary

Adds `toPascalCase` utility that transforms a string or array of strings into `PascalCase`.