### PR TITLE
Use Mona Sans and Monaspace instead of current fonts

### DIFF
--- a/.changeset/four-trainers-pay.md
+++ b/.changeset/four-trainers-pay.md
@@ -1,0 +1,5 @@
+---
+'@primer/primitives': minor
+---
+
+Use Mona Sans and Monaspace instead of current fonts

--- a/src/tokens/functional/typography/typography.json5
+++ b/src/tokens/functional/typography/typography.json5
@@ -11,7 +11,7 @@
       },
     },
     sansSerif: {
-      $value: "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
+      $value: "'Mona Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
       $type: 'fontFamily',
       $extensions: {
         'org.primer.figma': {
@@ -21,7 +21,7 @@
       },
     },
     sansSerifDisplay: {
-      $value: "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
+      $value: "'Mona Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
       $type: 'fontFamily',
       $extensions: {
         'org.primer.figma': {
@@ -31,7 +31,7 @@
       },
     },
     monospace: {
-      $value: 'ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace',
+      $value: "'Monaspace Neon', 'ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace'",
       $type: 'fontFamily',
       $extensions: {
         'org.primer.figma': {


### PR DESCRIPTION
## Summary

This PR uses mona sans and monospace instead of just the system fonts.

This is currently an exploration. If we do want to implement this we would need to load those fonts on github.com and don't just rely on the fonts being installed locally.