### PR TITLE
use the official $deprecated property now

### DIFF
--- a/.changeset/lemon-donuts-protect.md
+++ b/.changeset/lemon-donuts-protect.md
@@ -1,0 +1,5 @@
+---
+'@primer/primitives': patch
+---
+
+Replace `deprecated` prop with `$deprecated` which is the w3c standard

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "devDependencies": {
         "@actions/core": "^1.11.1",
-        "@actions/github": "^6.0.0",
         "@actions/glob": "^0.5.0",
         "@changesets/changelog-github": "^0.5.0",
         "@changesets/cli": "^2.27.7",
@@ -62,18 +61,6 @@
       "dev": true,
       "dependencies": {
         "@actions/io": "^1.0.1"
-      }
-    },
-    "node_modules/@actions/github": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.0.tgz",
-      "integrity": "sha512-alScpSVnYmjNEXboZjarjukQEzgCRmjMv6Xj47fsdnqGS73bjJNDpiiXmp8jr0UZLdUB6d9jW63IcmddUP+l0g==",
-      "dev": true,
-      "dependencies": {
-        "@actions/http-client": "^2.2.0",
-        "@octokit/core": "^5.0.1",
-        "@octokit/plugin-paginate-rest": "^9.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "^10.0.0"
       }
     },
     "node_modules/@actions/glob": {
@@ -1208,164 +1195,6 @@
         "node": "^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/@octokit/auth-token": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
-      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/core": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
-      "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/auth-token": "^4.0.0",
-        "@octokit/graphql": "^7.1.0",
-        "@octokit/request": "^8.3.1",
-        "@octokit/request-error": "^5.1.0",
-        "@octokit/types": "^13.0.0",
-        "before-after-hook": "^2.2.0",
-        "universal-user-agent": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/endpoint": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.5.tgz",
-      "integrity": "sha512-ekqR4/+PCLkEBF6qgj8WqJfvDq65RH85OAgrtnVp1mSxaXF03u2xW/hUdweGS5654IlC0wkNYC18Z50tSYTAFw==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/types": "^13.1.0",
-        "universal-user-agent": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/graphql": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.0.tgz",
-      "integrity": "sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/request": "^8.3.0",
-        "@octokit/types": "^13.0.0",
-        "universal-user-agent": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/openapi-types": {
-      "version": "22.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
-      "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
-      "dev": true
-    },
-    "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.1.tgz",
-      "integrity": "sha512-wfGhE/TAkXZRLjksFXuDZdmGnJQHvtU/joFQdweXUgzo1XwvBCD4o4+75NtFfjfLK5IwLf9vHTfSiU3sLRYpRw==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/types": "^12.6.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@octokit/core": "5"
-      }
-    },
-    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
-      "dev": true
-    },
-    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
-      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/openapi-types": "^20.0.0"
-      }
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
-      "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/types": "^12.6.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@octokit/core": "5"
-      }
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
-      "dev": true
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
-      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/openapi-types": "^20.0.0"
-      }
-    },
-    "node_modules/@octokit/request": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.0.tgz",
-      "integrity": "sha512-9Bb014e+m2TgBeEJGEbdplMVWwPmL1FPtggHQRkV+WVsMggPtEkLKPlcVYm/o8xKLkpJ7B+6N8WfQMtDLX2Dpw==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/endpoint": "^9.0.1",
-        "@octokit/request-error": "^5.1.0",
-        "@octokit/types": "^13.1.0",
-        "universal-user-agent": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/request-error": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.0.tgz",
-      "integrity": "sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/types": "^13.1.0",
-        "deprecation": "^2.0.0",
-        "once": "^1.4.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/types": {
-      "version": "13.6.1",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.6.1.tgz",
-      "integrity": "sha512-PHZE9Z+kWXb23Ndik8MKPirBPziOc0D2/3KH1P+6jK5nGWe96kadZuE4jev2/Jq7FvIfTlT2Ltg8Fv2x1v0a5g==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/openapi-types": "^22.2.0"
-      }
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2472,12 +2301,6 @@
         }
       ]
     },
-    "node_modules/before-after-hook": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
-      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
-      "dev": true
-    },
     "node_modules/better-path-resolve": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
@@ -3006,12 +2829,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/deprecation": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
-      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
-      "dev": true
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -10096,12 +9913,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
-    },
-    "node_modules/universal-user-agent": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
-      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
-      "dev": true
     },
     "node_modules/universalify": {
       "version": "0.1.2",

--- a/src/filters/isDeprecated.test.ts
+++ b/src/filters/isDeprecated.test.ts
@@ -3,17 +3,17 @@ import {isDeprecated} from './isDeprecated.js'
 
 describe('Filter: isDeprecated', () => {
   it('Returns true if depreacted property is true', () => {
-    expect(isDeprecated(getMockToken({deprecated: true}))).toStrictEqual(true)
+    expect(isDeprecated(getMockToken({$deprecated: true}))).toStrictEqual(true)
   })
 
   it('Returns true if depreacted property is a string', () => {
-    expect(isDeprecated(getMockToken({deprecated: 'pumpkin'}))).toStrictEqual(true)
+    expect(isDeprecated(getMockToken({$deprecated: 'pumpkin'}))).toStrictEqual(true)
   })
 
   it('Returns false if deprecated is falsy', () => {
-    expect(isDeprecated(getMockToken({deprecated: false}))).toStrictEqual(false)
-    expect(isDeprecated(getMockToken({deprecated: null}))).toStrictEqual(false)
-    expect(isDeprecated(getMockToken({deprecated: undefined}))).toStrictEqual(false)
+    expect(isDeprecated(getMockToken({$deprecated: false}))).toStrictEqual(false)
+    expect(isDeprecated(getMockToken({$deprecated: null}))).toStrictEqual(false)
+    expect(isDeprecated(getMockToken({$deprecated: undefined}))).toStrictEqual(false)
   })
 
   it('Returns false if no deprecated property exists', () => {
@@ -22,19 +22,19 @@ describe('Filter: isDeprecated', () => {
 
   const inputArray = [
     getMockToken({
-      deprecated: true,
+      $deprecated: true,
     }),
     getMockToken({
-      deprecated: '{scale.yellow}',
+      $deprecated: '{scale.yellow}',
     }),
     getMockToken({
-      deprecated: null,
+      $deprecated: null,
     }),
     getMockToken({
-      deprecated: false,
+      $deprecated: false,
     }),
     getMockToken({
-      deprecated: undefined,
+      $deprecated: undefined,
     }),
     getMockToken({
       value: 'pumpkin',
@@ -43,10 +43,10 @@ describe('Filter: isDeprecated', () => {
 
   const expectedOutput = [
     getMockToken({
-      deprecated: true,
+      $deprecated: true,
     }),
     getMockToken({
-      deprecated: '{scale.yellow}',
+      $deprecated: '{scale.yellow}',
     }),
   ]
 

--- a/src/filters/isDeprecated.ts
+++ b/src/filters/isDeprecated.ts
@@ -6,5 +6,5 @@ import type {TransformedToken} from 'style-dictionary/types'
  * @returns boolean
  */
 export const isDeprecated = (token: TransformedToken): boolean => {
-  return token.deprecated === true || typeof token.deprecated === 'string'
+  return token.$deprecated === true || typeof token.$deprecated === 'string'
 }

--- a/src/schemas/baseToken.ts
+++ b/src/schemas/baseToken.ts
@@ -3,6 +3,6 @@ import {z} from 'zod'
 export const baseToken = z
   .object({
     $description: z.string().optional(),
-    deprecated: z.union([z.string(), z.boolean()]).optional(),
+    $deprecated: z.union([z.string(), z.boolean()]).optional(),
   })
   .strict()

--- a/src/transformers/jsonDeprecated.test.ts
+++ b/src/transformers/jsonDeprecated.test.ts
@@ -5,7 +5,7 @@ describe('Transformer: jsonDeprecated', () => {
   it('Replaces token value with `null` if deprecated is set to `true`', () => {
     const item = getMockToken({
       value: 'tokenName',
-      deprecated: true,
+      $deprecated: true,
     })
     const expectedOutput = null
     expect(jsonDeprecated.transform(item, {}, {})).toStrictEqual(expectedOutput)
@@ -14,7 +14,7 @@ describe('Transformer: jsonDeprecated', () => {
   it('Replaces token value with deprecated value if deprecated is a `string`', () => {
     const item = getMockToken({
       value: 'tokenName',
-      deprecated: `token.pumpkin`,
+      $deprecated: `token.pumpkin`,
     })
     const expectedOutput = 'token.pumpkin'
     expect(jsonDeprecated.transform(item, {}, {})).toStrictEqual(expectedOutput)
@@ -23,7 +23,7 @@ describe('Transformer: jsonDeprecated', () => {
   it('Replaces token value with deprecated value if deprecated is a `string` and removes {}', () => {
     const item = getMockToken({
       value: 'tokenName',
-      deprecated: `{token.pumpkin}`,
+      $deprecated: `{token.pumpkin}`,
     })
     const expectedOutput = 'token.pumpkin'
     expect(jsonDeprecated.transform(item, {}, {})).toStrictEqual(expectedOutput)

--- a/src/transformers/jsonDeprecated.ts
+++ b/src/transformers/jsonDeprecated.ts
@@ -12,5 +12,5 @@ export const jsonDeprecated: Transform = {
   transitive: true,
   filter: isDeprecated,
   transform: (token: TransformedToken) =>
-    typeof token.deprecated === 'string' ? token.deprecated.replace(/[{}]/g, '') : null,
+    typeof token.$deprecated === 'string' ? token.$deprecated.replace(/[{}]/g, '') : null,
 }


### PR DESCRIPTION
## Summary

Replaces `deprecated` with `$deprecated`

Close https://github.com/github/primer/issues/4437