### PR TITLE
Add Overlay backdrop tokens to old build

### DIFF
--- a/.changeset/itchy-beers-fix.md
+++ b/.changeset/itchy-beers-fix.md
@@ -1,0 +1,6 @@
+---
+"@primer/primitives": patch
+---
+
+- Update Overlay backdrop color for dark mode
+- Add Overlay backdrop tokens to the old build

--- a/data/colors/vars/component_dark.ts
+++ b/data/colors/vars/component_dark.ts
@@ -27,7 +27,7 @@ export default {
   overlay: {
     shadow: (theme: any) =>
       `0 0 0 1px ${get('scale.gray.6')(theme)}, 0 16px 32px ${alpha(get('scale.black'), 0.85)(theme)}`,
-    backdrop: alpha(get('scale.gray.2'), 0.2)
+    backdrop: alpha(get('scale.gray.8'), 0.4)
   },
   header: {
     text: alpha(get('scale.white'), 0.7),

--- a/data/colors/vars/component_dark.ts
+++ b/data/colors/vars/component_dark.ts
@@ -26,7 +26,8 @@ export default {
   },
   overlay: {
     shadow: (theme: any) =>
-      `0 0 0 1px ${get('scale.gray.6')(theme)}, 0 16px 32px ${alpha(get('scale.black'), 0.85)(theme)}`
+      `0 0 0 1px ${get('scale.gray.6')(theme)}, 0 16px 32px ${alpha(get('scale.black'), 0.85)(theme)}`,
+    backdrop: alpha(get('scale.gray.2'), 0.2)
   },
   header: {
     text: alpha(get('scale.white'), 0.7),

--- a/data/colors/vars/component_light.ts
+++ b/data/colors/vars/component_light.ts
@@ -26,7 +26,8 @@ export default {
   },
   overlay: {
     shadow: (theme: any) =>
-      `0 1px 3px ${alpha(get('scale.black'), 0.12)(theme)}, 0 8px 24px ${alpha(get('scale.gray.7'), 0.12)(theme)}`
+      `0 1px 3px ${alpha(get('scale.black'), 0.12)(theme)}, 0 8px 24px ${alpha(get('scale.gray.7'), 0.12)(theme)}`,
+    backdrop: alpha(get('scale.gray.4'), 0.2)
   },
   header: {
     text: alpha(get('scale.white'), 0.7),

--- a/src/tokens/functional/color/dark/patterns-dark.json5
+++ b/src/tokens/functional/color/dark/patterns-dark.json5
@@ -739,9 +739,9 @@
     },
     backdrop: {
       bgColor: {
-        $value: '{base.color.gray.2}',
+        $value: '{base.color.gray.8}',
         $type: 'color',
-        alpha: 0.2,
+        alpha: 0.4,
       },
     },
   },


### PR DESCRIPTION
Adds the new Overlay backdrop color tokens to the old build, and also adjusts the dark theme value to look more subtle and dimmed.

| Before | After |
| -- | -- |
| ![image](https://github.com/primer/primitives/assets/18661030/ec3155bf-75ab-4f14-8861-f3f1ddde9c70) | ![image](https://github.com/primer/primitives/assets/18661030/100ab0d9-3136-41cf-a470-6ca0e979525d) |

To test this in dotcom, open a new global nav sidebar and replace the background color of the backdrop with `#161b2266`