### PR TITLE
Fix `danger` fgColor

### DIFF
--- a/.changeset/eleven-kangaroos-visit.md
+++ b/.changeset/eleven-kangaroos-visit.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Fix `danger` fgColor in colorblind theme

--- a/src/tokens/functional/color/dark/overrides/dark.protanopia-deuteranopia.json5
+++ b/src/tokens/functional/color/dark/overrides/dark.protanopia-deuteranopia.json5
@@ -168,7 +168,6 @@
           $value: '{fgColor.danger}',
           $type: 'color',
         },
-        }
       },
       bgColor: {
         hover: {

--- a/src/tokens/functional/color/dark/overrides/dark.protanopia-deuteranopia.json5
+++ b/src/tokens/functional/color/dark/overrides/dark.protanopia-deuteranopia.json5
@@ -163,6 +163,13 @@
       },
     },
     danger: {
+      fgColor: {
+        rest: {
+          $value: '{fgColor.danger}',
+          $type: 'color',
+        },
+        }
+      },
       bgColor: {
         hover: {
           $value: '{base.color.orange.6}',


### PR DESCRIPTION
I recently changed the default color to a scale `red` variable, and forgot to fix the override in the colorblind theme.