### PR TITLE
use default border-muted value for light HC

### DIFF
--- a/src/tokens/functional/color/light/overrides/light.high-contrast.json5
+++ b/src/tokens/functional/color/light/overrides/light.high-contrast.json5
@@ -427,13 +427,7 @@
     borderColor: {
       $value: '{borderColor.muted}',
       $type: 'color',
-      $extensions: {
-        'org.primer.figma': {
-          collection: 'mode',
-          mode: 'light',
-          group: 'component (internal)',
-        },
-      },
+      alpha: null
     },
   },
 }


### PR DESCRIPTION
## Summary

Set light HC overlay border to default alpha value