### PR TITLE
Added missing prop which lead to wrong output for subtitle line-height in Figma

### DIFF
--- a/.changeset/soft-wolves-ring.md
+++ b/.changeset/soft-wolves-ring.md
@@ -1,0 +1,5 @@
+---
+'@primer/primitives': patch
+---
+
+Added missing prop which lead to wrong output for subtitle line-height in Figma

--- a/src/tokens/functional/typography/typography.json
+++ b/src/tokens/functional/typography/typography.json
@@ -245,6 +245,9 @@
         "$value": 1.6,
         "$type": "number",
         "$extensions": {
+          "org.primer.data": {
+            "fontSize": 20
+          },
           "org.primer.figma": {
             "collection": "typography",
             "scopes": ["all"]


### PR DESCRIPTION
## Summary

Added missing prop which lead to wrong output for subtitle line-height in Figma