### PR TITLE
Use `bgColor-default` for `overlay` background in dark themes

### DIFF
--- a/.changeset/ten-adults-matter.md
+++ b/.changeset/ten-adults-matter.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": minor
+---
+
+Change `overlay` background color in `dark` themes

--- a/src/tokens/component/overlay.json5
+++ b/src/tokens/component/overlay.json5
@@ -10,7 +10,6 @@
           scopes: ['bgColor'],
         },
         'org.primer.overrides': {
-          dark: '{bgColor.muted}',
           'dark-dimmed': '{base.color.neutral.5}',
         },
       },


### PR DESCRIPTION
Use `bgColor-default` for dark overlays. I'm really not sure how I feel about this solution as we rely on a slightly lighter shade to show dimension for dark mode where shadows aren't very useful. But we're lacking the ability to layer inside overlays by using `muted` as the background.

Closes https://github.com/github/primer/issues/4175

Before

<img width="1188" alt="Overlay demo before" src="https://github.com/user-attachments/assets/2a3f159f-9926-4a83-9377-44fd9e5a5e7a" />

After

<img width="1190" alt="Overlay demo after" src="https://github.com/user-attachments/assets/7ad29257-6ed0-4752-a034-c92a9720508f" />
