### PR TITLE
Add display color tokens to functional patterns-light.json5

### DIFF
--- a/src/tokens/functional/color/light/patterns-display-light.json5
+++ b/src/tokens/functional/color/light/patterns-display-light.json5
@@ -1,0 +1,1035 @@
+{
+  display-blue: {
+    bgColor: {
+      muted: {
+        $value: '{base.display.color.blue.0}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.blue.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+    },
+    fgColor: {
+      $value: '{base.display.color.blue.6}',
+      $type: 'color',
+      $extensions: {
+        'org.primer.figma': {
+          collection: 'mode',
+          mode: 'light',
+          group: 'component (internal)',
+          scopes: ['fgColor'],
+        },
+      },
+    },
+    borderColor: {
+      muted: {
+        $value: '{base.display.color.blue.1}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.blue.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+    },
+  },
+  display-green: {
+    bgColor: {
+      muted: {
+        $value: '{base.display.color.green.0}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.green.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+    },
+    fgColor: {
+      $value: '{base.display.color.green.6}',
+      $type: 'color',
+      $extensions: {
+        'org.primer.figma': {
+          collection: 'mode',
+          mode: 'light',
+          group: 'component (internal)',
+          scopes: ['fgColor'],
+        },
+      },
+    },
+    borderColor: {
+      muted: {
+        $value: '{base.display.color.green.1}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.green.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+    },
+  },
+  display-orange: {
+    bgColor: {
+      muted: {
+        $value: '{base.display.color.orange.0}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.orange.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+    },
+    fgColor: {
+      $value: '{base.display.color.orange.6}',
+      $type: 'color',
+      $extensions: {
+        'org.primer.figma': {
+          collection: 'mode',
+          mode: 'light',
+          group: 'component (internal)',
+          scopes: ['fgColor'],
+        },
+      },
+    },
+    borderColor: {
+      muted: {
+        $value: '{base.display.color.orange.1}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.orange.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+    },
+  },
+  display-purple: {
+    bgColor: {
+      muted: {
+        $value: '{base.display.color.purple.0}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.purple.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+    },
+    fgColor: {
+      $value: '{base.display.color.purple.6}',
+      $type: 'color',
+      $extensions: {
+        'org.primer.figma': {
+          collection: 'mode',
+          mode: 'light',
+          group: 'component (internal)',
+          scopes: ['fgColor'],
+        },
+      },
+    },
+    borderColor: {
+      muted: {
+        $value: '{base.display.color.purple.1}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.purple.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+    },
+  },
+  display-red: {
+    bgColor: {
+      muted: {
+        $value: '{base.display.color.red.0}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.red.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+    },
+    fgColor: {
+      $value: '{base.display.color.red.6}',
+      $type: 'color',
+      $extensions: {
+        'org.primer.figma': {
+          collection: 'mode',
+          mode: 'light',
+          group: 'component (internal)',
+          scopes: ['fgColor'],
+        },
+      },
+    },
+    borderColor: {
+      muted: {
+        $value: '{base.display.color.red.1}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.red.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+    },
+  },
+  display-yellow: {
+    bgColor: {
+      muted: {
+        $value: '{base.display.color.yellow.0}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.yellow.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+    },
+    fgColor: {
+      $value: '{base.display.color.yellow.6}',
+      $type: 'color',
+      $extensions: {
+        'org.primer.figma': {
+          collection: 'mode',
+          mode: 'light',
+          group: 'component (internal)',
+          scopes: ['fgColor'],
+        },
+      },
+    },
+    borderColor: {
+      muted: {
+        $value: '{base.display.color.yellow.1}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.yellow.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+    },
+  },
+  display-gray: {
+    bgColor: {
+      muted: {
+        $value: '{base.display.color.gray.0}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.gray.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+    },
+    fgColor: {
+      $value: '{base.display.color.gray.6}',
+      $type: 'color',
+      $extensions: {
+        'org.primer.figma': {
+          collection: 'mode',
+          mode: 'light',
+          group: 'component (internal)',
+          scopes: ['fgColor'],
+        },
+      },
+    },
+    borderColor: {
+      muted: {
+        $value: '{base.display.color.gray.1}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.gray.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+    },
+  },
+  display-auburn: {
+    bgColor: {
+      muted: {
+        $value: '{base.display.color.auburn.0}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.auburn.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+    },
+    fgColor: {
+      $value: '{base.display.color.auburn.6}',
+      $type: 'color',
+      $extensions: {
+        'org.primer.figma': {
+          collection: 'mode',
+          mode: 'light',
+          group: 'component (internal)',
+          scopes: ['fgColor'],
+        },
+      },
+    },
+    borderColor: {
+      muted: {
+        $value: '{base.display.color.auburn.1}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.auburn.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+    },
+  },
+  display-brown: {
+    bgColor: {
+      muted: {
+        $value: '{base.display.color.brown.0}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.brown.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+    },
+    fgColor: {
+      $value: '{base.display.color.brown.6}',
+      $type: 'color',
+      $extensions: {
+        'org.primer.figma': {
+          collection: 'mode',
+          mode: 'light',
+          group: 'component (internal)',
+          scopes: ['fgColor'],
+        },
+      },
+    },
+    borderColor: {
+      muted: {
+        $value: '{base.display.color.brown.1}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.brown.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+    },
+  },
+  display-lemon: {
+    bgColor: {
+      muted: {
+        $value: '{base.display.color.lemon.0}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.lemon.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+    },
+    fgColor: {
+      $value: '{base.display.color.lemon.6}',
+      $type: 'color',
+      $extensions: {
+        'org.primer.figma': {
+          collection: 'mode',
+          mode: 'light',
+          group: 'component (internal)',
+          scopes: ['fgColor'],
+        },
+      },
+    },
+    borderColor: {
+      muted: {
+        $value: '{base.display.color.lemon.1}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.lemon.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+    },
+  },
+  display-olive: {
+    bgColor: {
+      muted: {
+        $value: '{base.display.color.olive.0}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.olive.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+    },
+    fgColor: {
+      $value: '{base.display.color.olive.6}',
+      $type: 'color',
+      $extensions: {
+        'org.primer.figma': {
+          collection: 'mode',
+          mode: 'light',
+          group: 'component (internal)',
+          scopes: ['fgColor'],
+        },
+      },
+    },
+    borderColor: {
+      muted: {
+        $value: '{base.display.color.olive.1}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.olive.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+    },
+  },
+  display-lime: {
+    bgColor: {
+      muted: {
+        $value: '{base.display.color.lime.0}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.lime.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+    },
+    fgColor: {
+      $value: '{base.display.color.lime.6}',
+      $type: 'color',
+      $extensions: {
+        'org.primer.figma': {
+          collection: 'mode',
+          mode: 'light',
+          group: 'component (internal)',
+          scopes: ['fgColor'],
+        },
+      },
+    },
+    borderColor: {
+      muted: {
+        $value: '{base.display.color.lime.1}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.lime.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+    },
+  },
+  display-pine: {
+    bgColor: {
+      muted: {
+        $value: '{base.display.color.pine.0}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.pine.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+    },
+    fgColor: {
+      $value: '{base.display.color.pine.6}',
+      $type: 'color',
+      $extensions: {
+        'org.primer.figma': {
+          collection: 'mode',
+          mode: 'light',
+          group: 'component (internal)',
+          scopes: ['fgColor'],
+        },
+      },
+    },
+    borderColor: {
+      muted: {
+        $value: '{base.display.color.pine.1}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.pine.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+    },
+  },
+  display-teal: {
+    bgColor: {
+      muted: {
+        $value: '{base.display.color.teal.0}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.teal.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+    },
+    fgColor: {
+      $value: '{base.display.color.teal.6}',
+      $type: 'color',
+      $extensions: {
+        'org.primer.figma': {
+          collection: 'mode',
+          mode: 'light',
+          group: 'component (internal)',
+          scopes: ['fgColor'],
+        },
+      },
+    },
+    borderColor: {
+      muted: {
+        $value: '{base.display.color.teal.1}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.teal.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+    },
+  },
+  display-cyan: {
+    bgColor: {
+      muted: {
+        $value: '{base.display.color.cyan.0}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.cyan.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+    },
+    fgColor: {
+      $value: '{base.display.color.cyan.6}',
+      $type: 'color',
+      $extensions: {
+        'org.primer.figma': {
+          collection: 'mode',
+          mode: 'light',
+          group: 'component (internal)',
+          scopes: ['fgColor'],
+        },
+      },
+    },
+    borderColor: {
+      muted: {
+        $value: '{base.display.color.cyan.1}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.cyan.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['borderColor'],
+          },
+        },
+      },
+    },
+  },
+  display-indigo: {
+    bgColor: {
+      muted: {
+        $value: '{base.display.color.indigo.0}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+      emphasis: {
+        $value: '{base.display.color.indigo.5}',
+        $type: 'color',
+        $extensions: {
+          'org.primer.figma': {
+            collection: 'mode',
+            mode: 'light',
+            group: 'component (internal)',
+            scopes: ['bgColor'],
+          },
+        },
+      },
+    },
+    fgColor: {
+      $value: '{base.display.color.indigo.6}',
+      $type: 'color',
+      $extensions: {
+        'org.primer.figma': {
+          collection: 'mode',
+          mode: 'light',
+          group: 'component (internal)',
+          scopes: ['fgColor'],
+        },
+      },
+    },
+    borderColor: {
+      muted: {
+        $value: '{base.display.color.indigo.1}',
+        $type: 'color',
+        $extensions


### PR DESCRIPTION
Add display color tokens to functional patterns-light.json5

This PR was created with Copilot Workspace (v0.15). For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/primer/primitives?shareId=8dbfae90-d015-4f93-862e-7ef451b4eeee).