### PR TITLE
Bug fix: `danger` counter fg 

### DIFF
--- a/.changeset/fresh-baboons-drop.md
+++ b/.changeset/fresh-baboons-drop.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Bug fix: `danger` counter fg 

--- a/data/colors/vars/component_light.ts
+++ b/data/colors/vars/component_light.ts
@@ -142,7 +142,7 @@ export default {
       counterBg: alpha(get('scale.red.5'), 0.1),
       icon: get('scale.red.5'),
       hoverIcon: get('scale.white'),
-      counterFg: '#c21c2c',
+      counterFg: get('scale.red.6'),
       hoverCounterFg: get('scale.white'),
       disabledCounterFg: alpha(get('scale.red.5'), 0.5)
     }


### PR DESCRIPTION
Using a `scale` color to respect color blind themes