### PR TITLE
Disable unused imports

### DIFF
--- a/scripts/buildTokens.ts
+++ b/scripts/buildTokens.ts
@@ -2,14 +2,14 @@ import type StyleDictionary from 'style-dictionary'
 import {PrimerStyleDictionary} from '~/src/PrimerStyleDictionary'
 import {copyFromDir} from '~/src/utilities'
 import {
-  typeDefinitions,
+  // typeDefinitions,
   deprecatedJson,
   css,
   docJson,
-  scss,
-  javascript,
-  typescript,
-  json,
+  // scss,
+  // javascript,
+  // typescript,
+  // json,
   fallbacks,
 } from '~/src/platforms'
 import type {ConfigGeneratorOptions, StyleDictionaryConfigGenerator} from '~/src/types/StyleDictionaryConfigGenerator'
@@ -35,10 +35,10 @@ const getStyleDictionaryConfig: StyleDictionaryConfigGenerator = (
   include,
   platforms: {
     css: css(`css/${filename}.css`, options.prefix, options.buildPath, {themed: options.themed}),
-    scss: scss(`scss/${filename}.scss`, options.prefix, options.buildPath),
-    js: javascript(`js/${filename}.js`, options.prefix, options.buildPath),
-    ts: typescript(`ts/${filename}.ts`, options.prefix, options.buildPath),
-    json: json(`json/${filename}.json`, options.prefix, options.buildPath),
+    // scss: scss(`scss/${filename}.scss`, options.prefix, options.buildPath),
+    // js: javascript(`js/${filename}.js`, options.prefix, options.buildPath),
+    // ts: typescript(`ts/${filename}.ts`, options.prefix, options.buildPath),
+    // json: json(`json/${filename}.json`, options.prefix, options.buildPath),
     docJson: docJson(`docs/${filename}.json`, options.prefix, options.buildPath),
     fallbacks: fallbacks(`fallbacks/${filename}.json`, options.prefix, options.buildPath),
     ...platforms,
@@ -157,49 +157,49 @@ export const buildDesignTokens = (buildOptions: ConfigGeneratorOptions): void =>
   /** -----------------------------------
    * Type definitions
    * ----------------------------------- */
-  const typeBuilds: TokenBuildInput[] = [
-    // color, shadow & border
-    {
-      filename: 'theme',
-      source: [
-        `src/tokens/functional/color/light/*.json5`,
-        `src/tokens/functional/shadow/light.json5`,
-        `src/tokens/functional/border/light.json5`,
-      ],
-      include: [`src/tokens/base/color/light/light.json5`],
-    },
-    // typography
-    {
-      filename: 'typography',
-      source: [`src/tokens/functional/typography/*.json`],
-      include: [`src/tokens/base/typography/*.json`],
-    },
-    // size
-    {
-      filename: 'size',
-      source: [`src/tokens/functional/size/*.json`],
-      include: [`src/tokens/base/size/*.json`],
-    },
-  ]
-  //
-  for (const {filename, source, include} of typeBuilds) {
-    PrimerStyleDictionary.extend({
-      source,
-      include,
-      platforms: {
-        types: typeDefinitions(filename, buildOptions.prefix, `${buildOptions.buildPath}ts/types/`),
-      },
-    }).buildAllPlatforms()
-  }
+  // const typeBuilds: TokenBuildInput[] = [
+  //   // color, shadow & border
+  //   {
+  //     filename: 'theme',
+  //     source: [
+  //       `src/tokens/functional/color/light/*.json5`,
+  //       `src/tokens/functional/shadow/light.json5`,
+  //       `src/tokens/functional/border/light.json5`,
+  //     ],
+  //     include: [`src/tokens/base/color/light/light.json5`],
+  //   },
+  //   // typography
+  //   {
+  //     filename: 'typography',
+  //     source: [`src/tokens/functional/typography/*.json`],
+  //     include: [`src/tokens/base/typography/*.json`],
+  //   },
+  //   // size
+  //   {
+  //     filename: 'size',
+  //     source: [`src/tokens/functional/size/*.json`],
+  //     include: [`src/tokens/base/size/*.json`],
+  //   },
+  // ]
+  // //
+  // for (const {filename, source, include} of typeBuilds) {
+  //   PrimerStyleDictionary.extend({
+  //     source,
+  //     include,
+  //     platforms: {
+  //       types: typeDefinitions(filename, buildOptions.prefix, `${buildOptions.buildPath}ts/types/`),
+  //     },
+  //   }).buildAllPlatforms()
+  // }
 
-  // build types for base scale
-  PrimerStyleDictionary.extend({
-    source: [`src/tokens/functional/color/scales.json5`],
-    include: [`src/tokens/base/color/light/light.json5`],
-    platforms: {
-      types: typeDefinitions(`baseColor`, undefined, `${buildOptions.buildPath}ts/types/`),
-    },
-  }).buildAllPlatforms()
+  // // build types for base scale
+  // PrimerStyleDictionary.extend({
+  //   source: [`src/tokens/functional/color/scales.json5`],
+  //   include: [`src/tokens/base/color/light/light.json5`],
+  //   platforms: {
+  //     types: typeDefinitions(`baseColor`, undefined, `${buildOptions.buildPath}ts/types/`),
+  //   },
+  // }).buildAllPlatforms()
 }
 
 /** -----------------------------------

--- a/scripts/buildTokens.ts
+++ b/scripts/buildTokens.ts
@@ -6,7 +6,7 @@ import {
   deprecatedJson,
   css,
   docJson,
-  // scss,
+  scss,
   // javascript,
   // typescript,
   // json,
@@ -35,7 +35,7 @@ const getStyleDictionaryConfig: StyleDictionaryConfigGenerator = (
   include,
   platforms: {
     css: css(`css/${filename}.css`, options.prefix, options.buildPath, {themed: options.themed}),
-    // scss: scss(`scss/${filename}.scss`, options.prefix, options.buildPath),
+    scss: scss(`scss/${filename}.scss`, options.prefix, options.buildPath),
     // js: javascript(`js/${filename}.js`, options.prefix, options.buildPath),
     // ts: typescript(`ts/${filename}.ts`, options.prefix, options.buildPath),
     // json: json(`json/${filename}.json`, options.prefix, options.buildPath),


### PR DESCRIPTION
## Summary

When releasing v8 we don't want user to use any platform other than `css` with `css variables`.
Not offering alternative platforms is the best way to avoid this.

## List of notable changes:

- **disabled** typeDefinitions
- **disabled** scss
- **disabled** js
- **disabled** json (not the json for docs)
- **disabled** typescript

## What should reviewers focus on?
- any reason why any of those platforms are needed?