### PR TITLE
fix: preserve CSS variable references in border and outline tokens

### DIFF
--- a/src/platforms/css.ts
+++ b/src/platforms/css.ts
@@ -3,6 +3,28 @@ import type {PlatformInitializer} from '../types/platformInitializer.js'
 import type {PlatformConfig, TransformedToken} from 'style-dictionary/types'
 import {outputReferencesTransformed, outputReferencesFilter} from 'style-dictionary/utils'
 
+/**
+ * Determines whether a token's value should use CSS variable references.
+ *
+ * For most tokens, we check both that referenced tokens are in the current output
+ * (outputReferencesFilter) and that the string replacement is valid (outputReferencesTransformed).
+ *
+ * Composite border tokens need special handling because:
+ * 1. outputReferencesTransformed returns false for object original values
+ * 2. outputReferencesFilter returns false because width tokens are in a separate CSS file
+ * Style Dictionary's formatter correctly handles var() substitution in flattened composite strings,
+ * and the referenced tokens (borderColor.*, borderWidth.*, focus.outline-*) all exist as CSS variables at runtime.
+ */
+const shouldOutputReferences = (
+  token: TransformedToken,
+  platformOptions: Parameters<typeof outputReferencesFilter>[1],
+) => {
+  if (token.$type === 'border') {
+    return true
+  }
+  return outputReferencesFilter(token, platformOptions) && outputReferencesTransformed(token, platformOptions)
+}
+
 const getCssSelectors = (outputFile: string) => {
   // check for dark in the beginning of the output filename
   const lastSlash = outputFile.lastIndexOf('/')
@@ -62,8 +84,7 @@ export const css: PlatformInitializer = (outputFile, prefix, buildPath, options)
           ]),
         options: {
           showFileHeader: false,
-          outputReferences: (token, platformOptions) =>
-            outputReferencesFilter(token, platformOptions) && outputReferencesTransformed(token, platformOptions),
+          outputReferences: shouldOutputReferences,
           descriptions: false,
           queries: getCssSelectors(outputFile),
           ...options?.options,
@@ -82,8 +103,7 @@ export const css: PlatformInitializer = (outputFile, prefix, buildPath, options)
           ]),
         options: {
           showFileHeader: false,
-          outputReferences: (token, platformOptions) =>
-            outputReferencesFilter(token, platformOptions) && outputReferencesTransformed(token, platformOptions),
+          outputReferences: shouldOutputReferences,
           descriptions: false,
           ...options?.options,
         },
@@ -94,8 +114,7 @@ export const css: PlatformInitializer = (outputFile, prefix, buildPath, options)
         filter: token => isSource(token) && options?.themed !== true && token.$type === 'custom-viewportRange',
         options: {
           showFileHeader: false,
-          outputReferences: (token, platformOptions) =>
-            outputReferencesFilter(token, platformOptions) && outputReferencesTransformed(token, platformOptions),
+          outputReferences: shouldOutputReferences,
         },
       },
       {
@@ -109,8 +128,7 @@ export const css: PlatformInitializer = (outputFile, prefix, buildPath, options)
           ]),
         options: {
           descriptions: false,
-          outputReferences: (token, platformOptions) =>
-            outputReferencesFilter(token, platformOptions) && outputReferencesTransformed(token, platformOptions),
+          outputReferences: shouldOutputReferences,
           showFileHeader: false,
           queries: [
             {


### PR DESCRIPTION
## Summary

Border and outline tokens were resolving to raw values instead of keeping CSS variable references.

**Before:**
```css
--border-default: 0.0625rem solid #d1d9e0;
--focus-outline: 2px solid #0969da;
```

**After:**
```css
--border-default: var(--borderWidth-default) solid var(--borderColor-default);
--focus-outline: var(--focus-outline-width) solid var(--focus-outline-color);
```

## Root cause

Style Dictionary's `outputReferencesTransformed()` always returns `false` for composite tokens (original value is an object, not a string), and `outputReferencesFilter()` returns `false` because width tokens live in a separate CSS file. Together, these prevented reference output for all composite border tokens.

## Fix

Added a `shouldOutputReferences()` helper in `src/platforms/css.ts` that returns `true` for `$type === 'border'` tokens. Style Dictionary's formatter already correctly handles `var()` substitution in flattened composite strings — it just needed to be enabled.

## Validation

- All lint, format, tests, and build pass
- Verified output across light, dark, and dark-dimmed themes
- Alias border tokens (e.g. `border.closed.emphasis`) continue to work correctly