### PR TITLE
allow for deprecated property on tokens

### DIFF
--- a/src/schemas/baseToken.ts
+++ b/src/schemas/baseToken.ts
@@ -3,5 +3,6 @@ import {z} from 'zod'
 export const baseToken = z
   .object({
     $description: z.string().optional(),
+    deprecated: z.union([z.string(), z.boolean()]).optional(),
   })
   .strict()


### PR DESCRIPTION
## Summary

Updated `zod` json validation to allow for a `deprecated` property with either a boolean or a string value.