### PR TITLE
ci(release): change variable and secret names for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,11 @@ jobs:
       - id: get-access-token
         uses: camertron/github-app-installation-auth-action@v1
         with:
-          app-id: ${{ vars.PRIMER_ISSUE_TRIAGE_APP_ID }}
-          private-key: ${{ secrets.PRIMER_ISSUE_TRIAGE_APP_PRIVATE_KEY }}
-          client-id: ${{ vars.PRIMER_ISSUE_TRIAGE_APP_CLIENT_ID }}
-          client-secret: ${{ secrets.PRIMER_ISSUE_TRIAGE_APP_CLIENT_SECRET }}
-          installation-id: ${{ vars.PRIMER_ISSUE_TRIAGE_APP_INSTALLATION_ID }}
+          app-id: ${{ vars.PPRIMER_APP_CLIENT_ID_SHARED }}
+          private-key: ${{ secrets.PRIMER_APP_PRIVATE_KEY_SHARED }}
+          client-id: ${{ vars.PRIMER_APP_CLIENT_ID_SHARED }}
+          client-secret: ${{ secrets.PRIMER_APP_CLIENT_SECRET_SHARED }}
+          installation-id: ${{ vars.PRIMER_APP_INSTALLATION_ID_SHARED }}
 
       - name: Create release pull request or publish to npm
         id: changesets


### PR DESCRIPTION
We ran into an error over at: https://github.com/primer/primitives/actions/runs/6106288510/job/16571101152 in the release workflow where the error indicated that the app id was not provided. This PR is adding in the shared variables and secrets in use in other repos that I _think_ are correct but wanted to double-check with you @camertron to see if there is another set we should be using 👀 