### PR TITLE
Fix `primary` button text color

### DIFF
--- a/.changeset/strong-gorillas-boil.md
+++ b/.changeset/strong-gorillas-boil.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Change `primary` button text color to pure white instead of scale white (impact dark_dimmed)

--- a/src/tokens/functional/color/dark/patterns-dark.json5
+++ b/src/tokens/functional/color/dark/patterns-dark.json5
@@ -910,7 +910,7 @@
     primary: {
       fgColor: {
         rest: {
-          $value: '{base.color.white}',
+          $value: '{fgColor.white}',
           $type: 'color',
           $extensions: {
             'org.primer.figma': {
@@ -937,7 +937,7 @@
       },
       iconColor: {
         rest: {
-          $value: '{base.color.white}',
+          $value: '{fgColor.white}',
           $type: 'color',
           $extensions: {
             'org.primer.figma': {

--- a/src/tokens/functional/color/light/patterns-light.json5
+++ b/src/tokens/functional/color/light/patterns-light.json5
@@ -901,7 +901,7 @@
     primary: {
       fgColor: {
         rest: {
-          $value: '{base.color.white}',
+          $value: '{fgColor.white}',
           $type: 'color',
           $extensions: {
             'org.primer.figma': {
@@ -928,7 +928,7 @@
       },
       iconColor: {
         rest: {
-          $value: '{base.color.white}',
+          $value: '{fgColor.white}',
           $type: 'color',
           $extensions: {
             'org.primer.figma': {


### PR DESCRIPTION
In the old token build, the Primary button has a hardcoded `#ffffff` white value. It looks too dim in `dark_dimmed` using scale white.