### PR TITLE
add test for alpha only override

### DIFF
--- a/src/preprocessors/themeOverrides.test.ts
+++ b/src/preprocessors/themeOverrides.test.ts
@@ -9,6 +9,7 @@ describe('Preprocessor: themeOverrides', () => {
         name: 'red',
         description: 'This is a description',
         $value: 'transformedValue',
+        alpha: 0.6,
         path: ['tokens', 'subgroup', 'red'],
         $extensions: {
           'org.primer.overrides': {
@@ -30,6 +31,20 @@ describe('Preprocessor: themeOverrides', () => {
           },
         },
       }),
+      alphaOnlyOverride: getMockToken({
+        name: 'red',
+        description: 'This is a description',
+        $value: 'transformedValue',
+        alpha: 0.6,
+        path: ['tokens', 'subgroup', 'red'],
+        $extensions: {
+          'org.primer.overrides': {
+            dark: {
+              alpha: 0.75,
+            },
+          },
+        },
+      }),
     })
 
     const resultDictionary = getMockDictionary({
@@ -37,6 +52,7 @@ describe('Preprocessor: themeOverrides', () => {
         name: 'red',
         description: 'This is a description',
         $value: 'darkValue',
+        alpha: 0.6,
         path: ['tokens', 'subgroup', 'red'],
         $extensions: {
           'org.primer.overrides': {
@@ -54,6 +70,20 @@ describe('Preprocessor: themeOverrides', () => {
             dark: {
               $value: 'darkValue',
               description: 'DarkMode description',
+            },
+          },
+        },
+      }),
+      alphaOnlyOverride: getMockToken({
+        name: 'red',
+        description: 'This is a description',
+        $value: 'transformedValue',
+        alpha: 0.75,
+        path: ['tokens', 'subgroup', 'red'],
+        $extensions: {
+          'org.primer.overrides': {
+            dark: {
+              alpha: 0.75,
             },
           },
         },


### PR DESCRIPTION
## Summary

This closes https://github.com/github/primer/issues/4727

Overriding `alpha` without a `$value` override does already work. I just added a test.

<!--
A few sentences describing the changes being proposed in this pull request.
-->

## List of notable changes:

<!--
E.g.

- **added** new design token for # because #
- **deprecated**  design token for # because #
- **updated** documentation for # because #
-->

-

## What should reviewers focus on?

-

## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

1. Open the preview documentation that has been deployed in this pull request
2. Go to # page
3. Verify that # behaves as described in the pull request description

1.
1.
1.

## Supporting resources (related issues, external links, etc):

-

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
- [ ] Verify the design tokens changed in this PR are expected using the diffing results in this PR
