### PR TITLE
ci(vrt): update workflow to use github app auth

### DIFF
--- a/.github/workflows/update_visual_snapshots.yml
+++ b/.github/workflows/update_visual_snapshots.yml
@@ -19,8 +19,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.PRIVATE_KEY }}
+          app_id: ${{ secrets.VRT_APP_ID }}
+          private_key: ${{ secrets.VRT_PRIVATE_KEY }}
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/update_visual_snapshots.yml
+++ b/.github/workflows/update_visual_snapshots.yml
@@ -15,11 +15,18 @@ jobs:
     runs-on:
       labels: ubuntu-latest-16-cores
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
+          token: ${{ steps.generate_token.outputs.token }}
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
@@ -52,5 +59,6 @@ jobs:
         with:
           commit_message: github-actions[bot] Regenerated snapshots
       - uses: actions-ecosystem/action-remove-labels@v1
+        if: always()
         with:
           labels: 'update snapshots'


### PR DESCRIPTION
Closes https://github.com/github/primer/issues/2944

## Summary

<!--
A few sentences describing the changes being proposed in this pull request.
-->

Update the visual regression update snapshots workflow to authenticate through a GitHub App

## List of notable changes:

<!--
E.g.

- **added** new design token for # because #
- **deprecated**  design token for # because #
- **updated** documentation for # because #
-->

- Update workflow to use actions/create-github-app-token and checkout using it

## Steps to test:

Most likely we'll need to test this on a PR that updates snapshots in order to fully check. I'll also add the update snapshots label to this PR to make sure it completes before merging.

## Supporting resources (related issues, external links, etc):

- https://github.com/github/primer/issues/2944

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [x] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [x] Check that tests prove the feature works and covers both happy and unhappy paths
- [x] Check that there aren't other open Pull Requests for the same update/change
- [x] Verify the design tokens changed in this PR are expected using the diffing results in this PR
