### PR TITLE
Add functional transparent tokens

### DIFF
--- a/.changeset/tall-bananas-float.md
+++ b/.changeset/tall-bananas-float.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Add functional transparent tokens

--- a/docs/storybook/stories/Color/Functional/Background.stories.tsx
+++ b/docs/storybook/stories/Color/Functional/Background.stories.tsx
@@ -9,7 +9,7 @@ export default {
   },
 }
 
-const bgColors = ['bgColor-default', 'bgColor-muted', 'bgColor-disabled', 'bgColor-emphasis']
+const bgColors = ['bgColor-default', 'bgColor-muted', 'bgColor-disabled', 'bgColor-emphasis', 'bgColor-transparent']
 
 export const Background = () => {
   return (

--- a/docs/storybook/stories/Color/Functional/Border.stories.tsx
+++ b/docs/storybook/stories/Color/Functional/Border.stories.tsx
@@ -9,7 +9,13 @@ export default {
   },
 }
 
-const borderColors = ['borderColor-default', 'borderColor-muted', 'borderColor-emphasis', 'borderColor-disabled']
+const borderColors = [
+  'borderColor-default',
+  'borderColor-muted',
+  'borderColor-emphasis',
+  'borderColor-disabled',
+  'borderColor-transparent',
+]
 
 export const Border = () => {
   return (

--- a/docs/storybook/stories/Migration/v8/DeprecatedPatternTokensMap.json
+++ b/docs/storybook/stories/Migration/v8/DeprecatedPatternTokensMap.json
@@ -244,7 +244,7 @@
     "color": "control-checked-fgColor-disabled"
   },
   "color-switch-track-checked-border": {
-    "border": "transparent"
+    "border": "borderColor-transparent"
   },
   "color-switch-knob-bg": {
     "background": "controlKnob-bgColor-rest"

--- a/docs/storybook/stories/Migration/v8/DeprecatedPrimitiveTokensMap.json
+++ b/docs/storybook/stories/Migration/v8/DeprecatedPrimitiveTokensMap.json
@@ -1,5 +1,7 @@
 {
-  "color-canvas-default-transparent": {},
+  "color-canvas-default-transparent": {
+    "background": "bgColor-transparent"
+  },
   "color-fg-default": {
     "color": "fgColor-default"
   },

--- a/src/tokens/functional/color/dark/primitives-dark.json5
+++ b/src/tokens/functional/color/dark/primitives-dark.json5
@@ -88,6 +88,10 @@
       $value: '{base.color.gray.5}',
       $type: 'color',
     },
+    transparent: {
+      $value: '{base.color.transparent}',
+      $type: 'color',
+    },
     neutral: {
       muted: {
         $value: '{base.color.gray.4}',
@@ -215,6 +219,10 @@
     },
     disabled: {
       $value: '{borderColor.default}',
+      $type: 'color',
+    },
+    transparent: {
+      $value: '{base.color.transparent}',
       $type: 'color',
     },
     neutral: {

--- a/src/tokens/functional/color/light/primitives-light.json5
+++ b/src/tokens/functional/color/light/primitives-light.json5
@@ -84,6 +84,10 @@
       $value: '{base.color.gray.0}',
       $type: 'color',
     },
+    transparent: {
+      $value: '{base.color.transparent}',
+      $type: 'color',
+    },
     neutral: {
       muted: {
         $value: '{base.color.gray.1}',
@@ -206,6 +210,10 @@
     },
     disabled: {
       $value: '{borderColor.default}',
+      $type: 'color',
+    },
+    transparent: {
+      $value: '{base.color.transparent}',
       $type: 'color',
     },
     neutral: {


### PR DESCRIPTION
Originally I had planned on just using `transparent` but that makes rolling out new tokens a little more complicated. This adds functional tokens for `bg` and `border` referencing the base `transparent` token.