### PR TITLE
Improve color contrast of light theme entity var

### DIFF
--- a/.changeset/hot-hairs-marry.md
+++ b/.changeset/hot-hairs-marry.md
@@ -1,0 +1,5 @@
+---
+'@primer/primitives': patch
+---
+
+Adjust value of entity highlighting so it meets required color contrast on a diff deletion background

--- a/.changeset/hot-hairs-marry.md
+++ b/.changeset/hot-hairs-marry.md
@@ -2,4 +2,4 @@
 '@primer/primitives': patch
 ---
 
-Adjust value of entity highlighting so it meets required color contrast on a diff deletion background
+Adjust the value of entity highlighting so it meets the required color contrast on a diff deletion background.

--- a/data/colors/vars/app_light.ts
+++ b/data/colors/vars/app_light.ts
@@ -43,7 +43,7 @@ export default {
     syntax: {
       comment: get('scale.gray.5'),
       constant: get('scale.blue.6'),
-      entity: get('scale.purple.5'),
+      entity: get('scale.purple.6'),
       storageModifierImport: get('scale.gray.9'),
       entityTag: get('scale.green.6'),
       keyword: get('scale.red.5'),

--- a/src/tokens/functional/color/light/syntax-light.json5
+++ b/src/tokens/functional/color/light/syntax-light.json5
@@ -85,7 +85,7 @@
           $type: 'color',
         },
         entity: {
-          $value: '{base.color.purple.5}',
+          $value: '{base.color.purple.6}',
           $type: 'color',
         },
         storage: {


### PR DESCRIPTION
## Summary

Adjust the value of entity highlighting so it meets the required color contrast on a diff deletion background.

This PR adjusts it from `color-scale-purple-5` to `color-scale-purple-6`

Before: 
<img width="471" alt="Screenshot 2023-06-26 at 11 57 40 AM" src="https://github.com/primer/primitives/assets/12767551/9bf5128c-92c6-47fa-af45-0ae91d5576a2">

After:
<img width="469" alt="Screenshot 2023-06-26 at 11 58 19 AM" src="https://github.com/primer/primitives/assets/12767551/07a83a85-0161-4f96-860b-a1519f9b9c07">

Fixes https://github.com/github/accessibility-audits/issues/3367

## List of notable changes:

<!--
E.g.

- **added** new design token for # because #
- **deprecated**  design token for # because #
- **updated** documentation for # because #
-->


- Update the color value of prettylights.syntax.entity to `color-scale-purple-6`

## What should reviewers focus on?

- Color changes and correct changeset

## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

1. Open the preview documentation that has been deployed in this pull request
2. Go to # page
3. Verify that # behaves as described in the pull request description
-->

1.
1.
1.

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
- [ ] Verify the design tokens changed in this PR are expected using the diffing results in this PR
