### PR TITLE
Replace action that generates a token with `secrets.GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,15 +30,6 @@ jobs:
       - name: Build tokens
         run: npm run build:next
 
-      - id: get-access-token
-        uses: camertron/github-app-installation-auth-action@v1
-        with:
-          app-id: ${{ vars.PRIMER_APP_ID_SHARED }}
-          private-key: ${{ secrets.PRIMER_APP_PRIVATE_KEY_SHARED }}
-          client-id: ${{ vars.PRIMER_APP_CLIENT_ID_SHARED }}
-          client-secret: ${{ secrets.PRIMER_APP_CLIENT_SECRET_SHARED }}
-          installation-id: ${{ vars.PRIMER_APP_INSTALLATION_ID_SHARED }}
-
       - name: Create release pull request or publish to npm
         id: changesets
         uses: changesets/action@v1.4.7
@@ -48,7 +39,7 @@ jobs:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: npm run release
         env:
-          GITHUB_TOKEN: ${{ steps.get-access-token.outputs.access-token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}
 
       - name: Output release version to summary


### PR DESCRIPTION
## Summary

The goal of this PR is to remove a dependency of a repo outside of primer/github.