### PR TITLE
Scope some borders to also effectColor

### DIFF
--- a/src/tokens/functional/color/borderColor.json5
+++ b/src/tokens/functional/color/borderColor.json5
@@ -13,7 +13,7 @@
         'org.primer.figma': {
           collection: 'mode',
           group: 'semantic',
-          scopes: ['borderColor'],
+          scopes: ['borderColor', 'effectColor'],
           codeSyntax: {
             web: 'var(--borderColor-default) /* utility class: .color-border-default */',
           },
@@ -27,7 +27,7 @@
         'org.primer.figma': {
           collection: 'mode',
           group: 'semantic',
-          scopes: ['borderColor'],
+          scopes: ['borderColor', 'effectColor'],
           codeSyntax: {
             web: 'var(--borderColor-muted) /* utility class: .color-border-muted */',
           },
@@ -56,7 +56,7 @@
         'org.primer.figma': {
           collection: 'mode',
           group: 'semantic',
-          scopes: ['borderColor'],
+          scopes: ['borderColor', 'effectColor'],
         },
         'org.primer.overrides': {
           'light-high-contrast': '{borderColor.default}',
@@ -71,7 +71,7 @@
         'org.primer.figma': {
           collection: 'mode',
           group: 'semantic',
-          scopes: ['borderColor'],
+          scopes: ['borderColor', 'effectColor'],
         },
         'org.primer.overrides': {
           'dark-dimmed': {
@@ -93,7 +93,7 @@
         'org.primer.figma': {
           collection: 'mode',
           group: 'semantic',
-          scopes: ['borderColor'],
+          scopes: ['borderColor', 'effectColor'],
         },
       },
     },
@@ -104,7 +104,7 @@
         'org.primer.figma': {
           collection: 'mode',
           group: 'semantic',
-          scopes: ['borderColor'],
+          scopes: ['borderColor', 'effectColor'],
         },
         'org.primer.overrides': {
           'light-high-contrast': {
@@ -160,7 +160,7 @@
           'org.primer.figma': {
             collection: 'mode',
             group: 'semantic',
-            scopes: ['borderColor'],
+            scopes: ['borderColor', 'effectColor'],
             codeSyntax: {
               web: 'var(--borderColor-accent-muted) /* utility class: .color-border-accent */',
             },
@@ -186,7 +186,7 @@
           'org.primer.figma': {
             collection: 'mode',
             group: 'semantic',
-            scopes: ['borderColor'],
+            scopes: ['borderColor', 'effectColor'],
             codeSyntax: {
               web: 'var(--borderColor-accent-emphasis) /* utility class: .color-border-accent-emphasis */',
             },


### PR DESCRIPTION
## Summary

This allows to use some border colors as shadows in Figma, needed for specific workarounds.