### PR TITLE
rm web specific values

### DIFF
--- a/src/tokens/functional/color/dark/patterns-dark.json5
+++ b/src/tokens/functional/color/dark/patterns-dark.json5
@@ -112,7 +112,7 @@
     transparent: {
       bgColor: {
         rest: {
-          $value: 'transparent',
+          $value: '{base.color.transparent}',
           $type: 'color',
         },
         hover: {
@@ -126,7 +126,7 @@
           alpha: 0.2,
         },
         disabled: {
-          $value: 'transparent',
+          $value: '{base.color.transparent}',
           $type: 'color',
         },
         selected: {
@@ -137,15 +137,15 @@
       },
       borderColor: {
         rest: {
-          $value: 'transparent',
+          $value: '{base.color.transparent}',
           $type: 'color',
         },
         hover: {
-          $value: 'transparent',
+          $value: '{base.color.transparent}',
           $type: 'color',
         },
         active: {
-          $value: 'transparent',
+          $value: '{base.color.transparent}',
           $type: 'color',
         },
       },
@@ -277,7 +277,7 @@
     },
     borderColor: {
       rest: {
-        $value: 'transparent',
+        $value: '{base.color.transparent}',
         $type: 'color',
       },
       disabled: {

--- a/src/tokens/functional/color/light/patterns-light.json5
+++ b/src/tokens/functional/color/light/patterns-light.json5
@@ -111,7 +111,7 @@
     transparent: {
       bgColor: {
         rest: {
-          $value: 'transparent',
+          $value: '{base.color.transparent}',
           $type: 'color',
         },
         hover: {
@@ -135,15 +135,15 @@
       },
       borderColor: {
         rest: {
-          $value: 'transparent',
+          $value: '{base.color.transparent}',
           $type: 'color',
         },
         hover: {
-          $value: 'transparent',
+          $value: '{base.color.transparent}',
           $type: 'color',
         },
         active: {
-          $value: 'transparent',
+          $value: '{base.color.transparent}',
           $type: 'color',
         },
       },
@@ -275,7 +275,7 @@
     },
     borderColor: {
       rest: {
-        $value: 'transparent',
+        $value: '{base.color.transparent}',
         $type: 'color',
       },
       disabled: {

--- a/src/tokens/functional/size/border.json
+++ b/src/tokens/functional/size/border.json
@@ -33,7 +33,7 @@
       "value": "12px"
     },
     "full": {
-      "value": "100vh"
+      "value": "9999px"
     }
   },
   "outline": {


### PR DESCRIPTION
## Summary

Replace values that only work on the web with alternatives. This is important for the figma import.

## List of notable changes:

- **updated** `transparent` to `{base.color.transparent}` which is a hex with 0% opacity
- **updated** `100vh` for full border radius with `9999px`

## What should reviewers focus on?

- any issue with using `9999px` for border radius?
