### PR TITLE
docs: Simplify Storybook dependency install with postinstall hook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,8 @@ Good pull requests are a fantastic help. They should remain focused in scope and
 
 1. Clone [this repository](https://github.com/primer/primitives).
 1. Create a new feature branch: `git checkout -b my-handle/my-branch-name`.
-1. Configure and install the dependencies: `npm install --legacy-peer-deps`
+1. Install dependencies: `npm install`
+   - This automatically installs both root and Storybook workspace dependencies via the `postinstall` hook
 1. Make your changes and commit them.
 1. Create a changeset for your changes if your contribution affects distributed code: `npx changeset`
    - See [changesets/changesets](https://github.com/changesets/changesets) for more information.
@@ -42,7 +43,7 @@ Good pull requests are a fantastic help. They should remain focused in scope and
    - If the tests pass, you should see a status check advising you that a canary build of `@primer/primitives` has been published, and ready to test in-app.
    - If the tests fail, review the logs and address any issues.
    - If the builds fail for any other reason (as they occasionally do), they may need to be manually restarted.
-1. 🙌 Nice job! Sit back and wait for your pull request to be reviewed.
+1. Nice job! Sit back and wait for your pull request to be reviewed.
 
 Here are a few things you can do that will increase the likelihood of your pull request being accepted:
 

--- a/docs/storybook/package-lock.json
+++ b/docs/storybook/package-lock.json
@@ -2189,6 +2189,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.6",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.6.tgz",
@@ -3244,6 +3255,14 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -5394,6 +5413,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -5522,11 +5548,11 @@
       }
     },
     "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT"
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
+      "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/readdirp": {
       "version": "3.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@primer/primitives",
       "version": "11.7.1",
+      "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "prepack": "npm run build",
     "release": "changeset publish",
     "storybook": "npm run build:tokens && cd docs/storybook && npm run storybook",
-    "storybook:install": "cd docs/storybook && npm ci --legacy-peer-deps --no-audit --no-fund"
+    "storybook:install": "cd docs/storybook && npm ci --no-audit --no-fund",
+    "postinstall": "npm run storybook:install"
   },
   "prettier": "@github/prettier-config",
   "devDependencies": {


### PR DESCRIPTION
## Problem
The docs/storybook workspace requires separate `npm ci` from contributors and agents, adding complexity and friction to the setup workflow.

## Solution
Use npm's `postinstall` hook to automatically install Storybook dependencies whenever root dependencies are installed.

### How it works
- Root `npm install` now triggers postinstall hook
- Postinstall hook runs `npm run storybook:install` 
- Both root and docs/storybook dependencies install in one command

### Benefits
- No separate install steps for contributors
- Agents automatically handle both installs  
- No npm workspaces complexity
- Single command: `npm install`

## Changes
- Added `postinstall` hook to npm scripts in package.json
- Updated `storybook:install` script to simplify command
- Updated CONTRIBUTING.md to reflect simpler workflow