### PR TITLE
Don't export new high contrast modes

### DIFF
--- a/scripts/buildFigma.ts
+++ b/scripts/buildFigma.ts
@@ -1,11 +1,12 @@
 import fs from 'fs'
 import {PrimerStyleDictionary} from '../src/primerStyleDictionary.js'
-import {themes} from './themes.config.js'
+import {themes as origialThemes} from './themes.config.js'
 import {figma} from '../src/platforms/index.js'
 import type {ConfigGeneratorOptions} from '../src/types/styleDictionaryConfigGenerator.js'
 import {getFallbackTheme} from './utilities/getFallbackTheme.js'
 
 const buildFigma = async (buildOptions: ConfigGeneratorOptions): Promise<void> => {
+  const themes = origialThemes.filter(theme => theme.exportToFigma !== false)
   /** -----------------------------------
    * Colors
    * ----------------------------------- */

--- a/scripts/themes.config.ts
+++ b/scripts/themes.config.ts
@@ -4,6 +4,7 @@ export const themes: TokenBuildInput[] = [
   {
     filename: 'light',
     theme: 'light',
+    exportToFigma: true,
     source: [
       `src/tokens/functional/shadow/shadow.json5`,
       `src/tokens/functional/border/*.json5`,
@@ -19,6 +20,7 @@ export const themes: TokenBuildInput[] = [
   {
     filename: 'light-tritanopia',
     theme: 'light-tritanopia',
+    exportToFigma: true,
     source: [
       `src/tokens/functional/shadow/shadow.json5`,
       `src/tokens/functional/border/*.json5`,
@@ -34,6 +36,7 @@ export const themes: TokenBuildInput[] = [
   {
     filename: 'light-tritanopia-high-contrast',
     theme: 'light-tritanopia-high-contrast',
+    exportToFigma: false,
     source: [
       `src/tokens/functional/shadow/shadow.json5`,
       `src/tokens/functional/border/*.json5`,
@@ -51,6 +54,7 @@ export const themes: TokenBuildInput[] = [
   {
     filename: 'light-colorblind',
     theme: 'light-protanopia-deuteranopia',
+    exportToFigma: true,
     source: [
       `src/tokens/functional/shadow/shadow.json5`,
       `src/tokens/functional/border/*.json5`,
@@ -66,6 +70,7 @@ export const themes: TokenBuildInput[] = [
   {
     filename: 'light-colorblind-high-contrast',
     theme: 'light-protanopia-deuteranopia-high-contrast',
+    exportToFigma: false,
     source: [
       `src/tokens/functional/shadow/shadow.json5`,
       `src/tokens/functional/border/*.json5`,
@@ -83,6 +88,7 @@ export const themes: TokenBuildInput[] = [
   {
     filename: 'light-high-contrast',
     theme: 'light-high-contrast',
+    exportToFigma: true,
     source: [
       `src/tokens/functional/shadow/shadow.json5`,
       `src/tokens/functional/border/*.json5`,
@@ -99,6 +105,7 @@ export const themes: TokenBuildInput[] = [
   {
     filename: 'dark',
     theme: 'dark',
+    exportToFigma: true,
     source: [
       `src/tokens/functional/shadow/shadow.json5`,
       `src/tokens/functional/border/*.json5`,
@@ -114,6 +121,7 @@ export const themes: TokenBuildInput[] = [
   {
     filename: 'dark-dimmed',
     theme: 'dark-dimmed',
+    exportToFigma: true,
     source: [
       `src/tokens/functional/shadow/shadow.json5`,
       `src/tokens/functional/border/*.json5`,
@@ -130,6 +138,7 @@ export const themes: TokenBuildInput[] = [
   {
     filename: 'dark-dimmed-high-contrast',
     theme: 'dark-dimmed-high-contrast',
+    exportToFigma: false,
     source: [
       `src/tokens/functional/shadow/shadow.json5`,
       `src/tokens/functional/border/*.json5`,
@@ -148,6 +157,7 @@ export const themes: TokenBuildInput[] = [
   {
     filename: 'dark-tritanopia',
     theme: 'dark-tritanopia',
+    exportToFigma: true,
     source: [
       `src/tokens/functional/shadow/shadow.json5`,
       `src/tokens/functional/border/*.json5`,
@@ -163,6 +173,7 @@ export const themes: TokenBuildInput[] = [
   {
     filename: 'dark-tritanopia-high-contrast',
     theme: 'dark-tritanopia-high-contrast',
+    exportToFigma: false,
     source: [
       `src/tokens/functional/shadow/shadow.json5`,
       `src/tokens/functional/border/*.json5`,
@@ -180,6 +191,7 @@ export const themes: TokenBuildInput[] = [
   {
     filename: 'dark-colorblind',
     theme: 'dark-protanopia-deuteranopia',
+    exportToFigma: true,
     source: [
       `src/tokens/functional/shadow/shadow.json5`,
       `src/tokens/functional/border/*.json5`,
@@ -195,6 +207,7 @@ export const themes: TokenBuildInput[] = [
   {
     filename: 'dark-colorblind-high-contrast',
     theme: 'dark-protanopia-deuteranopia-high-contrast',
+    exportToFigma: false,
     source: [
       `src/tokens/functional/shadow/shadow.json5`,
       `src/tokens/functional/border/*.json5`,
@@ -212,6 +225,7 @@ export const themes: TokenBuildInput[] = [
   {
     filename: 'dark-high-contrast',
     theme: 'dark-high-contrast',
+    exportToFigma: true,
     source: [
       `src/tokens/functional/shadow/shadow.json5`,
       `src/tokens/functional/border/*.json5`,

--- a/src/types/tokenBuildInput.d.ts
+++ b/src/types/tokenBuildInput.d.ts
@@ -1,6 +1,8 @@
 export type TokenBuildInput = {
   // The output filename WITHOUT the extension
   filename: string
+  // defines if the theme should be exported to Figma
+  exportToFigma: boolean
   // Array of `filepaths` to token files that should be converted and included in the output. Accepts relative or glob paths.
   source: string[]
   // The mode of the theme


### PR DESCRIPTION
This PR make sure that we only export indented color themes for Figma.