### PR TITLE
Fix box shadow on AvatarPair

### DIFF
--- a/.changeset/nice-queens-tease.md
+++ b/.changeset/nice-queens-tease.md
@@ -1,0 +1,5 @@
+---
+'@primer/primitives': patch
+---
+
+Fix bug on AvatarPair box shadow

--- a/data/colors/vars/component_dark.ts
+++ b/data/colors/vars/component_dark.ts
@@ -11,7 +11,7 @@ export default {
     border: get('border.subtle'),
     stackFade: get('scale.gray.6'),
     stackFadeMore: get('scale.gray.7'),
-    childShadow: (theme: any) => `-2px -2px 0 ${get('scale.gray.9')(theme)}`
+    childShadow: (theme: any) => `0 0 0 2px ${get('scale.gray.9')(theme)}`
   },
   topicTag: {
     border: 'transparent'

--- a/data/colors/vars/component_light.ts
+++ b/data/colors/vars/component_light.ts
@@ -11,7 +11,7 @@ export default {
     border: get('border.subtle'),
     stackFade: get('scale.gray.3'),
     stackFadeMore: get('scale.gray.2'),
-    childShadow: (theme: any) => `-2px -2px 0 ${alpha(get('scale.white'), 0.8)(theme)}`
+    childShadow: (theme: any) => `0 0 0 2px ${alpha(get('scale.white'), 0.8)(theme)}`
   },
   topicTag: {
     border: 'transparent'


### PR DESCRIPTION
## Summary

Fixing a box-shadow bug in the `AvatarPair` children. The shadow was relatively positioned using offset-x and offset-y values (-2px). This PR uses a `spread-radius` of `2px` instead, the same styles we use on the Avatar box-shadow [here](https://github.com/primer/react/blob/46865b8ae143859c8689629affb3785d46da0678/src/Avatar/Avatar.tsx#L34). This works both for non-square and square variants.

> Before
> <img width="235" alt="Screenshot 2023-02-17 at 10 48 22" src="https://user-images.githubusercontent.com/912236/219615511-f4bec7e1-dc36-4a9c-b742-27307fd45318.png">
> 


> After
> <img width="241" alt="Screenshot 2023-02-17 at 11 13 40" src="https://user-images.githubusercontent.com/912236/219616212-02af085e-3783-493f-b443-66c83467f228.png">
> 

## List of notable changes:

- **updated** AvatarPair box shadow properties

## Steps to test:

1. Open https://primer.style/react/AvatarPair#examples
2. Check the avatar pair children has an off box-shadow 
3. Change values in dev tools
4. Verify that # behaves as described in the pull request description

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [x] Check that there aren't other open Pull Requests for the same update/change
- [ ] Verify the design tokens changed in this PR are expected using the diffing results in this PR
