### PR TITLE
Update light-high-contrast fgColor.draft to custom hex value between neutral scale levels 10 and 11

### DIFF
--- a/.changeset/fgcolor-draft-light-high-contrast.md
+++ b/.changeset/fgcolor-draft-light-high-contrast.md
@@ -1,0 +1,7 @@
+---
+"@primer/primitives": patch
+---
+
+Update light-high-contrast fgColor.draft to custom hex value between neutral scale levels 10 and 11
+
+Lightens the draft state icon color in the light high-contrast theme from `{base.color.neutral.11}` (#393F46) to a custom value (#444B53) that is closer to the adjacent status colors in lightness while still clearing 7:1 contrast against all required backgrounds. This improves visual differentiation between draft (gray) and open/closed/done (green/red/purple) status icons in PR lists. Follows the same custom-hex approach used for fgColor.success, fgColor.danger, and fgColor.done in PR #1346.

--- a/scripts/colorContrast.config.ts
+++ b/scripts/colorContrast.config.ts
@@ -97,6 +97,9 @@ const baseRequirements: ContrastRequirementBlueprint[] = [
   ['contrast.text', 'fgColor-done', 'bgColor-default'],
   ['contrast.text', 'fgColor-done', 'bgColor-muted'],
   ['contrast.text', 'fgColor-done', 'bgColor-inset'],
+  ['contrast.text', 'fgColor-draft', 'bgColor-default'],
+  ['contrast.text', 'fgColor-draft', 'bgColor-muted'],
+  ['contrast.text', 'fgColor-draft', 'bgColor-inset'],
   ['contrast.text', 'fgColor-upsell', 'bgColor-default'],
   ['contrast.text', 'fgColor-upsell', 'bgColor-muted'],
   ['contrast.text', 'fgColor-upsell', 'bgColor-inset'],
@@ -113,6 +116,7 @@ const baseRequirements: ContrastRequirementBlueprint[] = [
   ['contrast.text', 'fgColor-attention', 'bgColor-attention-muted'],
   ['contrast.text', 'fgColor-severe', 'bgColor-severe-muted'],
   ['contrast.text', 'fgColor-done', 'bgColor-done-muted'],
+  ['contrast.text', 'fgColor-draft', 'bgColor-neutral-muted'],
   ['contrast.text', 'fgColor-upsell', 'bgColor-upsell-muted'],
   ['contrast.text', 'fgColor-sponsors', 'bgColor-sponsors-muted'],
   // fgColor-onEmphasis

--- a/src/tokens/functional/color/fgColor.json5
+++ b/src/tokens/functional/color/fgColor.json5
@@ -432,6 +432,9 @@
             web: 'var(--fgColor-draft)',
           },
         },
+        'org.primer.overrides': {
+          'light-high-contrast': '#444B53', /* Custom hex between neutral.10 and neutral.11: neutral.11 is too dark and visually indistinct from status colors (open/closed/done). Same approach as fgColor.success/danger/done overrides (PR #1346). Clears 7.02:1 vs bgColor-neutral-muted (#E0E6EB). */
+        },
         'org.primer.llm': {
           usage: ['draft-text', 'draft-pr', 'draft-issue'],
           rules: 'Use for draft/WIP status text. Conveys incomplete or pending state.',


### PR DESCRIPTION
## Summary

Follow-up to #1346. In the `light-high-contrast` theme, the draft PR icon color (`fgColor.draft`) inherits from `fgColor.neutral`, which resolves to `{base.color.neutral.11}` (#393F46). At this level, the draft icon is very dark and visually hard to distinguish from the saturated status icons (open/closed/done) that were updated in #1346.

This PR adds a `light-high-contrast` override on `fgColor.draft` with a custom hex value (`#444B53`) interpolated between `neutral.10` and `neutral.11`. This follows the same approach used for `fgColor.success`, `fgColor.danger`, and `fgColor.done` in #1346. The value is as light as possible while clearing 7:1 contrast against all required background pairings.

### How we got here

PR #1346 updated three status `fgColor` tokens (`success`, `danger`, `done`) to custom hex values between scale levels 5 and 6, improving chromatic distinction between open, closed, and merged/done PR icons. However, the neutral/draft icon was not addressed, and [user feedback confirmed](https://github.com/orgs/community/discussions/191306#discussioncomment-16636820) that the draft icon remains too similar to the status icons in the light high-contrast theme. The constraining background is `bgColor-neutral-muted` (`{base.color.neutral.4}` = `#E0E6EB`), which is the darkest background `fgColor.draft` may appear on.

## List of notable changes

In `src/tokens/functional/color/fgColor.json5`, added a `light-high-contrast` override for `fgColor.draft`:

| Token | Before (inherited) | After (custom hex) | vs `bgColor-neutral-muted` (#E0E6EB) |
|---|---|---|---|
| `fgColor.draft` | `{base.color.neutral.11}` (`#393F46`) | `#444B53` | 7.02:1 |

Full contrast results for `#444B53` in `light-high-contrast`:

| Background | Value | Contrast |
|---|---|---|
| `bgColor-default` | `#FFFFFF` | 8.83:1 |
| `bgColor-muted` | `#E6EAEF` | 7.31:1 |
| `bgColor-inset` | `#EFF2F5` | 7.86:1 |
| `bgColor-neutral-muted` | `#E0E6EB` | 7.02:1 |

In `scripts/colorContrast.config.ts`, added contrast validation pairs for `fgColor-draft` against `bgColor-default`, `bgColor-muted`, `bgColor-inset`, and `bgColor-neutral-muted`.

## What should reviewers focus on?

- Confirm only the `light-high-contrast` override on `fgColor.draft` changed in `fgColor.json5`. No other theme, base scale, or token values should differ
- Verify the custom hex value is visually distinguishable from the status icons (open: green, closed: red, done: purple) on the PR list page with the light high-contrast theme enabled
- Confirm the new contrast validation pairs for `fgColor-draft` are appropriate

## Steps to test

1. Apply the `light-high-contrast` theme on a repo with a mix of open, closed, merged, and **draft** PRs
2. Confirm that the draft (gray) icon is visually distinguishable from the open (green), closed (red), and done (purple) status icons
3. Run `npm run check:contrast` to confirm all contrast pairs pass

## Supporting resources

- Original user report: https://github.com/orgs/community/discussions/191306
- Accessibility tracking issue: https://github.com/github/accessibility-external/issues/1607
- Previous PR: https://github.com/primer/primitives/pull/1346

## Contributor checklist

- [x] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
- [ ] Verify the design tokens changed in this PR are expected using the diffing results in this PR