### PR TITLE
Reset onEmphasis in dark HC to be white

### DIFF
--- a/.changeset/rude-camels-relate.md
+++ b/.changeset/rude-camels-relate.md
@@ -1,0 +1,5 @@
+---
+'@primer/primitives': patch
+---
+
+Reset onEmphasis to white for dark HC to align with all other modes

--- a/src/tokens/functional/color/dark/overrides/dark.high-contrast.json5
+++ b/src/tokens/functional/color/dark/overrides/dark.high-contrast.json5
@@ -551,7 +551,7 @@
     blue: {
       bgColor: {
         emphasis: {
-          $value: '{base.display.color.blue.6}',
+          $value: '{base.display.color.blue.3}',
           $type: 'color',
         },
       },
@@ -569,7 +569,7 @@
     indigo: {
       bgColor: {
         emphasis: {
-          $value: '{base.display.color.indigo.6}',
+          $value: '{base.display.color.indigo.3}',
           $type: 'color',
         },
       },
@@ -587,7 +587,7 @@
     gray: {
       bgColor: {
         emphasis: {
-          $value: '{base.display.color.gray.6}',
+          $value: '{base.display.color.gray.3}',
           $type: 'color',
         },
       },
@@ -605,7 +605,7 @@
     cyan: {
       bgColor: {
         emphasis: {
-          $value: '{base.display.color.cyan.6}',
+          $value: '{base.display.color.cyan.3}',
           $type: 'color',
         },
       },
@@ -623,7 +623,7 @@
     teal: {
       bgColor: {
         emphasis: {
-          $value: '{base.display.color.teal.6}',
+          $value: '{base.display.color.teal.3}',
           $type: 'color',
         },
       },
@@ -641,7 +641,7 @@
     pine: {
       bgColor: {
         emphasis: {
-          $value: '{base.display.color.pine.6}',
+          $value: '{base.display.color.pine.3}',
           $type: 'color',
         },
       },
@@ -659,7 +659,7 @@
     green: {
       bgColor: {
         emphasis: {
-          $value: '{base.display.color.green.6}',
+          $value: '{base.display.color.green.3}',
           $type: 'color',
         },
       },
@@ -677,7 +677,7 @@
     lime: {
       bgColor: {
         emphasis: {
-          $value: '{base.display.color.lime.6}',
+          $value: '{base.display.color.lime.3}',
           $type: 'color',
         },
       },
@@ -695,7 +695,7 @@
     olive: {
       bgColor: {
         emphasis: {
-          $value: '{base.display.color.olive.6}',
+          $value: '{base.display.color.olive.3}',
           $type: 'color',
         },
       },
@@ -713,7 +713,7 @@
     lemon: {
       bgColor: {
         emphasis: {
-          $value: '{base.display.color.lemon.6}',
+          $value: '{base.display.color.lemon.3}',
           $type: 'color',
         },
       },
@@ -731,7 +731,7 @@
     yellow: {
       bgColor: {
         emphasis: {
-          $value: '{base.display.color.yellow.6}',
+          $value: '{base.display.color.yellow.3}',
           $type: 'color',
         },
       },
@@ -749,7 +749,7 @@
     orange: {
       bgColor: {
         emphasis: {
-          $value: '{base.display.color.orange.6}',
+          $value: '{base.display.color.orange.3}',
           $type: 'color',
         },
       },
@@ -767,7 +767,7 @@
     red: {
       bgColor: {
         emphasis: {
-          $value: '{base.display.color.red.6}',
+          $value: '{base.display.color.red.3}',
           $type: 'color',
         },
       },
@@ -785,7 +785,7 @@
     coral: {
       bgColor: {
         emphasis: {
-          $value: '{base.display.color.coral.6}',
+          $value: '{base.display.color.coral.3}',
           $type: 'color',
         },
       },
@@ -803,7 +803,7 @@
     pink: {
       bgColor: {
         emphasis: {
-          $value: '{base.display.color.pink.6}',
+          $value: '{base.display.color.pink.3}',
           $type: 'color',
         },
       },
@@ -821,7 +821,7 @@
     plum: {
       bgColor: {
         emphasis: {
-          $value: '{base.display.color.plum.6}',
+          $value: '{base.display.color.plum.3}',
           $type: 'color',
         },
       },
@@ -839,7 +839,7 @@
     purple: {
       bgColor: {
         emphasis: {
-          $value: '{base.display.color.purple.6}',
+          $value: '{base.display.color.purple.3}',
           $type: 'color',
         },
       },
@@ -857,7 +857,7 @@
     brown: {
       bgColor: {
         emphasis: {
-          $value: '{base.display.color.brown.6}',
+          $value: '{base.display.color.brown.3}',
           $type: 'color',
         },
       },
@@ -875,7 +875,7 @@
     auburn: {
       bgColor: {
         emphasis: {
-          $value: '{base.display.color.auburn.6}',
+          $value: '{base.display.color.auburn.3}',
           $type: 'color',
         },
       },

--- a/src/tokens/functional/color/dark/overrides/dark.high-contrast.json5
+++ b/src/tokens/functional/color/dark/overrides/dark.high-contrast.json5
@@ -64,7 +64,7 @@
         alpha: 0.1,
       },
       emphasis: {
-        $value: '{base.color.neutral.4}',
+        $value: '{base.color.neutral.6}',
         $type: 'color',
       },
     },
@@ -75,7 +75,7 @@
         alpha: 0.1,
       },
       emphasis: {
-        $value: '{base.color.blue.4}',
+        $value: '{base.color.blue.9}',
         $type: 'color',
       },
     },
@@ -86,7 +86,7 @@
         alpha: 0.14,
       },
       emphasis: {
-        $value: '{base.color.green.4}',
+        $value: '{base.color.green.9}',
         $type: 'color',
       },
     },
@@ -104,7 +104,7 @@
         alpha: 0.09,
       },
       emphasis: {
-        $value: '{base.color.red.4}',
+        $value: '{base.color.red.9}',
         $type: 'color',
       },
     },
@@ -122,13 +122,13 @@
         alpha: 0.088,
       },
       emphasis: {
-        $value: '{base.color.orange.4}',
+        $value: '{base.color.orange.9}',
         $type: 'color',
       },
     },
     attention: {
       emphasis: {
-        $value: '{base.color.yellow.4}',
+        $value: '{base.color.yellow.9}',
         $type: 'color',
       },
     },
@@ -139,15 +139,8 @@
         alpha: 0.09,
       },
       emphasis: {
-        $value: '{base.color.purple.4}',
+        $value: '{base.color.purple.9}',
         $type: 'color',
-      },
-    },
-    upsell: {
-      muted: {
-        $value: '{bgColor.done.muted}',
-        $type: 'color',
-        alpha: 0.09,
       },
     },
     upsell: {
@@ -164,7 +157,7 @@
         alpha: 0.09,
       },
       emphasis: {
-        $value: '{base.color.pink.4}',
+        $value: '{base.color.pink.9}',
         $type: 'color',
       },
     },

--- a/src/tokens/functional/color/dark/overrides/dark.high-contrast.json5
+++ b/src/tokens/functional/color/dark/overrides/dark.high-contrast.json5
@@ -5,10 +5,6 @@
  */
 {
   fgColor: {
-    onEmphasis: {
-      $value: '{base.color.neutral.9}',
-      $type: 'color',
-    },
     muted: {
       $value: '{base.color.neutral.1}',
       $type: 'color',


### PR DESCRIPTION
## Summary

This PR resolves https://github.com/github/primer/issues/3410 by resetting the `onEmphasis` color in the dark high contrast theme to white.
