### PR TITLE
Remove redundant lineBoxHeight tokens

### DIFF
--- a/.changeset/remove-lineboxheight-tokens.md
+++ b/.changeset/remove-lineboxheight-tokens.md
@@ -1,0 +1,16 @@
+---
+"@primer/primitives": minor
+---
+
+Remove redundant `lineBoxHeight` tokens
+
+The following tokens have been removed:
+
+- `text-display-lineBoxHeight` - Duplicated `text-display-lineHeight` value
+- `control-xsmall-lineBoxHeight`
+- `control-small-lineBoxHeight`
+- `control-medium-lineBoxHeight`
+- `control-large-lineBoxHeight`
+- `control-xlarge-lineBoxHeight`
+
+These tokens were inconsistently defined (typography used unitless multipliers while controls used absolute dimensions) and were not providing clear value. The control sizing formula (`size = lineBoxHeight + 2 × paddingBlock`) can be derived from existing `size` and `paddingBlock` tokens. Breaking changes have been mitigated on the platform.

--- a/src/tokens/functional/size/size.json5
+++ b/src/tokens/functional/size/size.json5
@@ -40,16 +40,6 @@
           }
         }
       },
-      "lineBoxHeight": {
-        "$value": "{base.size.20}",
-        "$type": "dimension",
-        "$extensions": {
-          "org.primer.figma": {
-            "collection": "pattern/size",
-            "scopes": ["size"]
-          }
-        }
-      },
       "paddingBlock": {
         "$value": {"value": 2, "unit": "px"},
         "$type": "dimension",
@@ -106,16 +96,6 @@
     "small": {
       "size": {
         "$value": "{base.size.28}",
-        "$type": "dimension",
-        "$extensions": {
-          "org.primer.figma": {
-            "collection": "pattern/size",
-            "scopes": ["size"]
-          }
-        }
-      },
-      "lineBoxHeight": {
-        "$value": "{base.size.20}",
         "$type": "dimension",
         "$extensions": {
           "org.primer.figma": {
@@ -188,16 +168,6 @@
           }
         }
       },
-      "lineBoxHeight": {
-        "$value": "{base.size.20}",
-        "$type": "dimension",
-        "$extensions": {
-          "org.primer.figma": {
-            "collection": "pattern/size",
-            "scopes": ["size"]
-          }
-        }
-      },
       "paddingBlock": {
         "$value": {"value": 6, "unit": "px"},
         "$type": "dimension",
@@ -262,16 +232,6 @@
           }
         }
       },
-      "lineBoxHeight": {
-        "$value": "{base.size.20}",
-        "$type": "dimension",
-        "$extensions": {
-          "org.primer.figma": {
-            "collection": "pattern/size",
-            "scopes": ["size"]
-          }
-        }
-      },
       "paddingBlock": {
         "$value": {"value": 10, "unit": "px"},
         "$type": "dimension",
@@ -328,16 +288,6 @@
     "xlarge": {
       "size": {
         "$value": "{base.size.48}",
-        "$type": "dimension",
-        "$extensions": {
-          "org.primer.figma": {
-            "collection": "pattern/size",
-            "scopes": ["size"]
-          }
-        }
-      },
-      "lineBoxHeight": {
-        "$value": "{base.size.20}",
         "$type": "dimension",
         "$extensions": {
           "org.primer.figma": {

--- a/src/tokens/functional/typography/typography.json5
+++ b/src/tokens/functional/typography/typography.json5
@@ -1,20 +1,6 @@
 {
   text: {
     display: {
-      lineBoxHeight: {
-        $value: '{base.text.lineHeight.snug}',
-        $type: 'number',
-        $extensions: {
-          'org.primer.data': {
-            fontSize: 40,
-          },
-          'org.primer.figma': {
-            collection: 'typography',
-            scopes: ['lineHeight'],
-            fontSizeInPx: 40,
-          },
-        },
-      },
       size: {
         $value: '{base.text.size.2xl}',
         $type: 'dimension',


### PR DESCRIPTION
## Summary

Remove redundant `lineBoxHeight` tokens that were inconsistently defined and not providing clear value.

## Changes

The following tokens have been removed:

- `text-display-lineBoxHeight` - Duplicated `text-display-lineHeight` value (both referenced `base.text.lineHeight.snug`)
- `control-xsmall-lineBoxHeight`
- `control-small-lineBoxHeight`
- `control-medium-lineBoxHeight`
- `control-large-lineBoxHeight`
- `control-xlarge-lineBoxHeight`

## Rationale

1. **Typography token was redundant**: `text-display-lineBoxHeight` stored the same unitless multiplier (`1.375`) as `lineHeight`, making it a duplicate
2. **Inconsistent types**: Typography used unitless multipliers while controls used absolute dimensions, making `lineBoxHeight` confusing
3. **Control sizing can be derived**: The formula `size = lineBoxHeight + 2 × paddingBlock` means `lineBoxHeight` can be calculated from existing `size` and `paddingBlock` tokens if needed

## Breaking changes

Breaking changes have been mitigated on the platform side before this removal.