### PR TITLE
feat: generate dist/deprecated.json and dist/removed.json on build

### DIFF
--- a/contributor-docs/agents/token-authoring.md
+++ b/contributor-docs/agents/token-authoring.md
@@ -93,11 +93,11 @@ Add `org.primer.llm` to include tokens in `DESIGN_TOKENS_SPEC.md`:
 
 ## Removing or Renaming Tokens
 
-When you remove or rename tokens in `src/tokens/`, you **must** document them in `src/tokens/removed/removed.json`.
+When you remove or rename tokens in `src/tokens/`, you **must** document them in `src/tokens/removed.json`.
 
 ### File format
 
-`src/tokens/removed/removed.json` is a flat JSON object. Each key is the source token path (dot-separated, matching the nested key structure in the JSON5 source files). The value is either:
+`src/tokens/removed.json` is a flat JSON object. Each key is the source token path (dot-separated, matching the nested key structure in the JSON5 source files). The value is either:
 
 - `null` — token was fully deleted with no replacement
 - `"new.token.path"` — token was renamed/replaced (points to the new name)
@@ -125,7 +125,6 @@ has the path `fgColor.muted`. The file name/location does not matter — only th
 
 ### Rules
 
-1. Create `src/tokens/removed/removed.json` if it doesn't exist
-2. If it already exists, merge your entries into it (don't overwrite existing entries)
+1. Add your entries to `src/tokens/removed.json` (don't overwrite existing entries)
 3. Every token path you delete or rename must have an entry
 4. Use `null` for deletions, use the new token path string for renames

--- a/contributor-docs/agents/token-authoring.md
+++ b/contributor-docs/agents/token-authoring.md
@@ -126,5 +126,5 @@ has the path `fgColor.muted`. The file name/location does not matter — only th
 ### Rules
 
 1. Add your entries to `src/tokens/removed.json` (don't overwrite existing entries)
-3. Every token path you delete or rename must have an entry
-4. Use `null` for deletions, use the new token path string for renames
+2. Every token path you delete or rename must have an entry
+3. Use `null` for deletions, use the new token path string for renames

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@primer/primitives",
-  "version": "11.7.1",
+  "version": "11.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@primer/primitives",
-      "version": "11.7.1",
+      "version": "11.8.0",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/scripts/buildTokens.ts
+++ b/scripts/buildTokens.ts
@@ -388,6 +388,7 @@ export const buildDesignTokens = async (buildOptions: ConfigGeneratorOptions): P
     fs.writeFileSync(`${buildOptions.buildPath}deprecated.json`, JSON.stringify(combined, null, 2))
   } catch (e) {
     console.error('🛑 Error trying to combine deprecated tokens:', e)
+    throw e
   }
 
   /** -----------------------------------

--- a/scripts/buildTokens.ts
+++ b/scripts/buildTokens.ts
@@ -1,6 +1,5 @@
 import type {Config} from 'style-dictionary/types'
 import {PrimerStyleDictionary} from '../src/primerStyleDictionary.js'
-import {copyFromDir} from '../src/utilities/index.js'
 import {deprecatedJson, css, docJson, fallbacks, styleLint} from '../src/platforms/index.js'
 import type {
   ConfigGeneratorOptions,
@@ -375,9 +374,26 @@ export const buildDesignTokens = async (buildOptions: ConfigGeneratorOptions): P
   }
 
   /** -----------------------------------
-   * Copy `removed` files
+   * Combine deprecated token files
    * ----------------------------------- */
-  copyFromDir(`src/tokens/removed`, `${buildOptions.buildPath}removed`)
+  try {
+    const combined: Record<string, unknown> = {}
+    for (const {filename} of deprecatedBuilds) {
+      const filePath = `${buildOptions.buildPath}deprecated/${filename}.json`
+      if (fs.existsSync(filePath)) {
+        const content = JSON.parse(fs.readFileSync(filePath, 'utf8')) as Record<string, unknown>
+        Object.assign(combined, content)
+      }
+    }
+    fs.writeFileSync(`${buildOptions.buildPath}deprecated.json`, JSON.stringify(combined, null, 2))
+  } catch (e) {
+    console.error('🛑 Error trying to combine deprecated tokens:', e)
+  }
+
+  /** -----------------------------------
+   * Copy `removed.json` to dist
+   * ----------------------------------- */
+  fs.copyFileSync('src/tokens/removed.json', `${buildOptions.buildPath}removed.json`)
 
   const excludePaths = [
     (path: string) => {

--- a/scripts/checkRemovedTokens.ts
+++ b/scripts/checkRemovedTokens.ts
@@ -1,13 +1,12 @@
 import {execSync} from 'child_process'
 import fs from 'fs'
-import path from 'path'
 import json5 from 'json5'
 import {walkDir} from './utilities/walkDir.js'
 import {extractTokenNames} from './utilities/extractTokenNames.js'
 
 const TOKEN_DIR = 'src/tokens'
-const REMOVED_DIR = 'src/tokens/removed'
-const IGNORE_DIRS = ['removed', 'fallback']
+const REMOVED_FILE = 'src/tokens/removed.json'
+const IGNORE_DIRS = ['fallback']
 
 // ---------------------------------------------------------------------------
 // CLI flag helper (supports both --flag=value and --flag value)
@@ -103,20 +102,16 @@ function collectTokensFromCommit(commit: string): Set<string> {
 function collectDocumentedRemovals(): Set<string> {
   const removals = new Set<string>()
 
-  if (!fs.existsSync(REMOVED_DIR)) return removals
+  if (!fs.existsSync(REMOVED_FILE)) return removals
 
-  const files = fs.readdirSync(REMOVED_DIR).filter(f => f.endsWith('.json') || f.endsWith('.json5'))
-
-  for (const file of files) {
-    try {
-      const content = fs.readFileSync(path.join(REMOVED_DIR, file), 'utf-8')
-      const parsed = json5.parse(content)
-      for (const key of Object.keys(parsed)) {
-        removals.add(key)
-      }
-    } catch (e) {
-      console.warn(`⚠️  Could not parse removed file ${file}: ${e}`)
+  try {
+    const content = fs.readFileSync(REMOVED_FILE, 'utf-8')
+    const parsed = json5.parse(content)
+    for (const key of Object.keys(parsed)) {
+      removals.add(key)
     }
+  } catch (e) {
+    console.warn(`⚠️  Could not parse ${REMOVED_FILE}: ${e}`)
   }
 
   return removals
@@ -160,12 +155,12 @@ const documented = collectDocumentedRemovals()
 const undocumented = removed.filter(t => !documented.has(t)).sort()
 
 if (undocumented.length === 0) {
-  console.log(`✅ ${removed.length} removed token(s) are properly documented in ${REMOVED_DIR}/`)
+  console.log(`✅ ${removed.length} removed token(s) are properly documented in ${REMOVED_FILE}`)
   process.exit(0)
 }
 
-console.error(`\n❌ ${undocumented.length} token(s) removed but not documented in ${REMOVED_DIR}/\n`)
-console.error('Add them to src/tokens/removed/removed.json:')
+console.error(`\n❌ ${undocumented.length} token(s) removed but not documented in ${REMOVED_FILE}\n`)
+console.error(`Add them to ${REMOVED_FILE}:`)
 console.error('  - null → fully removed')
 console.error('  - "new.token.name" → renamed/replaced\n')
 console.error('Missing entries:')

--- a/scripts/validateTokenJson.ts
+++ b/scripts/validateTokenJson.ts
@@ -7,7 +7,7 @@ import {walkDir} from './utilities/walkDir.js'
 import {validateTokenWithSchema, type validationErrors} from './utilities/validateTokenWithSchema.js'
 
 export const validateTokens = (tokenDir: string) => {
-  const tokenFiles = walkDir(tokenDir, ['removed', 'fallback'])
+  const tokenFiles = walkDir(tokenDir, ['removed', 'fallback']).filter(f => f.endsWith('.json5'))
   const failed: validationErrors[] = []
 
   for (const file of tokenFiles) {

--- a/src/filters/isDeprecated.ts
+++ b/src/filters/isDeprecated.ts
@@ -6,5 +6,6 @@ import type {TransformedToken} from 'style-dictionary/types'
  * @returns boolean
  */
 export const isDeprecated = (token: TransformedToken): boolean => {
-  return token.$deprecated === true || typeof token.$deprecated === 'string'
+  const deprecated = (token.original as Record<string, unknown>).$deprecated ?? token.$deprecated
+  return deprecated === true || typeof deprecated === 'string'
 }

--- a/src/tokens/removed.json
+++ b/src/tokens/removed.json
@@ -417,5 +417,12 @@
   "mktg.btn.dark.hover.text": null,
   "mktg.btn.dark.hover.border": null,
   "mktg.btn.dark.focus.border": null,
-  "mktg.btn.dark.focus.borderInset": null
+  "mktg.btn.dark.focus.borderInset": null,
+  "control.xsmall.lineBoxHeight": null,
+  "control.small.lineBoxHeight": null,
+  "control.medium.lineBoxHeight": null,
+  "control.large.lineBoxHeight": null,
+  "control.xlarge.lineBoxHeight": null,
+  "text.display.lineBoxHeight": "text.display.lineHeight",
+  "shadow.floating.legacy": "shadow.floating.small"
 }

--- a/src/transformers/jsonDeprecated.ts
+++ b/src/transformers/jsonDeprecated.ts
@@ -11,6 +11,8 @@ export const jsonDeprecated: Transform = {
   type: 'value',
   transitive: true,
   filter: isDeprecated,
-  transform: (token: TransformedToken) =>
-    typeof token.$deprecated === 'string' ? token.$deprecated.replace(/[{}]/g, '') : null,
+  transform: (token: TransformedToken) => {
+    const deprecated = (token.original as Record<string, unknown>).$deprecated ?? token.$deprecated
+    return typeof deprecated === 'string' ? deprecated.replace(/[{}]/g, '') : null
+  },
 }


### PR DESCRIPTION
## Summary

Generates two new flat JSON files in `dist/` on every build, making deprecated and removed token data easily consumable by downstream tooling.

### `dist/deprecated.json`

A flat map of all currently deprecated token names to their replacement (or `null`):

```json
{
  "focus.outlineColor": "focus.outline-color",
  "outline.focus.offset": "focus.outline-offset",
  "outline.focus.width": "focus.outline-width"
}
```

### `dist/removed.json`

A flat map of all historically removed/renamed token names to their replacement (or `null`). Copied directly from `src/tokens/removed.json`.

---

## Changes

### Bug fix — `isDeprecated` / `jsonDeprecated`

Style Dictionary v5 resolves reference strings inside `$deprecated` (e.g. `'{focus.outline-color}'` → resolved color object), causing the `isDeprecated` filter to return `false` for tokens with reference-based deprecation messages. Both `isDeprecated` and `jsonDeprecated` now read `token.original.$deprecated` (pre-resolution value) with a fallback to `token.$deprecated`.

### Build output

- **`dist/deprecated.json`** — merged from per-category Style Dictionary builds (theme, typography, size, motion)
- **`dist/removed.json`** — copied from `src/tokens/removed.json`

### Consolidate removed token files

- Merged `src/tokens/removed/{color,size,shadow}.json` into a single `src/tokens/removed.json`
- Added tokens removed in the last year: `control.*.lineBoxHeight`, `text.display.lineBoxHeight`, `shadow.floating.legacy`
- Updated `checkRemovedTokens.ts` to read from the single file
- Updated `validateTokenJson.ts` to only validate `.json5` files (prevents `removed.json` from being mistakenly validated as token definitions)
- Updated contributor docs to reference the new path