### PR TITLE
fix: ensure Figma base scale output includes all tokens for override themes

### DIFF
--- a/.changeset/figma-collection-override.md
+++ b/.changeset/figma-collection-override.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Fix Figma base scale output for override themes (dark-dimmed, dark-high-contrast, light-high-contrast) to include all tokens. Previously, inherited tokens (e.g. neutral, black, transparent) retained the parent theme's collection name and were missing from the override theme's Figma collection.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@primer/primitives",
-  "version": "11.6.0",
+  "version": "11.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@primer/primitives",
-      "version": "11.6.0",
+      "version": "11.7.0",
       "license": "MIT",
       "devDependencies": {
         "@actions/core": "^1.11.1",

--- a/scripts/buildFigma.ts
+++ b/scripts/buildFigma.ts
@@ -26,6 +26,7 @@ const buildFigma = async (buildOptions: ConfigGeneratorOptions): Promise<void> =
         `src/tokens/base/color/light/display-light.json5`,
         `src/tokens/base/color/light/light.high-contrast.json5`,
       ],
+      collectionOverride: {'base/color/light': 'base/color/light-high-contrast'},
     },
     {
       name: 'dark',
@@ -40,6 +41,7 @@ const buildFigma = async (buildOptions: ConfigGeneratorOptions): Promise<void> =
         `src/tokens/base/color/dark/display-dark.json5`,
         `src/tokens/base/color/dark/dark.high-contrast.json5`,
       ],
+      collectionOverride: {'base/color/dark': 'base/color/dark-high-contrast'},
     },
     {
       theme: 'dark-dimmed',
@@ -49,14 +51,17 @@ const buildFigma = async (buildOptions: ConfigGeneratorOptions): Promise<void> =
         `src/tokens/base/color/dark/display-dark.json5`,
         `src/tokens/base/color/dark/dark.dimmed.json5`,
       ],
+      collectionOverride: {'base/color/dark': 'base/color/dark-dimmed'},
     },
   ]
 
-  for (const {name, source} of baseScales) {
+  for (const {name, source, collectionOverride} of baseScales) {
     const extended = await PrimerStyleDictionary.extend({
       source,
       platforms: {
-        figma: figma(`figma/scales/${name}.json`, buildOptions.prefix, buildOptions.buildPath),
+        figma: figma(`figma/scales/${name}.json`, buildOptions.prefix, buildOptions.buildPath, {
+          collectionOverride,
+        }),
       },
     })
     // build

--- a/src/transformers/figmaAttributes.test.ts
+++ b/src/transformers/figmaAttributes.test.ts
@@ -1,0 +1,97 @@
+import {figmaAttributes} from './figmaAttributes.js'
+import type {TransformedToken, PlatformConfig} from 'style-dictionary/types'
+
+describe('figmaAttributes', () => {
+  const baseToken = {
+    $extensions: {
+      'org.primer.figma': {
+        collection: 'base/color/dark',
+        scopes: ['bgColor'],
+        group: undefined,
+        codeSyntax: undefined,
+      },
+    },
+  } as unknown as TransformedToken
+
+  it('returns collection from token extensions', () => {
+    const result = figmaAttributes.transform(baseToken, {} as PlatformConfig)
+    expect(result).toMatchObject({
+      collection: 'base/color/dark',
+      group: 'base/color/dark',
+    })
+  })
+
+  it('applies collectionOverride when collection matches', () => {
+    const platform = {
+      options: {
+        collectionOverride: {'base/color/dark': 'base/color/dark-dimmed'},
+      },
+    } as unknown as PlatformConfig
+
+    const result = figmaAttributes.transform(baseToken, platform)
+    expect(result).toMatchObject({
+      collection: 'base/color/dark-dimmed',
+      group: 'base/color/dark-dimmed',
+    })
+  })
+
+  it('does not apply collectionOverride when collection does not match', () => {
+    const token = {
+      $extensions: {
+        'org.primer.figma': {
+          collection: 'base/color/dark-dimmed',
+          scopes: ['bgColor'],
+        },
+      },
+    } as unknown as TransformedToken
+
+    const platform = {
+      options: {
+        collectionOverride: {'base/color/dark': 'base/color/dark-dimmed'},
+      },
+    } as unknown as PlatformConfig
+
+    const result = figmaAttributes.transform(token, platform)
+    expect(result).toMatchObject({
+      collection: 'base/color/dark-dimmed',
+      group: 'base/color/dark-dimmed',
+    })
+  })
+
+  it('preserves explicit group when set', () => {
+    const token = {
+      $extensions: {
+        'org.primer.figma': {
+          collection: 'base/color/dark',
+          group: 'custom-group',
+          scopes: ['bgColor'],
+        },
+      },
+    } as unknown as TransformedToken
+
+    const platform = {
+      options: {
+        collectionOverride: {'base/color/dark': 'base/color/dark-dimmed'},
+      },
+    } as unknown as PlatformConfig
+
+    const result = figmaAttributes.transform(token, platform)
+    expect(result).toMatchObject({
+      collection: 'base/color/dark-dimmed',
+      group: 'custom-group',
+    })
+  })
+
+  it('uses theme for mode when available', () => {
+    const platform = {
+      options: {
+        theme: 'dark dimmed',
+      },
+    } as unknown as PlatformConfig
+
+    const result = figmaAttributes.transform(baseToken, platform)
+    expect(result).toMatchObject({
+      mode: 'dark dimmed',
+    })
+  })
+})

--- a/src/transformers/figmaAttributes.ts
+++ b/src/transformers/figmaAttributes.ts
@@ -71,10 +71,14 @@ export const figmaAttributes: Transform = {
   transform: (token: TransformedToken, platform: PlatformConfig = {}) => {
     const {modeOverride, collection, scopes, group, codeSyntax} = token.$extensions?.['org.primer.figma'] || {}
 
+    const collectionOverride = platform.options?.collectionOverride as Record<string, string> | undefined
+    const resolvedCollection =
+      collectionOverride && collection && collection in collectionOverride ? collectionOverride[collection] : collection
+
     return {
       mode: asArray(platform.options?.theme)[0] || modeOverride || 'default',
-      collection,
-      group: group || collection,
+      collection: resolvedCollection,
+      group: group || resolvedCollection,
       scopes: getScopes(scopes),
       codeSyntax,
     }


### PR DESCRIPTION
## Problem

Override themes (`dark-dimmed`, `dark-high-contrast`, `light-high-contrast`) only define tokens that **differ** from their parent theme. For example, `dark.dimmed.json5` overrides `blue`, `green`, `red`, etc. but does **not** redefine `neutral`, `black`, `inset`, or `transparent` since they share the same values as `dark`.

When building Figma base scale output, inherited tokens retained the **parent's** collection name (e.g. `base/color/dark` instead of `base/color/dark-dimmed`). This meant those tokens were missing from the override theme's Figma collection — they appeared under the parent collection instead.

### Affected themes and missing scales

| Theme | Missing from Figma collection |
|---|---|
| `dark-dimmed` | `neutral`, `black`, `inset`, `transparent`, display tokens |
| `dark-high-contrast` | `neutral`, `white`, `inset`, `transparent`, display tokens |
| `light-high-contrast` | `neutral`, `white`, `inset`, `transparent`, display tokens |

## Solution

Added `collectionOverride` support to the `figmaAttributes` transformer. When a `collectionOverride` map is provided via platform options, any token whose collection matches a key in the map gets remapped to the corresponding value.

In `buildFigma.ts`, each override base scale entry now passes a `collectionOverride` that maps the parent collection to the theme's own collection (e.g. `{ 'base/color/dark': 'base/color/dark-dimmed' }`).

### Changes

- **`src/transformers/figmaAttributes.ts`** — Added `collectionOverride` lookup before returning collection/group attributes
- **`scripts/buildFigma.ts`** — Added `collectionOverride` to the 3 affected base scale configs and passes it through to the figma platform
- **`src/transformers/figmaAttributes.test.ts`** — New test file covering the override behavior

## Validation

- ✅ Lint passes
- ✅ All tests pass (including 5 new tests for `figmaAttributes`)
- ✅ Full build succeeds