### PR TITLE
Improve contrast for Buttons with counters

### DIFF
--- a/.changeset/weak-wasps-drop.md
+++ b/.changeset/weak-wasps-drop.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Improve contrast for Buttons with counters

--- a/data/colors/vars/component_dark.ts
+++ b/data/colors/vars/component_dark.ts
@@ -99,25 +99,28 @@ export default {
       disabledBg: alpha(get('scale.green.5'), 0.6),
       disabledBorder: get('border.subtle'),
       icon: get('scale.white'),
-      counterBg: alpha(get('scale.white'), 0.2)
+      counterBg: '#04260f33'
     },
 
     outline: {
       text: get('scale.blue.3'),
-      hoverText: get('scale.blue.3'),
+      hoverText: '#58a6ff',
       hoverBg: get('scale.gray.6'),
       hoverBorder: get('border.subtle'),
       hoverShadow: (theme: any) => `0 1px 0 ${alpha(get('scale.black'), 0.1)(theme)}`,
       hoverInsetShadow: (theme: any) => `inset 0 1px 0 ${alpha(get('scale.white'), 0.03)(theme)}`,
-      hoverCounterBg: alpha(get('scale.white'), 0.2),
+      hoverCounterBg: '#051d4d33',
       selectedText: get('scale.white'),
       selectedBg: get('scale.blue.7'),
       selectedBorder: get('border.subtle'),
       selectedShadow: '0 0 transparent',
       disabledText: alpha(get('scale.blue.3'), 0.5),
       disabledBg: get('scale.gray.9'),
-      disabledCounterBg: alpha(get('scale.blue.5'), 0.05),
-      counterBg: alpha(get('scale.blue.5'), 0.1)
+      disabledCounterBg: '#1f6feb0d',
+      counterBg: '#051d4d33',
+      hoverCounterFg: '#58a6ff',
+      disabledCounterFg: '#2f81f780',
+      counterFg: '#388bfd'
     },
 
     danger: {
@@ -135,9 +138,12 @@ export default {
       selectedShadow: '0 0 transparent',
       disabledText: alpha(get('scale.red.4'), 0.5),
       disabledBg: get('scale.gray.9'),
-      disabledCounterBg: alpha(get('scale.red.5'), 0.05),
-      counterBg: alpha(get('scale.red.5'), 0.1),
-      icon: get('scale.red.4')
+      disabledCounterBg: '#da36330d',
+      counterBg: '#49020233',
+      icon: get('scale.red.4'),
+      counterFg: '#f85149',
+      disabledCounterFg: '#f8514980',
+      hoverCounterFg: '#ffffff'
     }
   },
   underlinenav: {

--- a/data/colors/vars/component_dark.ts
+++ b/data/colors/vars/component_dark.ts
@@ -99,28 +99,28 @@ export default {
       disabledBg: alpha(get('scale.green.5'), 0.6),
       disabledBorder: get('border.subtle'),
       icon: get('scale.white'),
-      counterBg: '#04260f33'
+      counterBg: alpha(get('scale.green.9'), 0.2)
     },
 
     outline: {
-      text: get('scale.blue.3'),
-      hoverText: '#58a6ff',
+      text: get('scale.blue.4'),
+      hoverText: get('scale.blue.3'),
       hoverBg: get('scale.gray.6'),
       hoverBorder: get('border.subtle'),
       hoverShadow: (theme: any) => `0 1px 0 ${alpha(get('scale.black'), 0.1)(theme)}`,
       hoverInsetShadow: (theme: any) => `inset 0 1px 0 ${alpha(get('scale.white'), 0.03)(theme)}`,
-      hoverCounterBg: '#051d4d33',
+      hoverCounterBg: alpha(get('scale.blue.9'), 0.2),
       selectedText: get('scale.white'),
       selectedBg: get('scale.blue.7'),
       selectedBorder: get('border.subtle'),
       selectedShadow: '0 0 transparent',
       disabledText: alpha(get('scale.blue.3'), 0.5),
       disabledBg: get('scale.gray.9'),
-      disabledCounterBg: '#1f6feb0d',
-      counterBg: '#051d4d33',
-      hoverCounterFg: '#58a6ff',
-      disabledCounterFg: '#2f81f780',
-      counterFg: '#388bfd'
+      disabledCounterBg: alpha(get('scale.blue.5'), 0.05),
+      counterBg: alpha(get('scale.blue.9'), 0.2),
+      hoverCounterFg: get('scale.blue.3'),
+      disabledCounterFg: alpha(get('accent.fg'), 0.5),
+      counterFg: get('scale.blue.4'),
     },
 
     danger: {
@@ -138,12 +138,12 @@ export default {
       selectedShadow: '0 0 transparent',
       disabledText: alpha(get('scale.red.4'), 0.5),
       disabledBg: get('scale.gray.9'),
-      disabledCounterBg: '#da36330d',
-      counterBg: '#49020233',
+      disabledCounterBg: alpha(get('scale.red.5'), 0.05),
+      counterBg: alpha(get('scale.red.9'), 0.2),
       icon: get('scale.red.4'),
-      counterFg: '#f85149',
-      disabledCounterFg: '#f8514980',
-      hoverCounterFg: '#ffffff'
+      counterFg: get('danger.fg'),
+      disabledCounterFg: alpha(get('danger.fg'), 0.5),
+      hoverCounterFg: get('scale.white')
     }
   },
   underlinenav: {

--- a/data/colors/vars/component_light.ts
+++ b/data/colors/vars/component_light.ts
@@ -100,7 +100,7 @@ export default {
       disabledBg: '#94d3a2',
       disabledBorder: get('border.subtle'),
       icon: alpha(get('scale.white'), 0.8),
-      counterBg: alpha(get('scale.white'), 0.2)
+      counterBg: '#002d1133'
     },
 
     outline: {
@@ -118,7 +118,10 @@ export default {
       disabledText: alpha(get('scale.blue.5'), 0.5),
       disabledBg: get('scale.gray.0'),
       disabledCounterBg: alpha(get('scale.blue.5'), 0.05),
-      counterBg: alpha(get('scale.blue.5'), 0.1)
+      counterBg: '#0969da1a',
+      counterFg: '#0550ae',
+      hoverCounterFg: get('scale.white'),
+      disabledCounterFg: '#0969da80'
     },
 
     danger: {
@@ -138,7 +141,9 @@ export default {
       disabledCounterBg: alpha(get('scale.red.5'), 0.05),
       counterBg: alpha(get('scale.red.5'), 0.1),
       icon: get('scale.red.5'),
-      hoverIcon: get('scale.white')
+      hoverIcon: get('scale.white'),
+      counterFg: '#c21c2c',
+      disabledCounterFg: '#d1242f80'
     }
   },
   underlinenav: {

--- a/data/colors/vars/component_light.ts
+++ b/data/colors/vars/component_light.ts
@@ -100,7 +100,7 @@ export default {
       disabledBg: '#94d3a2',
       disabledBorder: get('border.subtle'),
       icon: alpha(get('scale.white'), 0.8),
-      counterBg: '#002d1133'
+      counterBg: alpha(get('scale.green.9'), 0.2)
     },
 
     outline: {
@@ -119,9 +119,9 @@ export default {
       disabledBg: get('scale.gray.0'),
       disabledCounterBg: alpha(get('scale.blue.5'), 0.05),
       counterBg: '#0969da1a',
-      counterFg: '#0550ae',
+      counterFg: get('scale.blue.6'),
       hoverCounterFg: get('scale.white'),
-      disabledCounterFg: '#0969da80'
+      disabledCounterFg: alpha(get('scale.blue.5'), 0.5)
     },
 
     danger: {
@@ -143,7 +143,8 @@ export default {
       icon: get('scale.red.5'),
       hoverIcon: get('scale.white'),
       counterFg: '#c21c2c',
-      disabledCounterFg: '#d1242f80'
+      hoverCounterFg: get('scale.white'),
+      disabledCounterFg: alpha(get('scale.red.5'), 0.5)
     }
   },
   underlinenav: {

--- a/docs/storybook/stories/Demos/Control.stories.tsx
+++ b/docs/storybook/stories/Demos/Control.stories.tsx
@@ -62,6 +62,10 @@ export const ButtonScheme = () => {
         Default
         <Button.Counter>{count}</Button.Counter>
       </Button>
+      <Button disabled id="default">
+        Default
+        <Button.Counter>{count}</Button.Counter>
+      </Button>
       <Button id="default" leadingIcon={HeartIcon} trailingIcon={EyeIcon}>
         Default
       </Button>
@@ -75,6 +79,10 @@ export const ButtonScheme = () => {
         Invisible
       </Button>
       <Button id="invisible" variant="invisible">
+        Invisible
+        <Button.Counter>{count}</Button.Counter>
+      </Button>
+      <Button disabled id="invisible" variant="invisible">
         Invisible
         <Button.Counter>{count}</Button.Counter>
       </Button>
@@ -94,6 +102,10 @@ export const ButtonScheme = () => {
         Primary
         <Button.Counter>{count}</Button.Counter>
       </Button>
+      <Button disabled variant="primary" id="primary">
+        Primary
+        <Button.Counter>{count}</Button.Counter>
+      </Button>
       <Button variant="primary" id="primary" leadingIcon={HeartIcon} trailingIcon={EyeIcon}>
         Primary
       </Button>
@@ -110,6 +122,10 @@ export const ButtonScheme = () => {
         Danger
         <Button.Counter>{count}</Button.Counter>
       </Button>
+      <Button disabled variant="danger" id="danger">
+        Danger
+        <Button.Counter>{count}</Button.Counter>
+      </Button>
       <Button variant="danger" id="danger" leadingIcon={HeartIcon} trailingIcon={EyeIcon}>
         Danger
       </Button>
@@ -123,6 +139,10 @@ export const ButtonScheme = () => {
         Outline
       </Button>
       <Button variant="outline" id="outline">
+        Outline
+        <Button.Counter>{count}</Button.Counter>
+      </Button>
+      <Button disabled variant="outline" id="outline">
         Outline
         <Button.Counter>{count}</Button.Counter>
       </Button>

--- a/docs/storybook/stories/Demos/PatternOverrides.css
+++ b/docs/storybook/stories/Demos/PatternOverrides.css
@@ -40,6 +40,22 @@
   color: var(--button-invisible-fgColor-rest);
 }
 
+.Button button[id='danger']:not(:hover) [data-component='ButtonCounter'] {
+  color: var(--buttonCounter-danger-fgColor-rest) !important;
+}
+
+.Button button[id='danger']:hover [data-component='ButtonCounter'] {
+  color: var(--buttonCounter-danger-fgColor-hover) !important;
+}
+
+.Button button[id='outline']:not(:hover) [data-component='ButtonCounter'] {
+  color: var(--buttonCounter-outline-fgColor-rest) !important;
+}
+
+.Button button[id='outline']:hover [data-component='ButtonCounter'] {
+  color: var(--buttonCounter-outline-fgColor-hover) !important;
+}
+
 .Overlay-backdrop--center {
   background-color: var(--overlay-backdrop-bgColor) !important;
 }

--- a/docs/storybook/stories/Demos/PatternOverrides.css
+++ b/docs/storybook/stories/Demos/PatternOverrides.css
@@ -24,6 +24,7 @@
 
 .Button button[id='invisible']:hover:not(:disabled) {
   background-color: var(--button-invisible-bgColor-hover);
+  color: var(--button-invisible-fgColor-hover);
 }
 
 .Button button[id='invisible']:disabled {

--- a/docs/storybook/stories/Demos/PatternOverrides.css
+++ b/docs/storybook/stories/Demos/PatternOverrides.css
@@ -41,19 +41,24 @@
   color: var(--button-invisible-fgColor-rest);
 }
 
-.Button button[id='danger']:not(:hover) [data-component='ButtonCounter'] {
+.Button button[id='default']:not(:hover) [data-component='ButtonCounter'] {
+  color: var(--buttonCounter-default-fgColor-rest) !important;
+  background-color: var(--buttonCounter-default-bgColor-rest) !important;
+}
+
+.Button button[id='danger']:not(:hover):not(:disabled) [data-component='ButtonCounter'] {
   color: var(--buttonCounter-danger-fgColor-rest) !important;
 }
 
-.Button button[id='danger']:hover [data-component='ButtonCounter'] {
+.Button button[id='danger']:hover:not(:disabled) [data-component='ButtonCounter'] {
   color: var(--buttonCounter-danger-fgColor-hover) !important;
 }
 
-.Button button[id='outline']:not(:hover) [data-component='ButtonCounter'] {
+.Button button[id='outline']:not(:hover):not(:disabled) [data-component='ButtonCounter'] {
   color: var(--buttonCounter-outline-fgColor-rest) !important;
 }
 
-.Button button[id='outline']:hover [data-component='ButtonCounter'] {
+.Button button[id='outline']:hover:not(:disabled) [data-component='ButtonCounter'] {
   color: var(--buttonCounter-outline-fgColor-hover) !important;
 }
 

--- a/src/tokens/functional/color/dark/patterns-dark.json5
+++ b/src/tokens/functional/color/dark/patterns-dark.json5
@@ -405,19 +405,17 @@
       },
       borderColor: {
         rest: {
-          $value: '{borderColor.default}',
+          $value: '{base.color.gray.0}',
           $type: 'color',
-          alpha: 0.8,
+          alpha: 0.1,
         },
         hover: {
-          $value: '{borderColor.default}',
+          $value: '{button.primary.borderColor.rest}',
           $type: 'color',
-          alpha: 0.8,
         },
         disabled: {
-          $value: '{borderColor.default}',
+          $value: '{button.primary.borderColor.rest}',
           $type: 'color',
-          alpha: 0.8,
         },
       },
     },

--- a/src/tokens/functional/color/dark/patterns-dark.json5
+++ b/src/tokens/functional/color/dark/patterns-dark.json5
@@ -427,6 +427,10 @@
           $value: '{fgColor.accent}',
           $type: 'color',
         },
+        hover: {
+          $value: '{base.color.blue.3}',
+          $type: 'color',
+        },
         disabled: {
           $value: '{control.fgColor.disabled}',
           $type: 'color',
@@ -590,7 +594,7 @@
     primary: {
       bgColor: {
         rest: {
-          $value: '{base.color.white}',
+          $value: '{base.color.green.9}',
           $type: 'color',
           alpha: 0.2,
         },
@@ -643,9 +647,24 @@
           alpha: 0.05,
         },
         rest: {
-          $value: '{bgColor.danger.emphasis}',
+          $value: '{base.color.red.9}',
           $type: 'color',
-          alpha: 0.1,
+          alpha: 0.2,
+        },
+      },
+      fgColor: {
+        rest: {
+          $value: '{fgColor.danger}',
+          $type: 'color',
+        },
+        hover: {
+          $value: '{base.color.white}',
+          $type: 'color',
+        },
+        disabled: {
+          $value: '{fgColor.danger}',
+          $type: 'color',
+          alpha: 0.5,
         },
       },
     },

--- a/src/tokens/functional/color/dark/patterns-dark.json5
+++ b/src/tokens/functional/color/dark/patterns-dark.json5
@@ -464,11 +464,11 @@
     outline: {
       fgColor: {
         rest: {
-          $value: '{fgColor.accent}',
+          $value: '{base.color.blue.4}',
           $type: 'color',
         },
         hover: {
-          $value: '{fgColor.accent}',
+          $value: '{base.color.blue.3}',
           $type: 'color',
         },
         active: {
@@ -599,12 +599,12 @@
     outline: {
       bgColor: {
         rest: {
-          $value: '{bgColor.accent.emphasis}',
+          $value: '{base.color.blue.9}',
           $type: 'color',
-          alpha: 0.1,
+          alpha: 0.2,
         },
         hover: {
-          $value: '{base.color.white}',
+          $value: '{base.color.blue.9}',
           $type: 'color',
           alpha: 0.2,
         },
@@ -612,6 +612,21 @@
           $value: '{bgColor.accent.emphasis}',
           $type: 'color',
           alpha: 0.05,
+        },
+      },
+      fgColor: {
+        rest: {
+          $value: '{base.color.blue.4}',
+          $type: 'color',
+        },
+        hover: {
+          $value: '{base.color.blue.3}',
+          $type: 'color',
+        },
+        disabled: {
+          $value: '{fgColor.accent}',
+          $type: 'color',
+          alpha: 0.5,
         },
       },
     },

--- a/src/tokens/functional/color/light/patterns-light.json5
+++ b/src/tokens/functional/color/light/patterns-light.json5
@@ -404,19 +404,17 @@
       },
       borderColor: {
         rest: {
-          $value: '{borderColor.muted}',
+          $value: '{base.color.black}',
           $type: 'color',
-          alpha: 0.8,
+          alpha: 0.15,
         },
         hover: {
-          $value: '{borderColor.muted}',
+          $value: '{button.primary.borderColor.rest}',
           $type: 'color',
-          alpha: 0.8,
         },
         disabled: {
-          $value: '{borderColor.muted}',
+          $value: '{button.primary.borderColor.rest}',
           $type: 'color',
-          alpha: 0.8,
         },
       },
     },

--- a/src/tokens/functional/color/light/patterns-light.json5
+++ b/src/tokens/functional/color/light/patterns-light.json5
@@ -593,7 +593,7 @@
     primary: {
       bgColor: {
         rest: {
-          $value: '{base.color.white}',
+          $value: '{base.color.green.9}',
           $type: 'color',
           alpha: 0.2,
         },
@@ -617,6 +617,21 @@
           alpha: 0.05,
         },
       },
+      fgColor: {
+        rest: {
+          $value: '{base.color.blue.6}',
+          $type: 'color',
+        },
+        hover: {
+          $value: '{base.color.white}',
+          $type: 'color',
+        },
+        disabled: {
+          $value: '{fgColor.accent}',
+          $type: 'color',
+          alpha: 0.5,
+        },
+      },
     },
     danger: {
       bgColor: {
@@ -634,6 +649,25 @@
           $value: '{bgColor.danger.emphasis}',
           $type: 'color',
           alpha: 0.1,
+        },
+      },
+      fgColor: {
+        rest: {
+          $value: '{base.color.red.5}',
+          $type: 'color',
+          mix: {
+            color: '{base.color.red.6}',
+            weight: 0.3,
+          },
+        },
+        hover: {
+          $value: '{base.color.white}',
+          $type: 'color',
+        },
+        disabled: {
+          $value: '{fgColor.danger}',
+          $type: 'color',
+          alpha: 0.5,
         },
       },
     },

--- a/src/tokens/functional/color/light/patterns-light.json5
+++ b/src/tokens/functional/color/light/patterns-light.json5
@@ -426,6 +426,10 @@
           $value: '{fgColor.accent}',
           $type: 'color',
         },
+        hover: {
+          $value: '{fgColor.accent}',
+          $type: 'color',
+        },
         disabled: {
           $value: '{control.fgColor.disabled}',
           $type: 'color',


### PR DESCRIPTION
`Button` variants `danger`, `outline`, and `primary` are failing contrast checks when they have a counter label. This PR includes slight changes to the counter backgrounds, and adds new tokens for the counter label text color to achieve sufficient contrast.

### Additions

**Legacy**
- `btn.outline.hoverCounterFg`
- `btn.outline.disabledCounterFg`
- `btn.outline.counterFg`
- `btn.danger.hoverCounterFg`
- `btn.danger.disabledCounterFg`
- `btn.danger.counterFg`

**v8**
- `--button-invisible-fgColor-hover` (another contrast issue)
- `--buttonCounter-outline-fgColor-rest`
- `--buttonCounter-outline-fgColor-hover`
- `--buttonCounter-outline-fgColor-disabled`
- `--buttonCounter-danger-fgColor-rest`
- `--buttonCounter-danger-fgColor-hover`
- `--buttonCounter-danger-fgColor-disabled`

### Test

Check out the [preview Storybook](https://primer-3f662c74ed-26615723.drafts.github.io/storybook/?path=/story/demos-controls--button-scheme)

### Screenshots

Light before:
<img width="1120" alt="image" src="https://user-images.githubusercontent.com/18661030/236035427-f18556d1-e7a4-4669-ba6c-e9a68e614d1b.png">

Light after:
<img width="1143" alt="image" src="https://user-images.githubusercontent.com/18661030/236035501-1550362e-ec88-4c45-9450-585ed58b64db.png">

Dark before: 
<img width="1140" alt="image" src="https://user-images.githubusercontent.com/18661030/236035583-d00ea5b4-28c9-4fb3-ae4e-9bfc7c9d6fed.png">

Dark after:
<img width="1129" alt="image" src="https://user-images.githubusercontent.com/18661030/236035769-63306931-6fd1-4999-83d1-016cc770abbd.png">
