### PR TITLE
Fix trigger for diff-v8 action

### DIFF
--- a/.github/workflows/diff-v8.yml
+++ b/.github/workflows/diff-v8.yml
@@ -12,7 +12,7 @@ jobs:
 
   diff:
     needs: changes
-    if: needs.changes.outputs.tokens == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.changes.outputs.outputAffected == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

It should also run if we change the build scripts but not the tokens.