### PR TITLE
chore: improve postinstall script error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "release": "changeset publish",
     "storybook": "npm run build:tokens && cd docs/storybook && npm run storybook",
     "storybook:install": "cd docs/storybook && npm ci --no-audit --no-fund",
-    "postinstall": "npm run storybook:install"
+    "postinstall": "npm run storybook:install || echo 'Warning: Storybook dependencies were not installed. Run npm run storybook:install manually.'"
   },
   "prettier": "@github/prettier-config",
   "devDependencies": {


### PR DESCRIPTION
Updates the postinstall npm script to gracefully handle Storybook dependency installation failures with a clear user-facing warning message instead of failing silently.

## Change
```json
-"postinstall": "npm run storybook:install"
+"postinstall": "npm run storybook:install || echo 'Warning: Storybook dependencies were not installed. Run npm run storybook:install manually.'"
```

This ensures installation continues even if Storybook dependencies fail, while providing clear guidance to users on how to recover.