### PR TITLE
Update base green 5

### DIFF
--- a/.changeset/chilly-years-drive.md
+++ b/.changeset/chilly-years-drive.md
@@ -1,0 +1,5 @@
+---
+'@primer/primitives': patch
+---
+
+Adjust base.green.5 and change bgColor-success-muted to use base.green.5

--- a/src/tokens/base/color/light/light.json5
+++ b/src/tokens/base/color/light/light.json5
@@ -264,7 +264,7 @@
       },
       green: {
         '0': {
-          $value: '#dafbe1',
+          $value: '#E3FCE9',
           $type: 'color',
           $extensions: {
             'org.primer.figma': {

--- a/src/tokens/base/color/light/light.json5
+++ b/src/tokens/base/color/light/light.json5
@@ -309,7 +309,7 @@
           },
         },
         '5': {
-          $value: '#1a7f37',
+          $value: '#1B8238',
           $type: 'color',
           $extensions: {
             'org.primer.figma': {

--- a/src/tokens/functional/color/bgColor.json5
+++ b/src/tokens/functional/color/bgColor.json5
@@ -300,7 +300,7 @@
         },
       },
       emphasis: {
-        $value: '#1f883d',
+        $value: '{base.color.green.5}',
         $type: 'color',
         $extensions: {
           'org.primer.figma': {


### PR DESCRIPTION
## Summary

- update base green 5 and 0
- use base green 5 for bgColor-success-emphasis

This would fixes https://github.com/github/primer/issues/5737

## What should reviewers focus on?

-

## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

1. Open the preview documentation that has been deployed in this pull request
2. Go to # page
3. Verify that # behaves as described in the pull request description

1.
1.
1.

## Supporting resources (related issues, external links, etc):

-

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
- [ ] Verify the design tokens changed in this PR are expected using the diffing results in this PR
