### PR TITLE
Adding src to output

### DIFF
--- a/.changeset/cool-trains-shake.md
+++ b/.changeset/cool-trains-shake.md
@@ -1,0 +1,5 @@
+---
+'@primer/primitives': minor
+---
+
+Adding src to output so it can be reused by other packages

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "tokens-v2-private",
     "tokens-next-private",
     "build.js",
-    "tokens/"
+    "tokens/",
+    "src/**/*",
+    "!src/**/*.test.ts"
   ],
   "main": "dist/js/index.js",
   "types": "dist/js/index.d.ts",


### PR DESCRIPTION
## Summary

This PR adds the `src` folder to the output (`dist`) so that it can be used by other packages.

