### PR TITLE
disable import/no-unresolved for dist files to avoid issues when committing

### DIFF
--- a/docs/src/components/color-scales.tsx
+++ b/docs/src/components/color-scales.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-unresolved
 import colors from '../../../dist/js/colors'
 import React from 'react'
 import {useColorTheme} from './color-theme-context'

--- a/docs/src/components/color-theme-picker.tsx
+++ b/docs/src/components/color-theme-picker.tsx
@@ -1,6 +1,7 @@
 import {Box} from '@primer/react'
 import React from 'react'
 import {sentenceCase} from 'sentence-case'
+// eslint-disable-next-line import/no-unresolved
 import colors from '../../../dist/js/colors'
 import {useColorTheme} from './color-theme-context'
 

--- a/docs/src/components/swatch-grid.tsx
+++ b/docs/src/components/swatch-grid.tsx
@@ -1,6 +1,7 @@
 import {Box} from '@primer/react'
 import get from 'lodash.get'
 import React from 'react'
+// eslint-disable-next-line import/no-unresolved
 import colors from '../../../dist/js/colors'
 import {getFullName} from '../../../scripts/lib/variable-collection'
 import {useColorTheme} from './color-theme-context'

--- a/scripts/color-contrast.ts
+++ b/scripts/color-contrast.ts
@@ -2,6 +2,7 @@ import type {ContrastRequirement} from './color-contrast.config'
 import {contrastRequirements, canvasColors} from './color-contrast.config'
 import {Table} from 'console-table-printer'
 import {flattenObject} from './utilities/flattenObject'
+// eslint-disable-next-line import/no-unresolved
 import colors from '../dist/ts'
 import {writeFile} from 'fs'
 import {normal} from 'color-blend'


### PR DESCRIPTION
## Summary
Currently if you don't run `npm run build` before commiting eslint throws an import error for the color check and the docs.

This happens even if you didn't work on this part at all. When the docs are being built `npm run build` is run by default, so the error does not help.

I disabled eslint for those 4 imports using:

```js
// eslint-disable-next-line import/no-unresolved
```