### PR TITLE
Build v8 tokens to `/dist`

### DIFF
--- a/.changeset/wise-hornets-sin.md
+++ b/.changeset/wise-hornets-sin.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Build v8 tokens to `/dist`

--- a/scripts/buildTokens.ts
+++ b/scripts/buildTokens.ts
@@ -236,6 +236,12 @@ export const buildDesignTokens = (buildOptions: ConfigGeneratorOptions): void =>
 /** -----------------------------------
  * Run build script
  * ----------------------------------- */
+// build to private directory for backwards compatibility
 buildDesignTokens({
   buildPath: 'tokens-next-private/',
+})
+
+// build to dist
+buildDesignTokens({
+  buildPath: 'dist/',
 })


### PR DESCRIPTION
Adding the v8 tokens to `dist` so we can start updating our documentation with the final import paths. Right now `dist` will be a combination of new and old stuff, and with our next major we'll remove the legacy build for just v8 tokens. 

I left the old build in place for backwards compatibility, which we can also remove with v8. 

Do I need to update any build processes to ensure the new tokens don't get deleted from `/dist` when the old tokens build? 