### PR TITLE
Use the Primer GitHub App for auth instead of the GPR_AUTH_TOKEN_SHARED

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,15 @@ jobs:
       - name: Build experimental tokens
         run: npm run build:tokens
 
+      - id: get-access-token
+        uses: camertron/github-app-installation-auth-action@v1
+        with:
+          app-id: ${{ vars.PRIMER_ISSUE_TRIAGE_APP_ID }}
+          private-key: ${{ secrets.PRIMER_ISSUE_TRIAGE_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.PRIMER_ISSUE_TRIAGE_APP_CLIENT_ID }}
+          client-secret: ${{ secrets.PRIMER_ISSUE_TRIAGE_APP_CLIENT_SECRET }}
+          installation-id: ${{ vars.PRIMER_ISSUE_TRIAGE_APP_INSTALLATION_ID }}
+
       - name: Create release pull request or publish to npm
         id: changesets
         uses: changesets/action@v1.4.1
@@ -41,5 +50,5 @@ jobs:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: npm run release
         env:
-          GITHUB_TOKEN: ${{ secrets.GPR_AUTH_TOKEN_SHARED }}
+          GITHUB_TOKEN: ${{ steps.get-access-token.outputs.access-token }}
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}


### PR DESCRIPTION
## Summary

### What are you trying to accomplish?

This PR replaces usage of the `GPR_AUTH_TOKEN_SHARED` PAT with a token obtained through the Primer GitHub App in several CI scenarios.

Fixes https://github.com/github/primer/issues/2583