### PR TITLE
Add changeset for a11y update

### DIFF
--- a/.changeset/dirty-terms-confess.md
+++ b/.changeset/dirty-terms-confess.md
@@ -1,0 +1,5 @@
+---
+'@primer/primitives': patch
+---
+
+A11y changes to primary green, fg.default and fg.muted and some more


### PR DESCRIPTION
## Summary

Updating primitives to improve a11y issues.

- Primary green in light mode: https://github.com/primer/primitives/pull/514
- default and muted text in light mode: https://github.com/primer/primitives/pull/515
- default and muted text in dark mode: https://github.com/primer/primitives/pull/516
- accent color for dark mode: https://github.com/primer/primitives/pull/517
- role subtle colors: https://github.com/primer/primitives/pull/518