### PR TITLE
Updated to render border radius definitions in storybook.

### DIFF
--- a/docs/storybook/stories/Size/Border.stories.tsx
+++ b/docs/storybook/stories/Size/Border.stories.tsx
@@ -4,6 +4,7 @@ import {SizeTokenSwatch} from '../StorybookComponents/SizeTokenSwatch/SizeTokenS
 import {DataTable, Table} from '@primer/react/experimental'
 import {getTokensByName} from '../utilities/getTokensByName'
 import sizeTokens from '../../../../dist/docs/functional/size/border.json'
+import radiusTokens from '../../../../dist/docs/functional/size/radius.json'
 import {tokenColumn, outputValueColumn, sourceValueColumn} from '../utilities/commonTableColumns'
 
 export default {
@@ -50,7 +51,7 @@ export const BorderSize = () => {
 BorderSize.tags = ['snapshotLight']
 
 export const BorderRadius = () => {
-  const data = getTokensByName(sizeTokens, 'borderRadius').map(token => ({id: token.name, ...token}))
+  const data = getTokensByName(radiusTokens, 'borderRadius').map(token => ({id: token.name, ...token}))
 
   return (
     <Table.Container>


### PR DESCRIPTION
## Summary

I updated the border radius page in storybook to pull the border radius definitions that moved from border.json to radius.json in the docs.

## List of notable changes:

- **updated** documentation for **border radius** because they didn't render


## What should reviewers focus on?

- The border radius definitions render and are visible

## Steps to test:

1. Open the preview documentation that has been deployed in this pull request
2. Go to [size / functional / border / border radius](http://localhost:6006/?path=/story/size-functional-border--border-radius)
3. You see the border radius definitions.


## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
- [ ] Verify the design tokens changed in this PR are expected using the diffing results in this PR
