### PR TITLE
Combine common files and themes into single files for distribution

### DIFF
--- a/.changeset/rare-spies-taste.md
+++ b/.changeset/rare-spies-taste.md
@@ -1,0 +1,5 @@
+---
+'@primer/primitives': minor
+---
+
+Combine common files into single file for distribution

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@primer/primitives",
-  "version": "8.0.0",
+  "version": "8.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@primer/primitives",
-      "version": "8.0.0",
+      "version": "8.2.0",
       "license": "MIT",
       "devDependencies": {
         "@actions/github": "^6.0.0",

--- a/scripts/buildTokens.ts
+++ b/scripts/buildTokens.ts
@@ -6,6 +6,7 @@ import type {ConfigGeneratorOptions, StyleDictionaryConfigGenerator} from '../sr
 import type {TokenBuildInput} from '../src/types/TokenBuildInput'
 import glob from 'fast-glob'
 import {themes} from './themes.config'
+import fs from 'fs'
 
 /**
  * getStyleDictionaryConfig
@@ -212,6 +213,14 @@ export const buildDesignTokens = (buildOptions: ConfigGeneratorOptions): void =>
    * Copy `removed` files
    * ----------------------------------- */
   copyFromDir(`src/tokens/removed`, `${buildOptions.buildPath}removed`)
+  /** -----------------------------------
+   * Roll up
+   * ----------------------------------- */
+  const contents = glob.sync('dist/css/{base,functional}/{motion,size,typography}/**/*.css').map(path => {
+    return fs.readFileSync(path, 'utf8').trim()
+  })
+
+  fs.writeFileSync('dist/css/primer.css', `${contents.join('\n')}\n`)
 }
 
 /** -----------------------------------

--- a/scripts/buildTokens.ts
+++ b/scripts/buildTokens.ts
@@ -7,6 +7,7 @@ import type {TokenBuildInput} from '../src/types/TokenBuildInput'
 import glob from 'fast-glob'
 import {themes} from './themes.config'
 import fs from 'fs'
+import path from 'path'
 
 /**
  * getStyleDictionaryConfig
@@ -215,22 +216,23 @@ export const buildDesignTokens = (buildOptions: ConfigGeneratorOptions): void =>
   copyFromDir(`src/tokens/removed`, `${buildOptions.buildPath}removed`)
 
   /** -----------------------------------
-   * Roll up common files
+   * Roll up
    * ----------------------------------- */
-  const commonContents = glob.sync('dist/css/{base,functional}/{motion,size,typography}/**/*.css').map(path => {
-    return fs.readFileSync(path, 'utf8').trim()
+  for (const dir of glob.sync('dist/css/{base,functional}/{motion,size,typography,themes}', {onlyDirectories: true})) {
+    const contents = glob.sync(path.join(dir, '**/*.css')).map(cssFile => {
+      return fs.readFileSync(cssFile, 'utf8').trim()
+    })
+
+    if (contents.length > 0) {
+      fs.writeFileSync(`${dir}.css`, `${contents.join('\n')}\n`)
+    }
+  }
+
+  const commonContents = glob.sync('dist/css/{base,functional}/{motion,size,typography}/**/*.css').map(cssFile => {
+    return fs.readFileSync(cssFile, 'utf8').trim()
   })
 
   fs.writeFileSync('dist/css/primer.css', `${commonContents.join('\n')}\n`)
-
-  /** -----------------------------------
-   * Roll up themes
-   * ----------------------------------- */
-  const themeContents = glob.sync('dist/css/functional/themes/*.css').map(path => {
-    return fs.readFileSync(path, 'utf8').trim()
-  })
-
-  fs.writeFileSync('dist/css/functional/themes/all.css', `${themeContents.join('\n')}\n`)
 }
 
 /** -----------------------------------

--- a/scripts/buildTokens.ts
+++ b/scripts/buildTokens.ts
@@ -213,14 +213,24 @@ export const buildDesignTokens = (buildOptions: ConfigGeneratorOptions): void =>
    * Copy `removed` files
    * ----------------------------------- */
   copyFromDir(`src/tokens/removed`, `${buildOptions.buildPath}removed`)
+
   /** -----------------------------------
-   * Roll up
+   * Roll up common files
    * ----------------------------------- */
-  const contents = glob.sync('dist/css/{base,functional}/{motion,size,typography}/**/*.css').map(path => {
+  const commonContents = glob.sync('dist/css/{base,functional}/{motion,size,typography}/**/*.css').map(path => {
     return fs.readFileSync(path, 'utf8').trim()
   })
 
-  fs.writeFileSync('dist/css/primer.css', `${contents.join('\n')}\n`)
+  fs.writeFileSync('dist/css/primer.css', `${commonContents.join('\n')}\n`)
+
+  /** -----------------------------------
+   * Roll up themes
+   * ----------------------------------- */
+  const themeContents = glob.sync('dist/css/functional/themes/*.css').map(path => {
+    return fs.readFileSync(path, 'utf8').trim()
+  })
+
+  fs.writeFileSync('dist/css/functional/themes/all.css', `${themeContents.join('\n')}\n`)
 }
 
 /** -----------------------------------


### PR DESCRIPTION
## Summary

<!--
A few sentences describing the changes being proposed in this pull request.
-->

Another Hubber and I were trying to set up primer/view_components in a new Rails app and ran into issues getting all the correct CSS on the page. One of the issues we had was pulling in primitives. We ended up copy/pasting this from Lookbook's CSS, which also includes a bunch of files from primer/css:

```
 *= require @primer/primitives/dist/css/base/size/size.css
 *= require @primer/primitives/dist/css/base/typography/typography.css
 *= require @primer/primitives/dist/css/functional/size/border.css
 *= require @primer/primitives/dist/css/functional/size/breakpoints.css
 *= require @primer/primitives/dist/css/functional/size/size-coarse.css
 *= require @primer/primitives/dist/css/functional/size/size-fine.css
 *= require @primer/primitives/dist/css/functional/size/size.css
 *= require @primer/primitives/dist/css/functional/size/viewport.css
 *= require @primer/primitives/dist/css/functional/typography/typography.css
 *= require @primer/primitives/dist/css/functional/themes/dark-colorblind.css
 *= require @primer/primitives/dist/css/functional/themes/dark-dimmed.css
 *= require @primer/primitives/dist/css/functional/themes/dark-high-contrast.css
 *= require @primer/primitives/dist/css/functional/themes/dark-tritanopia.css
 *= require @primer/primitives/dist/css/functional/themes/dark.css
 *= require @primer/primitives/dist/css/functional/themes/light-colorblind.css
 *= require @primer/primitives/dist/css/functional/themes/light-high-contrast.css
 *= require @primer/primitives/dist/css/functional/themes/light-tritanopia.css
 *= require @primer/primitives/dist/css/functional/themes/light.css
 *= require @primer/css/dist/base.css
 *= require @primer/css/dist/buttons.css
 *= require @primer/css/dist/layout.css
 *= require @primer/css/dist/utilities.css
 *= require @primer/css/dist/markdown.css
```

Wow, that's so many files! The average consumer is not going to know (or care) which files they need to include, hence the reason for this PR.

## List of notable changes:

<!--
E.g.

- **added** new design token for # because #
- **deprecated**  design token for # because #
- **updated** documentation for # because #
-->

- Updates the buildTokens.ts script to roll up all the common files in dist/css/base and dist/css/functional into a single css file at dist/css/primer.css, to match what primer/css does.
- Updates the buildTokens.ts script to roll up all the theme files in dist/css/functional/themes into a single css file at dist/css/functional/themes/all.css.

Now, bootstrapping a new app can be done with just a few lines:

```
 *= require @primer/primitives/dist/css/primer.css
 *= require @primer/primitives/dist/css/functional/themes/all.css
 *= require @primer/css/dist/primer.css
```

## What should reviewers focus on?

- Please help me understand if I'm doing something wrong or unnecessary - I barely understand primitives as it is 😅 

## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

1. Add the canary package to a Rails app and run `npm install`, or use a local checkout via `npm link`.
2. Add primer/css to the Rails app
3. Render a Rails component in the app and ensure the colors, spacing, and typography look correct

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
- [ ] Verify the design tokens changed in this PR are expected using the diffing results in this PR
