### PR TITLE
A11y update to fix contrast issue with primary green

### DIFF
--- a/data/colors/vars/app_light.ts
+++ b/data/colors/vars/app_light.ts
@@ -113,7 +113,7 @@ export default {
     inputShadow: 'none',
     donutError: get('scale.red.4'),
     donutPending: get('scale.yellow.4'),
-    donutSuccess: get('scale.green.4'),
+    donutSuccess: get('success.emphasis'),
     donutNeutral: get('scale.gray.3'),
     dropdownText: get('scale.gray.3'),
     dropdownBg: get('scale.gray.8'),

--- a/data/colors/vars/component_light.ts
+++ b/data/colors/vars/component_light.ts
@@ -48,7 +48,7 @@ export default {
     disabledBg: get('neutral.muted')
   },
   diffstat: {
-    additionBg: get('scale.green.4')
+    additionBg: get('success.emphasis')
   },
   timeline: {
     badgeBg: get('scale.gray.1') // needs to be opaque
@@ -88,11 +88,11 @@ export default {
 
     primary: {
       text: get('scale.white'),
-      bg: get('scale.green.4'),
+      bg: get('success.emphasis'),
       border: get('border.subtle'),
       shadow: (theme: any) => `0 1px 0 ${alpha(get('scale.black'), 0.1)(theme)}`,
       insetShadow: (theme: any) => `inset 0 1px 0 ${alpha(get('scale.white'), 0.03)(theme)}`,
-      hoverBg: '#2c974b',
+      hoverBg: get('scale.green.5'),
       hoverBorder: get('border.subtle'),
       selectedBg: darken(get('btn.primary.hoverBg'), 0.02),
       selectedShadow: (theme: any) => `inset 0 1px 0 ${alpha(get('scale.green.9'), 0.2)(theme)}`,

--- a/data/colors/vars/global_light.ts
+++ b/data/colors/vars/global_light.ts
@@ -40,7 +40,7 @@ export default {
   },
   success: {
     fg: get('scale.green.5'),
-    emphasis: get('scale.green.4'),
+    emphasis: '#1f883d',
     muted: alpha(get('scale.green.3'), 0.4),
     subtle: get('scale.green.0')
   },
@@ -64,7 +64,7 @@ export default {
   },
   open: {
     fg: get('scale.green.5'),
-    emphasis: get('scale.green.4'),
+    emphasis: get('success.emphasis'),
     muted: alpha(get('scale.green.3'), 0.4),
     subtle: get('scale.green.0')
   },


### PR DESCRIPTION
## Summary

This PR fixes the failing contrast between the white text and green button background as part of https://github.com/github/primer/issues/1648.

It addresses both the current (old) implementation as well as the new v3 tokens.

