### PR TITLE
Fix npm release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - 'main'
       - 'next_major'
+  workflow_dispatch:
+
 jobs:
   release:
     name: Final
@@ -33,15 +35,6 @@ jobs:
       - name: Build experimental tokens
         run: npm run build:tokens
 
-      - id: get-access-token
-        uses: camertron/github-app-installation-auth-action@v1
-        with:
-          app-id: ${{ vars.PRIMER_APP_ID_SHARED }}
-          private-key: ${{ secrets.PRIMER_APP_PRIVATE_KEY_SHARED }}
-          client-id: ${{ vars.PRIMER_APP_CLIENT_ID_SHARED }}
-          client-secret: ${{ secrets.PRIMER_APP_CLIENT_SECRET_SHARED }}
-          installation-id: ${{ vars.PRIMER_APP_INSTALLATION_ID_SHARED }}
-
       - name: Create release pull request or publish to npm
         id: changesets
         uses: changesets/action@v1.4.1
@@ -50,5 +43,5 @@ jobs:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: npm run release
         env:
-          GITHUB_TOKEN: ${{ steps.get-access-token.outputs.access-token }}
+          GITHUB_TOKEN: ${{ secrets.GPR_AUTH_TOKEN_SHARED }}
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}

--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -10,57 +10,9 @@ jobs:
   release-canary:
     name: Canary
     if: ${{ github.repository == 'primer/primitives' }}
-
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
-          fetch-depth: 0
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
-
-      - name: Install dependencies
-        run: npm ci --legacy-peer-deps --no-audit --no-fund --include=dev
-
-      - name: Build tokens
-        run: npm run build
-
-      - name: Build experimental tokens
-        run: npm run build:tokens
-
-      - name: Create .npmrc
-        run: |
-          cat << EOF > "$HOME/.npmrc"
-            //registry.npmjs.org/:_authToken=$NPM_TOKEN
-          EOF
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}
-
-      - name: Publish canary version
-        run: |
-          echo "$( jq '.version = "0.0.0"' package.json )" > package.json
-          echo -e "---\n'@primer/primitives': patch\n---\n\nFake entry to force publishing" > .changeset/force-snapshot-release.md
-          npx changeset version --snapshot
-          npx changeset publish --tag canary
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Output canary version number
-        uses: actions/github-script@v6.4.0
-        with:
-          script: |
-            const package = require(`${process.env.GITHUB_WORKSPACE}/package.json`)
-            github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: context.sha,
-              state: 'success',
-              context: `Published ${package.name}`,
-              description: package.version,
-              target_url: `https://unpkg.com/${package.name}@${package.version}/`
-            })
+    uses: primer/.github/.github/workflows/release_canary.yml@main
+    with:
+      install: npm ci --legacy-peer-deps --no-audit --no-fund --include=dev && npm run build && npm run build:tokens
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
+      npm_token: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}

--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -6,6 +6,12 @@ on:
       - 'changeset-release/**'
       - 'dependabot/**'
 
+permissions:
+  contents: write
+  pull-requests: write
+  checks: write
+  packages: write
+
 jobs:
   release-canary:
     name: Canary

--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -14,5 +14,5 @@ jobs:
     with:
       install: npm ci --legacy-peer-deps --no-audit --no-fund --include=dev && npm run build && npm run build:tokens
     secrets:
-      gh_token: ${{ secrets.GITHUB_TOKEN }}
+      gh_token: ${{ secrets.GPR_AUTH_TOKEN_SHARED }}
       npm_token: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 'changeset-release/**'
+  workflow_dispatch:
 
 jobs:
   release-candidate:

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@actions/github": "^5.1.1",
     "@changesets/changelog-github": "^0.4.8",
-    "@changesets/cli": "^2.22.0",
+    "@changesets/cli": "^2.26.1",
     "@github/prettier-config": "^0.0.6",
     "@playwright/test": "^1.35.1",
     "@types/flat": "^5.0.1",


### PR DESCRIPTION
## Summary

🚧 WIP

Fixing the library release to npm by using our Primer org workflow instead of a custom, local one.

## What approach did you choose and why?
- [Last two releases have failed](https://github.com/primer/primitives/actions/workflows/release.yml)
- I suspect they failed because the custom access token doesn't have the correct permission scopes for this repo, as [described here](https://github.com/changesets/changesets/issues/795#issuecomment-1631250128).
- Using the proposed token should work because it works for other Primer libraries

## What should reviewers focus on?

- We'll need to test in prod after merging by manually triggering the release. Added a command to do this via GitHub UI.


## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
- [ ] Verify the design tokens changed in this PR are expected using the diffing results in this PR
