### PR TITLE
Add default border radius

### DIFF
--- a/.changeset/wet-grapes-eat.md
+++ b/.changeset/wet-grapes-eat.md
@@ -1,0 +1,5 @@
+---
+'@primer/primitives': patch
+---
+
+add borderRadius.default token

--- a/src/tokens/functional/size/border.json
+++ b/src/tokens/functional/size/border.json
@@ -81,6 +81,19 @@
           }
         }
       }
+    },
+    "default": {
+      "$value": "{borderRadius.medium}",
+      "$type": "dimension",
+      "$extensions": {
+        "org.primer.figma": {
+          "collection": "functional/size",
+          "scopes": ["radius"],
+          "codeSyntax": {
+            "web": "var(--borderRadius-default) /* utility class: .rounded-2 */"
+          }
+        }
+      }
     }
   },
   "outline": {


### PR DESCRIPTION
## Summary

I actually only found borderRadius as a useful case for adding a `default`. Do you have other ideas?

Our sizes are cut into very small sections. If we ever refactor them there may be a case, but at the moment it does not seem helpful.

This resolves https://github.com/github/primer/issues/3456