### PR TITLE
add mix transformer

### DIFF
--- a/src/PrimerStyleDictionary.ts
+++ b/src/PrimerStyleDictionary.ts
@@ -13,6 +13,7 @@ import {
   namePathToKebabCase,
   shadowToCss,
   typographyToCss,
+  colorToHexMix,
 } from './transformers'
 import {
   scssMixinCssVariables,
@@ -75,6 +76,11 @@ StyleDictionary.registerTransform({
 StyleDictionary.registerTransform({
   name: 'color/hexAlpha',
   ...colorToHexAlpha,
+})
+
+StyleDictionary.registerTransform({
+  name: 'color/hexMix',
+  ...colorToHexMix,
 })
 
 StyleDictionary.registerTransform({

--- a/src/filters/index.ts
+++ b/src/filters/index.ts
@@ -1,6 +1,7 @@
 export {isBorder} from './isBorder'
 export {isColor} from './isColor'
 export {isColorWithAlpha} from './isColorWithAlpha'
+export {isColorWithMix} from './isColorWithMix'
 export {isDimension} from './isDimension'
 export {isDeprecated} from './isDeprecated'
 export {isFontFamily} from './isFontFamily'

--- a/src/filters/isColorWithMix.ts
+++ b/src/filters/isColorWithMix.ts
@@ -1,0 +1,33 @@
+import type StyleDictionary from 'style-dictionary'
+import {isColor} from './isColor'
+
+const throwError = (token: StyleDictionary.TransformedToken) => {
+  throw new Error(
+    `Invalid mix property on token: ${token.name}. "mix.color": ${token.mix.color}, "mix.weight": ${
+      typeof token.mix.weight === 'string' ? `"${token.mix.weight}" (string)` : token.mix.weight
+    } must be a number between 0 and 1.`,
+  )
+}
+
+/**
+ * @description Checks if token is color and has a mix property
+ * @param arguments [StyleDictionary.TransformedToken](https://github.com/amzn/style-dictionary/blob/main/types/TransformedToken.d.ts)
+ * @returns boolean
+ */
+export const isColorWithMix = (token: StyleDictionary.TransformedToken): boolean => {
+  // no color or no mix property
+  if (!isColor(token) || token.mix === undefined) {
+    return false
+  }
+  // invalid mix property
+  if (
+    typeof token.mix.color !== 'string' ||
+    typeof token.mix.weight !== 'number' ||
+    token.mix.weight < 0 ||
+    token.mix.weight > 1
+  ) {
+    throwError(token)
+  }
+  // valid mix property
+  return true
+}

--- a/src/platforms/css.ts
+++ b/src/platforms/css.ts
@@ -25,6 +25,7 @@ export const css: PlatformInitializer = (outputFile, prefix, buildPath, options)
       'name/pathToKebabCase',
       'color/hex',
       'color/hexAlpha',
+      'color/hexMix',
       'shadow/css',
       'border/css',
       'typography/css',

--- a/src/transformers/colorToHexMix.ts
+++ b/src/transformers/colorToHexMix.ts
@@ -1,0 +1,17 @@
+import {toHex, mix} from 'color2k'
+import {isColorWithMix} from '~/src/filters'
+import type StyleDictionary from 'style-dictionary'
+import {getTokenValue} from './utilities/getTokenValue'
+/**
+ * @description replaces tokens value with `hex8` color using the tokens `alpha` property to specify the value used for alpha
+ * @type value transformer — [StyleDictionary.ValueTransform](https://github.com/amzn/style-dictionary/blob/main/types/Transform.d.ts)
+ * @matcher matches all tokens of $type `color` with an `alpha` property
+ * @transformer returns `hex8` string
+ */
+export const colorToHexMix: StyleDictionary.Transform = {
+  type: `value`,
+  transitive: true,
+  matcher: isColorWithMix,
+  transformer: (token: StyleDictionary.TransformedToken) =>
+    toHex(mix(getTokenValue(token), token.mix.color, token.mix.weight)),
+}

--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -1,6 +1,7 @@
 export {borderToCss} from './borderToCss'
 export {colorToHex} from './colorToHex'
 export {colorToHexAlpha} from './colorToHexAlpha'
+export {colorToHexMix} from './colorToHexMix'
 export {colorToRgbAlpha} from './colorToRgbAlpha'
 export {fontFamilyToCss} from './fontFamilyToCss'
 export {fontWeightToNumber} from './fontWeightToNumber'


### PR DESCRIPTION
## Summary

This PR adds a transformer that allows us to mix two colors together with a specified weight.
The weight dictates how much of the second color is mixed into the first color.

This should be used for interactive states like hover and pressed. For other colors use steps from the scales.