### PR TITLE
Replace usage of errorMessages with errorsByPath

### DIFF
--- a/scripts/utilities/validateTokenWithSchema.ts
+++ b/scripts/utilities/validateTokenWithSchema.ts
@@ -3,7 +3,6 @@ import {fromZodError} from 'zod-validation-error'
 
 export type validationErrors = {
   fileName: string
-  errorMessage: string
   errorsByPath: Record<string, ZodIssue[]>
 }
 
@@ -18,7 +17,6 @@ export const validateTokenWithSchema = (
   if (!validateTypes.success) {
     return {
       fileName,
-      errorMessage: fromZodError(validateTypes.error, {prefix: '', prefixSeparator: '- '}).message.replace(/;/g, '\n-'),
       errorsByPath: fromZodError(validateTypes.error).details.reduce((acc, item) => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore

--- a/scripts/validateTokenJson.ts
+++ b/scripts/validateTokenJson.ts
@@ -65,11 +65,19 @@ if (getFlag('--silent') === null) {
     // eslint-disable-next-line no-console
     console.log(`\u001b[36;1m\u001b[1m${fail.fileName}\u001b[0m`)
     // eslint-disable-next-line no-console
-    console.log(
-      fail.errorMessage.replace(/\*\*(.*?)\*\*/g, '\u001b[31;1m\u001b[1m$1\u001b[0m').replace(/\n(?!-)/g, '\n  ↳ '),
-    )
-    // eslint-disable-next-line no-console
-    console.log('\n\n')
+    for (const path of Object.keys(fail.errorsByPath)) {
+      // eslint-disable-next-line no-console
+      console.log(`\nPath: \u001b[34;1m\u001b[1m${path}\u001b[0m`)
+      // eslint-disable-next-line no-console
+      console.log(
+        fail.errorsByPath[path]
+          .map(({message}) =>
+            message.replace(/\*\*(.*?)\*\*/g, '- \u001b[31;1m\u001b[1m$1\u001b[0m').replace(/\n(?!-)/g, '\n  ↳ '),
+          )
+          .join('\n'),
+        '\n',
+      )
+    }
   }
 }
 

--- a/src/schemas/colorHexValue.ts
+++ b/src/schemas/colorHexValue.ts
@@ -11,7 +11,7 @@ export const colorHexValue = z.string().refine(
   color => colorHexRegex.test(color),
   color => ({
     message: schemaErrorMessage(
-      `Invalid color: ${color}`,
+      `Invalid color: "${color}"`,
       'Color must be a hex string or a reference to a color token.',
     ),
   }),


### PR DESCRIPTION
## Summary

Replace usage of errorMessages with errorsByPath. 

The main benefit is to remove unused code and make the code easier to read and understand.