### PR TITLE
No alpha in extensions

### DIFF
--- a/src/schemas/colorToken.ts
+++ b/src/schemas/colorToken.ts
@@ -14,7 +14,6 @@ export const colorToken = baseToken
     alpha: alphaValue.optional().nullable(),
     $extensions: z
       .object({
-        alpha: z.number().min(0).max(1).optional().nullable(),
         'org.primer.figma': z
           .object({
             collection: collection([
@@ -68,6 +67,7 @@ export const colorToken = baseToken
           .strict()
           .optional(),
       })
+      .strict()
       .optional(),
   })
   .strict()

--- a/src/tokens/functional/color/dark/overrides/dark.protanopia-deuteranopia.json5
+++ b/src/tokens/functional/color/dark/overrides/dark.protanopia-deuteranopia.json5
@@ -60,9 +60,7 @@
       muted: {
         $value: '{bgColor.neutral.muted}',
         $type: 'color',
-        $extensions: {
-          alpha: 0.1,
-        },
+        alpha: 0.1,
       },
       emphasis: {
         $value: '{bgColor.neutral.emphasis}',
@@ -86,9 +84,7 @@
       muted: {
         $value: '{borderColor.muted}',
         $type: 'color',
-        $extensions: {
-          alpha: 0.4,
-        },
+        alpha: 0.4,
       },
       emphasis: {
         $value: '{borderColor.emphasis}',
@@ -231,16 +227,12 @@
         rest: {
           $value: '{base.color.neutral.6}',
           $type: 'color',
-          $extensions: {
-            alpha: 1,
-          },
+          alpha: 1,
         },
         hover: {
           $value: '{base.color.neutral.8}',
           $type: 'color',
-          $extensions: {
-            alpha: 1,
-          },
+          alpha: 1,
         },
       },
     },
@@ -248,9 +240,7 @@
       bgColor: {
         $value: '{base.color.neutral.3}',
         $type: 'color',
-        $extensions: {
-          alpha: 1,
-        },
+        alpha: 1,
       },
     },
   },

--- a/src/tokens/functional/color/dark/overrides/dark.tritanopia.json5
+++ b/src/tokens/functional/color/dark/overrides/dark.tritanopia.json5
@@ -80,9 +80,7 @@
       muted: {
         $value: '{base.color.blue.4}',
         $type: 'color',
-        $extensions: {
-          alpha: 0.4,
-        },
+        alpha: 0.4,
       },
       emphasis: {
         $value: '{base.color.blue.5}',
@@ -93,9 +91,7 @@
       muted: {
         $value: '{base.color.red.4}',
         $type: 'color',
-        $extensions: {
-          alpha: 0.4,
-        },
+        alpha: 0.4,
       },
       emphasis: {
         $value: '{base.color.red.5}',
@@ -106,9 +102,7 @@
       muted: {
         $value: '{base.color.red.4}',
         $type: 'color',
-        $extensions: {
-          alpha: 0.4,
-        },
+        alpha: 0.4,
       },
       emphasis: {
         $value: '{base.color.red.5}',
@@ -119,9 +113,7 @@
       muted: {
         $value: '{borderColor.default}',
         $type: 'color',
-        $extensions: {
-          alpha: 0.4,
-        },
+        alpha: 0.4,
       },
       emphasis: {
         $value: '{borderColor.emphasis}',
@@ -134,18 +126,14 @@
       bgColor: {
         $value: '{base.color.blue.3}',
         $type: 'color',
-        $extensions: {
-          alpha: 0.3,
-        },
+        alpha: 0.3,
       },
     },
     additionWord: {
       bgColor: {
         $value: '{base.color.blue.4}',
         $type: 'color',
-        $extensions: {
-          alpha: 0.4,
-        },
+        alpha: 0.4,
       },
     },
     hunkNum: {
@@ -153,16 +141,12 @@
         rest: {
           $value: '{base.color.neutral.6}',
           $type: 'color',
-          $extensions: {
-            alpha: 1,
-          },
+          alpha: 1,
         },
         hover: {
           $value: '{base.color.neutral.8}',
           $type: 'color',
-          $extensions: {
-            alpha: 1,
-          },
+          alpha: 1,
         },
       },
     },
@@ -170,9 +154,7 @@
       bgColor: {
         $value: '{base.color.neutral.3}',
         $type: 'color',
-        $extensions: {
-          alpha: 1,
-        },
+        alpha: 1,
       },
     },
   },

--- a/src/tokens/functional/color/dark/primitives-dark.json5
+++ b/src/tokens/functional/color/dark/primitives-dark.json5
@@ -84,8 +84,8 @@
     disabled: {
       $value: '{base.color.neutral.8}',
       $type: 'color',
+      alpha: 0.6,
       $extensions: {
-        alpha: 0.6,
         'org.primer.figma': {
           collection: 'mode',
 
@@ -592,8 +592,8 @@
       muted: {
         $value: '{base.color.red.4}',
         $type: 'color',
+        alpha: 0.1,
         $extensions: {
-          alpha: 0.1,
           'org.primer.figma': {
             collection: 'mode',
 
@@ -625,8 +625,8 @@
       muted: {
         $value: '{bgColor.danger.muted}',
         $type: 'color',
+        alpha: 0.1,
         $extensions: {
-          alpha: 0.1,
           'org.primer.figma': {
             collection: 'mode',
 

--- a/src/tokens/functional/color/light/overrides/light.protanopia-deuteranopia.json5
+++ b/src/tokens/functional/color/light/overrides/light.protanopia-deuteranopia.json5
@@ -80,9 +80,7 @@
       muted: {
         $value: '{borderColor.default}',
         $type: 'color',
-        $extensions: {
-          alpha: 0.4,
-        },
+        alpha: 0.4,
       },
       emphasis: {
         $value: '{borderColor.emphasis}',

--- a/src/tokens/functional/color/light/overrides/light.tritanopia.json5
+++ b/src/tokens/functional/color/light/overrides/light.tritanopia.json5
@@ -102,9 +102,7 @@
       muted: {
         $value: '{borderColor.default}',
         $type: 'color',
-        $extensions: {
-          alpha: 0.4,
-        },
+        alpha: 0.4,
       },
       emphasis: {
         $value: '{borderColor.emphasis}',


### PR DESCRIPTION
## Summary

This PR removes the Alpha prop from extensions and only allows alpha on the same level as `$value`.