### PR TITLE
Add customMedia format

### DIFF
--- a/src/PrimerStyleDictionary.ts
+++ b/src/PrimerStyleDictionary.ts
@@ -23,6 +23,7 @@ import {
   typescriptExportDefinition,
   jsonNestedPrefixed,
   cssThemed,
+  cssCustomMedia,
 } from './formats'
 
 /**
@@ -38,6 +39,11 @@ StyleDictionary.registerParser(w3cJsonParser)
 StyleDictionary.registerFormat({
   name: 'css/themed',
   formatter: cssThemed,
+})
+
+StyleDictionary.registerFormat({
+  name: 'css/customMedia',
+  formatter: cssCustomMedia,
 })
 
 StyleDictionary.registerFormat({

--- a/src/formats/cssCustomMedia.ts
+++ b/src/formats/cssCustomMedia.ts
@@ -1,0 +1,25 @@
+import StyleDictionary from 'style-dictionary'
+import type {FormatterArguments} from 'style-dictionary/types/Format'
+import {format} from 'prettier'
+const {fileHeader} = StyleDictionary.formatHelpers
+
+/**
+ * @description Converts `StyleDictionary.dictionary.tokens` to css with @custom-media
+ * @param arguments [FormatterArguments](https://github.com/amzn/style-dictionary/blob/main/types/Format.d.ts)
+ * @returns formatted `string`
+ */
+export const cssCustomMedia: StyleDictionary.Formatter = ({
+  dictionary,
+  options: _options,
+  file,
+}: FormatterArguments) => {
+  // add file header
+  const output = [fileHeader({file})]
+  // add single theme css
+  dictionary.allTokens.map(({name, value}) => {
+    output.push(`@custom-media --${name}-viewport ${value};`)
+  })
+  // add auto dark theme css
+  // return prettified
+  return format(output.join('\n'), {parser: 'css', printWidth: 500})
+}

--- a/src/formats/index.ts
+++ b/src/formats/index.ts
@@ -1,4 +1,5 @@
 export {cssThemed} from './cssThemed'
+export {cssCustomMedia} from './cssCustomMedia'
 export {javascriptCommonJs} from './javascriptCommonJs'
 export {javascriptEsm} from './javascriptEsm'
 export {jsonNestedPrefixed} from './jsonNestedPrefixed'

--- a/src/platforms/css.ts
+++ b/src/platforms/css.ts
@@ -56,6 +56,11 @@ export const css: PlatformInitializer = (outputFile, prefix, buildPath, options)
           outputReferences: false,
         },
       },
+      {
+        destination: `${outputFile}`,
+        format: `css/customMedia`,
+        filter: token => isSource(token) && options?.themed !== true && token.$type === 'custom-viewportRange',
+      },
     ],
   }
 }

--- a/src/tokens/functional/size/viewport.json
+++ b/src/tokens/functional/size/viewport.json
@@ -1,22 +1,28 @@
 {
   "viewportRange": {
     "narrow": {
-      "value": "(max-width: calc({breakpoint.medium} - 0.02px))"
+      "value": "(max-width: calc({breakpoint.medium} - 0.02px))",
+      "$type": "custom-viewportRange"
     },
     "narrowLandscape": {
-      "value": "(max-width: calc({breakpoint.large} - 0.02px) and (max-height: calc({breakpoint.small} - 0.02px)) and (orientation: landscape))"
+      "value": "(max-width: calc({breakpoint.large} - 0.02px) and (max-height: calc({breakpoint.small} - 0.02px)) and (orientation: landscape))",
+      "$type": "custom-viewportRange"
     },
     "regular": {
-      "value": "(min-width: {breakpoint.medium})"
+      "value": "(min-width: {breakpoint.medium})",
+      "$type": "custom-viewportRange"
     },
     "wide": {
-      "value": "(min-width: {breakpoint.xxlarge})"
+      "value": "(min-width: {breakpoint.xxlarge})",
+      "$type": "custom-viewportRange"
     },
     "portrait": {
-      "value": "(orientation: portrait)"
+      "value": "(orientation: portrait)",
+      "$type": "custom-viewportRange"
     },
     "landscape": {
-      "value": "(orientation: landscape)"
+      "value": "(orientation: landscape)",
+      "$type": "custom-viewportRange"
     }
   }
 }


### PR DESCRIPTION
## Summary

This PR adds a new format for css `@custom-media`.

It is used on any token of the type `custom-viewportRange`

It is currently only used in css.