### PR TITLE
Fix `danger` `fgColor` high contrast dark

### DIFF
--- a/.changeset/brown-lobsters-scream.md
+++ b/.changeset/brown-lobsters-scream.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Fix `danger` `fgColor` high contrast dark for button

--- a/src/tokens/functional/color/dark/overrides/dark.high-contrast.json5
+++ b/src/tokens/functional/color/dark/overrides/dark.high-contrast.json5
@@ -272,6 +272,22 @@
         },
       },
     },
+    danger: {
+      fgColor: {
+        rest: {
+          $value: '{base.color.red.3}',
+          $type: 'color',
+          $extensions: {
+            'org.primer.figma': {
+              collection: 'mode',
+              mode: 'light',
+              group: 'component (internal)',
+              scopes: ['fgColor'],
+            },
+          },
+        },
+      },
+    },
   },
   buttonCounter: {
     primary: {
@@ -294,20 +310,6 @@
           $value: '{base.color.black}',
           $type: 'color',
           alpha: 0.15,
-        },
-      },
-      fgColor: {
-        rest: {
-          $value: '{base.color.red.3}',
-          $type: 'color',
-          $extensions: {
-            'org.primer.figma': {
-              collection: 'mode',
-              mode: 'light',
-              group: 'component (internal)',
-              scopes: ['fgColor'],
-            },
-          },
         },
       },
     },

--- a/src/tokens/functional/color/dark/overrides/dark.high-contrast.json5
+++ b/src/tokens/functional/color/dark/overrides/dark.high-contrast.json5
@@ -296,6 +296,20 @@
           alpha: 0.15,
         },
       },
+      fgColor: {
+        rest: {
+          $value: '{base.color.red.3}',
+          $type: 'color',
+          $extensions: {
+            'org.primer.figma': {
+              collection: 'mode',
+              mode: 'light',
+              group: 'component (internal)',
+              scopes: ['fgColor'],
+            },
+          },
+        },
+      },
     },
   },
   diffBlob: {


### PR DESCRIPTION
Noticed this during some manual testing

<img width="606" alt="dark high contrast buttons" src="https://github.com/primer/primitives/assets/18661030/c2c7fcd7-52af-4007-8d39-4d54ae521c54">
