### PR TITLE
Update playwright.config.ts to set retries to 0

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   testDir: 'e2e',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
+  retries: 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: [
     ['line'],


### PR DESCRIPTION
Update our playwright setup so that the number of retries is 0. This will reduce the total time it takes a failing job to finish by up to 3x (one attempt plus two retries). The cost of this is that a job may fail if there is some flakiness that would be fixed by a retry.