### PR TITLE
Add motion CSS import documentation for animated components

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ All available imports:
 @import '@primer/primitives/dist/css/functional/size/viewport.css';
 @import '@primer/primitives/dist/css/functional/typography/typography.css';
 
+/* motion */
+@import '@primer/primitives/dist/css/base/motion/motion.css';
+
 /* color */
 @import '@primer/primitives/dist/css/functional/themes/light.css';
 @import '@primer/primitives/dist/css/functional/themes/light-tritanopia.css';
@@ -48,6 +51,8 @@ All available imports:
 @import '@primer/primitives/dist/css/functional/themes/dark-high-contrast.css';
 @import '@primer/primitives/dist/css/functional/themes/dark-tritanopia.css';
 ```
+
+> **Note:** Motion CSS imports are required for components with animations, such as `Spinner` from `@primer/react`. If you're experiencing issues with animated components appearing static, ensure you've imported the motion CSS files.
 
 ## Design token data
 

--- a/docs/storybook/stories/Migration/v8/Guide.mdx
+++ b/docs/storybook/stories/Migration/v8/Guide.mdx
@@ -97,6 +97,9 @@ Color themes are now exported directly from `/primitives` as individual CSS file
 @import '@primer/primitives/dist/css/functional/size/viewport.css';
 @import '@primer/primitives/dist/css/functional/typography/typography.css';
 
+/* motion */
+@import '@primer/primitives/dist/css/base/motion/motion.css';
+
 /* color */
 @import '@primer/primitives/dist/css/functional/themes/light.css';
 @import '@primer/primitives/dist/css/functional/themes/light-tritanopia.css';
@@ -108,6 +111,8 @@ Color themes are now exported directly from `/primitives` as individual CSS file
 @import '@primer/primitives/dist/css/functional/themes/dark-high-contrast.css';
 @import '@primer/primitives/dist/css/functional/themes/dark-tritanopia.css';
 ```
+
+> **Note:** Motion CSS imports are required for components with animations, such as `Spinner` from `@primer/react`. If you're experiencing issues with animated components appearing static, ensure you've imported the motion CSS files.
 
 ## Size, space and typography tokens
 


### PR DESCRIPTION
Adds documentation for the motion CSS import that's required for animated components like `Spinner` from `@primer/react`.
 
Fixes documentation gap identified in https://github.com/primer/react/issues/6903

