### PR TITLE
updating default and muted text in dark mode

### DIFF
--- a/data/colors/vars/global_dark.ts
+++ b/data/colors/vars/global_dark.ts
@@ -2,8 +2,8 @@ import {alpha, get} from '../../../src/utils-v1'
 
 export default {
   fg: {
-    default: get('scale.gray.1'),
-    muted: get('scale.gray.3'),
+    default: '#e6edf3',
+    muted: '#7d8590',
     subtle: get('scale.gray.4'),
     onEmphasis: get('scale.white')
   },


### PR DESCRIPTION
## Summary

This PR fixes the failing contrast between the default text and muted in **dark mode** as part of https://github.com/github/primer/issues/1648.

It addresses both the current (old) implementation as well as the new v3 tokens.