### PR TITLE
allows null in mix to disable it

### DIFF
--- a/src/filters/isColorWithMix.test.ts
+++ b/src/filters/isColorWithMix.test.ts
@@ -14,6 +14,10 @@ describe('Filter: isColorWithMix', () => {
     expect(isColorWithMix(getMockToken({value: '#000'}))).toStrictEqual(false)
   })
 
+  it('returns false if $type property is missing', () => {
+    expect(isColorWithMix(getMockToken({value: '#000', mix: null}))).toStrictEqual(false)
+  })
+
   it('returns false if $type `color` but mix is missing', () => {
     expect(isColorWithMix(getMockToken({$type: 'color'}))).toStrictEqual(false)
   })

--- a/src/filters/isColorWithMix.ts
+++ b/src/filters/isColorWithMix.ts
@@ -16,7 +16,7 @@ const throwError = (token: StyleDictionary.TransformedToken) => {
  */
 export const isColorWithMix = (token: StyleDictionary.TransformedToken): boolean => {
   // no color or no mix property
-  if (!isColor(token) || token.mix === undefined) {
+  if (!isColor(token) || token.mix === undefined || token.mix === null) {
     return false
   }
   // invalid mix property


### PR DESCRIPTION
## Summary

Allows for tokens to have a mix value of `null` to avoid inheriting mix values in overwrites. 