### PR TITLE
Add functional motion tokens

### DIFF
--- a/.changeset/proud-flowers-know.md
+++ b/.changeset/proud-flowers-know.md
@@ -1,0 +1,5 @@
+---
+'@primer/primitives': minor
+---
+
+Add functional motion tokens completing the base→functional→component architecture

--- a/DESIGN_TOKENS_GUIDE.md
+++ b/DESIGN_TOKENS_GUIDE.md
@@ -65,18 +65,26 @@
 
 ### Motion
 
-| Keyword | Rule                                                           |
-| ------- | -------------------------------------------------------------- |
-| MUST    | Use motion for interactive state changes (hover, focus, press) |
-| MUST    | Keep animations ≤300ms for UI interactions                     |
-| MUST    | Respect `prefers-reduced-motion` media query                   |
-| MUST    | Provide instant alternatives when motion is reduced            |
-| SHOULD  | Use 100-200ms for micro-interactions                           |
-| SHOULD  | Use 200-300ms for state changes                                |
-| NEVER   | Exceed 500ms for UI interactions                               |
-| NEVER   | Use motion purely for decoration                               |
-| NEVER   | Create indefinitely looping motion without user control        |
-| NEVER   | Rely solely on motion to convey information                    |
+```
+--motion-[property]-[semantic]
+  ├── property: duration | easing | transition
+  └── semantic: micro | short | medium | long       (duration)
+                hover | enter | exit | move | linear (easing)
+                hover | stateChange | enter | exit   (transition)
+```
+
+| Keyword | Rule                                                                       |
+| ------- | -------------------------------------------------------------------------- |
+| MUST    | Use `motion.transition.*` tokens for interactive state changes             |
+| MUST    | Keep animations ≤`motion.duration.medium` (300ms) for UI interactions      |
+| MUST    | Respect `prefers-reduced-motion` media query                               |
+| MUST    | Provide instant alternatives when motion is reduced                        |
+| SHOULD  | Use `motion.duration.micro` (100ms) for hover and focus micro-interactions |
+| SHOULD  | Use `motion.duration.short` (200ms) for state changes                      |
+| NEVER   | Exceed `motion.duration.long` (500ms) for UI interactions                  |
+| NEVER   | Use motion purely for decoration                                           |
+| NEVER   | Create indefinitely looping motion without user control                    |
+| NEVER   | Rely solely on motion to convey information                                |
 
 ### Typography
 
@@ -126,10 +134,10 @@
 
 ## Decision Tree: Easing Selection
 
-1. Is element entering/exiting viewport? → ease-out (default)
-2. Is element moving/morphing on screen? → ease-in-out
-3. Is this a hover state change? → ease
-4. Is this constant motion (loaders)? → linear
+1. Is element entering/exiting viewport? → `motion.easing.enter` / `motion.easing.exit`
+2. Is element moving/morphing on screen? → `motion.easing.move`
+3. Is this a hover state change? → `motion.easing.hover`
+4. Is this constant motion (loaders)? → `motion.easing.linear`
 
 ---
 
@@ -148,11 +156,11 @@
   font: var(--text-body-shorthand-medium);
   cursor: pointer;
 
-  /* Motion: MUST be <300ms */
+  /* Motion: Use functional motion tokens */
   transition:
-    background-color 150ms ease,
-    box-shadow 150ms ease,
-    transform 100ms ease;
+    background-color var(--motion-transition-hover),
+    box-shadow var(--motion-transition-hover),
+    transform var(--motion-transition-hover);
 }
 
 /* State: Hover */

--- a/docs/storybook/stories/Motion/Functional.stories.tsx
+++ b/docs/storybook/stories/Motion/Functional.stories.tsx
@@ -1,0 +1,142 @@
+import React from 'react'
+// eslint-disable-next-line import/extensions
+import functionalMotionTokens from '../../../../dist/docs/functional/motion/motion.json'
+import {DataTable, Table} from '@primer/react/experimental'
+import {InlineCode} from '../StorybookComponents/InlineCode/InlineCode'
+import {getTokensByName} from '../utilities/getTokensByName'
+import {CubicBezier} from '../StorybookComponents/BezierCurve/BezierCurve'
+import {Card} from '../StorybookComponents/Card/Card'
+
+export default {
+  title: 'Motion/Functional',
+  parameters: {
+    controls: {hideNoControlsWarning: true},
+    tags: ['snapshotLight'],
+  },
+}
+
+export const Functional = () => {
+  const data = getTokensByName(functionalMotionTokens, 'motion').map(token => {
+    return {
+      id: token.name,
+      ...token,
+    }
+  })
+
+  return (
+    <>
+      <Table.Container>
+        <h2 id="duration">Duration</h2>
+        <DataTable
+          aria-labelledby="duration"
+          data={data.filter(item => item.type === 'duration')}
+          columns={[
+            {
+              header: 'Token',
+              field: 'name',
+              rowHeader: true,
+              renderCell: row => {
+                return <InlineCode value={row.name} cssVar={true} copyClipboard />
+              },
+            },
+            {
+              header: 'Output value',
+              field: 'value',
+              rowHeader: true,
+              renderCell: row => {
+                const val = typeof row.value === 'object' ? `${row.value.value}${row.value.unit}` : row.value
+                return <p>{val}</p>
+              },
+            },
+            {
+              header: 'Reference',
+              field: 'original',
+              rowHeader: true,
+              renderCell: row => {
+                return <p>{row.original.$value}</p>
+              },
+            },
+            {
+              header: 'Description',
+              field: 'description',
+              rowHeader: true,
+              renderCell: row => {
+                return <p>{row.description}</p>
+              },
+            },
+          ]}
+        />
+      </Table.Container>
+
+      <h2 id="easing">Easing</h2>
+      <div style={{display: 'flex', flexDirection: 'row', alignItems: 'start', gap: 8, flexWrap: 'wrap'}}>
+        {data
+          .filter(item => item.type === 'cubicBezier')
+          .map(item => (
+            <Card
+              key={item.name}
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                gap: 8,
+                minWidth: 200,
+                maxWidth: 300,
+              }}
+            >
+              <CubicBezier bezier={item.value} />
+              <p>[{item.value.join(', ')}]</p>
+              <InlineCode value={item.name} cssVar={true} copyClipboard />
+              <p style={{fontSize: 12, textAlign: 'center', color: '#666'}}>{item.description}</p>
+            </Card>
+          ))}
+      </div>
+
+      <Table.Container>
+        <h2 id="transition">Transition</h2>
+        <DataTable
+          aria-labelledby="transition"
+          data={data.filter(item => item.type === 'transition')}
+          columns={[
+            {
+              header: 'Token',
+              field: 'name',
+              rowHeader: true,
+              renderCell: row => {
+                return <InlineCode value={row.name} cssVar={true} copyClipboard />
+              },
+            },
+            {
+              header: 'Output value',
+              field: 'value',
+              rowHeader: true,
+              renderCell: row => {
+                if (typeof row.value !== 'object') return <p>{row.value}</p>
+                const dur =
+                  typeof row.value.duration === 'object'
+                    ? `${row.value.duration.value}${row.value.duration.unit}`
+                    : row.value.duration
+                const tf = Array.isArray(row.value.timingFunction)
+                  ? `cubic-bezier(${row.value.timingFunction.join(', ')})`
+                  : row.value.timingFunction
+                const delay =
+                  row.value.delay != null
+                    ? ` ${typeof row.value.delay === 'object' ? `${row.value.delay.value}${row.value.delay.unit}` : row.value.delay}`
+                    : ''
+                return <p>{`${dur} ${tf}${delay}`}</p>
+              },
+            },
+            {
+              header: 'Description',
+              field: 'description',
+              rowHeader: true,
+              renderCell: row => {
+                return <p>{row.description}</p>
+              },
+            },
+          ]}
+        />
+      </Table.Container>
+    </>
+  )
+}

--- a/src/tokens/functional/motion/motion.json5
+++ b/src/tokens/functional/motion/motion.json5
@@ -1,0 +1,190 @@
+{
+  motion: {
+    duration: {
+      $description: 'Semantic duration tokens for UI motion. Maps interaction types to appropriate timing values.',
+      $extensions: {
+        'org.primer.llm': {
+          usage: ['transition-duration', 'animation-duration', 'motion-timing'],
+          rules:
+            'MUST keep UI interactions ≤300ms. Use micro for hover/focus, short for state changes, medium for enter/exit. NEVER exceed 500ms for UI interactions.',
+        },
+      },
+      micro: {
+        $value: '{base.duration.100}',
+        $type: 'duration',
+        $description: 'Fast micro-interactions like hover, focus ring, and color shifts.',
+        $extensions: {
+          'org.primer.llm': {
+            usage: ['hover-transition', 'focus-ring', 'color-shift', 'opacity-change'],
+            rules: 'Use for instantaneous feedback on hover and focus states.',
+          },
+        },
+      },
+      short: {
+        $value: '{base.duration.200}',
+        $type: 'duration',
+        $description: 'Quick transitions for state changes like expand/collapse, toggles, and visibility changes.',
+        $extensions: {
+          'org.primer.llm': {
+            usage: ['expand-collapse', 'toggle', 'visibility-change', 'state-transition'],
+            rules: 'Use for interactive state changes that need to feel responsive.',
+          },
+        },
+      },
+      medium: {
+        $value: '{base.duration.300}',
+        $type: 'duration',
+        $description: 'Standard duration for elements entering or exiting the viewport, such as modals and dropdowns.',
+        $extensions: {
+          'org.primer.llm': {
+            usage: ['modal-open', 'dropdown-appear', 'tooltip-show', 'enter-exit-viewport'],
+            rules: 'Use for elements entering or leaving the viewport. Maximum recommended duration for UI interactions.',
+          },
+        },
+      },
+      long: {
+        $value: '{base.duration.500}',
+        $type: 'duration',
+        $description: 'Longer duration for complex multi-step animations or large-scale layout shifts. Use sparingly.',
+        $extensions: {
+          'org.primer.llm': {
+            usage: ['complex-animation', 'multi-step', 'layout-shift', 'page-transition'],
+            rules: 'Use sparingly for complex animations. NEVER use for simple UI interactions.',
+          },
+        },
+      },
+    },
+    easing: {
+      $description: 'Semantic easing tokens for UI motion. Maps interaction types to appropriate cubic-bezier curves.',
+      $extensions: {
+        'org.primer.llm': {
+          usage: ['transition-timing-function', 'animation-timing-function', 'easing-curve'],
+          rules:
+            'Follow the easing decision tree: entering/exiting → enter, moving/morphing → move, hover → hover, constant → linear.',
+        },
+      },
+      hover: {
+        $value: '{base.easing.ease}',
+        $type: 'cubicBezier',
+        $description: 'Easing for hover state changes and micro-interactions.',
+        $extensions: {
+          'org.primer.llm': {
+            usage: ['hover-state', 'micro-interaction', 'button-hover', 'link-hover'],
+            rules: 'Use for hover state changes.',
+          },
+        },
+      },
+      enter: {
+        $value: '{base.easing.easeOut}',
+        $type: 'cubicBezier',
+        $description: 'Decelerating easing for elements entering the viewport or appearing on screen.',
+        $extensions: {
+          'org.primer.llm': {
+            usage: ['enter-animation', 'element-appearing', 'modal-open', 'dropdown-open', 'tooltip-appear'],
+            rules: 'RECOMMENDED default for enter animations. Element decelerates into its final position.',
+          },
+        },
+      },
+      exit: {
+        $value: '{base.easing.easeIn}',
+        $type: 'cubicBezier',
+        $description: 'Accelerating easing for elements exiting the viewport or leaving the screen.',
+        $extensions: {
+          'org.primer.llm': {
+            usage: ['exit-animation', 'element-leaving', 'modal-close', 'dismiss'],
+            rules: 'Use for elements leaving the viewport. Element accelerates away.',
+          },
+        },
+      },
+      move: {
+        $value: '{base.easing.easeInOut}',
+        $type: 'cubicBezier',
+        $description: 'Smooth easing for elements moving or morphing within the viewport.',
+        $extensions: {
+          'org.primer.llm': {
+            usage: ['position-change', 'size-change', 'morph-animation', 'expand-collapse', 'slide-transition'],
+            rules: 'Use for elements that move or change shape on screen.',
+          },
+        },
+      },
+      linear: {
+        $value: '{base.easing.linear}',
+        $type: 'cubicBezier',
+        $description: 'Constant motion with no acceleration. Use for continuous animations like progress bars or loaders.',
+        $extensions: {
+          'org.primer.llm': {
+            usage: ['progress-bar', 'loader', 'continuous-animation', 'scrolling'],
+            rules: 'Use only for constant, uninterrupted motion.',
+          },
+        },
+      },
+    },
+    transition: {
+      $description:
+        'Composite transition tokens bundling duration and easing for common UI interaction patterns. Use these for the CSS transition property.',
+      $extensions: {
+        'org.primer.llm': {
+          usage: ['css-transition', 'transition-shorthand'],
+          rules:
+            'Use transition tokens instead of raw duration + easing values. Pair with CSS transition-property to specify which properties to animate. MUST respect prefers-reduced-motion.',
+        },
+      },
+      hover: {
+        $value: {
+          duration: '{motion.duration.micro}',
+          timingFunction: '{motion.easing.hover}',
+        },
+        $type: 'transition',
+        $description: 'Transition for hover state changes on interactive elements like buttons and links.',
+        $extensions: {
+          'org.primer.llm': {
+            usage: ['button-hover', 'link-hover', 'interactive-hover', 'color-transition'],
+            rules: 'Use for all hover state transitions. Keeps interactions feeling instantaneous.',
+          },
+        },
+      },
+      stateChange: {
+        $value: {
+          duration: '{motion.duration.short}',
+          timingFunction: '{motion.easing.move}',
+        },
+        $type: 'transition',
+        $description: 'Transition for state changes like toggles, expand/collapse, and visibility changes.',
+        $extensions: {
+          'org.primer.llm': {
+            usage: ['toggle', 'expand-collapse', 'accordion', 'tab-switch', 'visibility-change'],
+            rules: 'Use for interactive elements that change between states.',
+          },
+        },
+      },
+      enter: {
+        $value: {
+          duration: '{motion.duration.medium}',
+          timingFunction: '{motion.easing.enter}',
+        },
+        $type: 'transition',
+        $description: 'Transition for elements entering the viewport, such as modals, dropdowns, and tooltips.',
+        $extensions: {
+          'org.primer.llm': {
+            usage: ['modal-open', 'dropdown-appear', 'tooltip-show', 'popover-enter', 'overlay-appear'],
+            rules: 'Use for elements appearing on screen. Element decelerates into final position.',
+          },
+        },
+      },
+      exit: {
+        $value: {
+          duration: '{motion.duration.short}',
+          timingFunction: '{motion.easing.exit}',
+        },
+        $type: 'transition',
+        $description: 'Transition for elements exiting the viewport, such as closing modals and dismissing dropdowns.',
+        $extensions: {
+          'org.primer.llm': {
+            usage: ['modal-close', 'dropdown-dismiss', 'tooltip-hide', 'popover-exit', 'overlay-dismiss'],
+            rules: 'Use for elements leaving the screen. Shorter than enter to feel snappy.',
+          },
+        },
+      },
+    },
+  },
+}

--- a/src/transformers/transitionToCss.test.ts
+++ b/src/transformers/transitionToCss.test.ts
@@ -82,4 +82,16 @@ describe('transitionToCss', () => {
       'Invalid cubicBezier token path, must be an array with 4 numbers, but got this instead: [0.4,0,0.2]',
     )
   })
+
+  it('should handle already-transformed cubicBezier string for timingFunction', () => {
+    const token = getMockToken({
+      $value: {
+        duration: '100ms',
+        timingFunction: 'cubic-bezier(0.25,0.1,0.25,1)',
+      },
+      $type: 'transition',
+    })
+
+    expect(transitionToCss.transform(token, {}, {})).toBe('100ms cubic-bezier(0.25,0.1,0.25,1)')
+  })
 })

--- a/src/transformers/transitionToCss.ts
+++ b/src/transformers/transitionToCss.ts
@@ -27,6 +27,12 @@ export const transitionToCss: Transform = {
     // check required properties
     checkRequiredTokenProperties(value, ['duration', 'timingFunction'])
 
-    return `${value.duration} ${cubicBezierArrayToCss(value.timingFunction, token.path)} ${value.delay ? value.delay : ''}`.trim()
+    // timingFunction may already be a CSS string if resolved from a cubicBezier reference
+    const timing =
+      typeof value.timingFunction === 'string'
+        ? value.timingFunction
+        : cubicBezierArrayToCss(value.timingFunction, token.path)
+
+    return `${value.duration} ${timing} ${value.delay ? value.delay : ''}`.trim()
   },
 }


### PR DESCRIPTION
## Summary

Adds a functional motion token layer that maps semantic intent to base motion primitives, completing the base → functional → component architecture for motion (matching color, typography, border, and shadow).

### New tokens (13 total)

| Category | Tokens | Description |
|----------|--------|-------------|
| Duration | `micro`, `short`, `medium`, `long` | Semantic durations (100–500ms) |
| Easing | `hover`, `enter`, `exit`, `move`, `linear` | Intent-based easing curves |
| Transition | `hover`, `stateChange`, `enter`, `exit` | Composite duration + easing shorthands |

### CSS output

```css
--motion-transition-hover: var(--motion-duration-micro) var(--motion-easing-hover);
--motion-transition-enter: var(--motion-duration-medium) var(--motion-easing-enter);
/* ... */
```

### Other changes

- **Fix `transitionToCss` transformer** — handles pre-transformed cubic-bezier CSS strings from resolved references (was producing `[object Object]`)
- **Storybook story** — `Motion/Functional` visualizes all new tokens
- **DESIGN_TOKENS_GUIDE.md** — updated motion rules, easing decision tree, and golden example to reference functional motion tokens

### Validation

- ✅ 103 test files, 524 tests passed
- ✅ Lint clean
- ✅ Build succeeds with correct CSS output