### PR TITLE
Bug fix: `invisible` text color

### DIFF
--- a/src/tokens/functional/color/dark/patterns-dark.json5
+++ b/src/tokens/functional/color/dark/patterns-dark.json5
@@ -1064,7 +1064,7 @@
     invisible: {
       fgColor: {
         rest: {
-          $value: '{fgColor.muted}',
+          $value: '{control.fgColor.rest}',
           $type: 'color',
           $extensions: {
             'org.primer.figma': {
@@ -1076,7 +1076,7 @@
           },
         },
         hover: {
-          $value: '{fgColor.muted}',
+          $value: '{control.fgColor.rest}',
           $type: 'color',
           $extensions: {
             'org.primer.figma': {

--- a/src/tokens/functional/color/light/patterns-light.json5
+++ b/src/tokens/functional/color/light/patterns-light.json5
@@ -1056,7 +1056,7 @@
     invisible: {
       fgColor: {
         rest: {
-          $value: '{fgColor.muted}',
+          $value: '{control.fgColor.rest}',
           $type: 'color',
           $extensions: {
             'org.primer.figma': {
@@ -1068,7 +1068,7 @@
           },
         },
         hover: {
-          $value: '{fgColor.muted}',
+          $value: '{control.fgColor.rest}',
           $type: 'color',
           $extensions: {
             'org.primer.figma': {


### PR DESCRIPTION
In the major I swapped from blue (everyone always overrode this) to `muted`, and now I'm moving to `default`. This aligns with our design documentation and works better with icons.