### PR TITLE
Add missing color overrides for dark tritanopia in v8 tokens

### DIFF
--- a/.changeset/long-countries-burn.md
+++ b/.changeset/long-countries-burn.md
@@ -1,0 +1,5 @@
+---
+'@primer/primitives': patch
+---
+
+add missing color overrides for dark tritanopia in v8 tokens

--- a/src/tokens/functional/color/dark/overrides/dark.tritanopia.json5
+++ b/src/tokens/functional/color/dark/overrides/dark.tritanopia.json5
@@ -35,6 +35,26 @@
         $type: 'color',
       },
     },
+    open: {
+      muted: {
+        $value: '{base.color.red.4}',
+        $type: 'color',
+      },
+      emphasis: {
+        $value: '{base.color.red.5}',
+        $type: 'color',
+      },
+    },
+    closed: {
+      muted: {
+        $value: '{base.color.gray.4}',
+        $type: 'color',
+      },
+      emphasis: {
+        $value: '{base.color.gray.5}',
+        $type: 'color',
+      },
+    },
   },
   borderColor: {
     success: {
@@ -56,6 +76,28 @@
       },
       emphasis: {
         $value: '{base.color.red.5}',
+        $type: 'color',
+      },
+    },
+    open: {
+      muted: {
+        $value: '{base.color.red.4}',
+        $type: 'color',
+        alpha: 0.4,
+      },
+      emphasis: {
+        $value: '{base.color.red.5}',
+        $type: 'color',
+      },
+    },
+    closed: {
+      muted: {
+        $value: '{base.color.gray.4}',
+        $type: 'color',
+        alpha: 0.4,
+      },
+      emphasis: {
+        $value: '{base.color.gray.5}',
         $type: 'color',
       },
     },

--- a/src/tokens/functional/color/light/overrides/light.tritanopia.json5
+++ b/src/tokens/functional/color/light/overrides/light.tritanopia.json5
@@ -49,7 +49,7 @@
         $type: 'color',
       },
     },
-    gray: {
+    closed: {
       muted: {
         $value: '{base.color.gray.0}',
         $type: 'color',


### PR DESCRIPTION
## Summary

Add missing color overrides for dark tritanopia in v8 tokens