### PR TITLE
make @ hack work for names

### DIFF
--- a/src/transformers/namePathToCamelCase.test.ts
+++ b/src/transformers/namePathToCamelCase.test.ts
@@ -34,7 +34,7 @@ describe('Transformer: namePathToCamelCase', () => {
       }),
       getMockToken({
         name: 'tokenName',
-        path: ['start', 'PATH_tO-Token'],
+        path: ['start', 'PATH_tO-+Token'],
       }),
       getMockToken({
         name: 'tokenName',
@@ -42,6 +42,21 @@ describe('Transformer: namePathToCamelCase', () => {
       }),
     ]
     const expectedOutput = ['startPathToToken', 'startPATHTOToken', 'startPathToToken']
+    expect(input.map(item => namePathToCamelCase.transformer(item, {}))).toStrictEqual(expectedOutput)
+  })
+
+  it('removes `@`, so we can use it for the default hack', () => {
+    const input = [
+      getMockToken({
+        name: 'tokenName',
+        path: ['fgColor', 'accent', '@'],
+      }),
+      getMockToken({
+        name: 'tokenName',
+        path: ['fgColor', '@', 'muted'],
+      }),
+    ]
+    const expectedOutput = ['fgColorAccent', 'fgColorMuted']
     expect(input.map(item => namePathToCamelCase.transformer(item, {}))).toStrictEqual(expectedOutput)
   })
 

--- a/src/transformers/namePathToDotNotation.test.ts
+++ b/src/transformers/namePathToDotNotation.test.ts
@@ -45,6 +45,21 @@ describe('Transformer: namePathToDotNotation', () => {
     expect(input.map(item => namePathToDotNotation.transformer(item, {}))).toStrictEqual(expectedOutput)
   })
 
+  it('removes `@`, so we can use it for the default hack', () => {
+    const input = [
+      getMockToken({
+        name: 'tokenName',
+        path: ['fgColor', 'accent', '@'],
+      }),
+      getMockToken({
+        name: 'tokenName',
+        path: ['fgColor', '@', 'muted'],
+      }),
+    ]
+    const expectedOutput = ['fgColor.accent', 'fgColor.muted']
+    expect(input.map(item => namePathToDotNotation.transformer(item, {}))).toStrictEqual(expectedOutput)
+  })
+
   it('adds prefix to token name', () => {
     const platform = {
       prefix: 'PRIMER',

--- a/src/transformers/namePathToDotNotation.ts
+++ b/src/transformers/namePathToDotNotation.ts
@@ -26,7 +26,7 @@ export const namePathToDotNotation: StyleDictionary.Transform = {
     return (
       [options?.prefix, ...token.path]
         // remove undefined if exists
-        .filter((part: unknown): part is string => typeof part === 'string')
+        .filter((part: unknown): part is string => typeof part === 'string' && part !== '@')
         .map((part: string) => camelCase(part))
         .join('.')
     )

--- a/src/transformers/namePathToKebabCase.test.ts
+++ b/src/transformers/namePathToKebabCase.test.ts
@@ -45,6 +45,21 @@ describe('Transformer: namePathToKebabCase', () => {
     expect(input.map(item => namePathToKebabCase.transformer(item, {}))).toStrictEqual(expectedOutput)
   })
 
+  it('removes `@`, so we can use it for the default hack', () => {
+    const input = [
+      getMockToken({
+        name: 'tokenName',
+        path: ['fgColor', 'accent', '@'],
+      }),
+      getMockToken({
+        name: 'tokenName',
+        path: ['fgColor', '@', 'muted'],
+      }),
+    ]
+    const expectedOutput = ['fgColor-accent', 'fgColor-muted']
+    expect(input.map(item => namePathToKebabCase.transformer(item, {}))).toStrictEqual(expectedOutput)
+  })
+
   it('adds prefix to token name', () => {
     const platform = {
       prefix: 'PRIMER',

--- a/src/transformers/namePathToKebabCase.ts
+++ b/src/transformers/namePathToKebabCase.ts
@@ -12,7 +12,7 @@ export const namePathToKebabCase: StyleDictionary.Transform = {
     return (
       [options?.prefix, ...token.path]
         // remove undefined if exists
-        .filter((part: unknown): part is string => typeof part === 'string')
+        .filter((part: unknown): part is string => typeof part === 'string' && part !== '@')
         .join('-')
     )
   },

--- a/src/transformers/namePathToSlashNotation.test.ts
+++ b/src/transformers/namePathToSlashNotation.test.ts
@@ -45,6 +45,21 @@ describe('Transformer: namePathToSlashNotation', () => {
     expect(input.map(item => namePathToSlashNotation.transformer(item, {}))).toStrictEqual(expectedOutput)
   })
 
+  it('removes `@`, so we can use it for the default hack', () => {
+    const input = [
+      getMockToken({
+        name: 'tokenName',
+        path: ['fgColor', 'accent', '@'],
+      }),
+      getMockToken({
+        name: 'tokenName',
+        path: ['fgColor', '@', 'muted'],
+      }),
+    ]
+    const expectedOutput = ['fgColor/accent', 'fgColor/muted']
+    expect(input.map(item => namePathToSlashNotation.transformer(item, {}))).toStrictEqual(expectedOutput)
+  })
+
   it('adds prefix to token name', () => {
     const platform = {
       prefix: 'PRIMER',

--- a/src/transformers/namePathToSlashNotation.ts
+++ b/src/transformers/namePathToSlashNotation.ts
@@ -12,7 +12,7 @@ export const namePathToSlashNotation: StyleDictionary.Transform = {
     return (
       [options?.prefix, ...token.path]
         // remove undefined if exists
-        .filter((part: unknown): part is string => typeof part === 'string')
+        .filter((part: unknown): part is string => typeof part === 'string' && part !== '@')
         .join('/')
     )
   },

--- a/src/utilities/toCamelCase.ts
+++ b/src/utilities/toCamelCase.ts
@@ -7,7 +7,12 @@ export const toCamelCase = (string: string | string[]) => {
   // match unsupported characters
   const regex = /[^a-zA-Z0-9]+/g
   // replace any non-letter and non-number character and split into word array
-  const stringArray = string.filter(Boolean).join(' ').replace(regex, ' ').split(' ')
+  const stringArray = string
+    .filter(part => part !== '@')
+    .filter(Boolean)
+    .join(' ')
+    .replace(regex, ' ')
+    .split(' ')
   return (
     stringArray
       // remove undefined if exists


### PR DESCRIPTION
## Summary

using `@` in the token files now works:

e.g. `bgColor.accent.@` will be transformed to `--bgColor-accent`