### PR TITLE
ADR: Move color token name variants adr

### DIFF
--- a/contributor-docs/adrs/adr-009-color-token-name-variants.md
+++ b/contributor-docs/adrs/adr-009-color-token-name-variants.md
@@ -1,0 +1,24 @@
+# Title
+
+## Status
+
+| Stage    | Status      |
+| -------- | ----------- |
+| Approved | <!-- ✅ --> |
+| Adopted  | <!-- 🚧 --> |
+
+## Context
+
+<!-- Provide background information needed for this ADR -->
+
+## Decision
+
+<!-- Provide information about the decision made by this ADR -->
+
+### Impact
+
+<!-- Describe the impact of the decision -->
+
+### Alternatives
+
+<!-- Describe the available alternatives if any, and why the current apporach was chosen -->


### PR DESCRIPTION
## Summary

Moved this [ADR](https://github.com/github/primer/blob/85827cee9022657301b88c3548e8dd6e3f728afa/adrs/2023-03-28-color-token-name-variants.md)
