### PR TITLE
add contrast badges

### DIFF
--- a/docs/storybook/stories/StorybookComponents/ColorScale/ColorScale.css
+++ b/docs/storybook/stories/StorybookComponents/ColorScale/ColorScale.css
@@ -1,9 +1,10 @@
 .ColorScale--block {
-  display: grid;
-  grid-template-columns: max-content max-content;
-  gap: 1rem;
+  padding: 10px 12px;
+  min-height: 72px;
+  display: flex;
+  flex-direction: column;
   justify-content: space-between;
-  padding: 0.5rem;
+  gap: 4px;
 }
 
 .ColorScale--block:first-of-type {
@@ -21,4 +22,77 @@
   gap: 1rem;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   border-radius: 6px;
+}
+
+.cs-name {
+  margin: 0;
+  font-weight: bold;
+  font-size: 13px;
+  line-height: 1.2;
+  font-family: monospace;
+}
+
+.cs-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  line-height: 1;
+}
+
+.cs-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  position: relative;
+  cursor: default;
+}
+
+.cs-badge[data-tooltip]:hover::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  background: var(--bgColor-emphasis, #1f2328);
+  color: var(--fgColor-onEmphasis, #ffffff);
+  font-size: 11px;
+  font-family: sans-serif;
+  padding: 3px 7px;
+  border-radius: 4px;
+  pointer-events: none;
+  z-index: 100;
+}
+
+.cs-aa {
+  font-size: 12px;
+  font-weight: bold;
+}
+
+.cs-num {
+  font-size: 11px;
+}
+
+.cs-square {
+  display: inline-block;
+  width: 11px;
+  height: 11px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.cs-square--outline {
+  border: 1.5px solid currentColor;
+}
+
+.cs-square--filled {
+  border: none;
+}
+
+.cs-hex {
+  margin-left: auto;
+  font-size: 11px;
+  font-family: monospace;
+  opacity: 0.75;
 }

--- a/docs/storybook/stories/StorybookComponents/ColorScale/ColorScale.tsx
+++ b/docs/storybook/stories/StorybookComponents/ColorScale/ColorScale.tsx
@@ -52,11 +52,46 @@ type ProbeConfig = {
 }
 
 const PROBES: ProbeConfig[] = [
-  {key: 'fgDefault', cssVar: '--fgColor-default', cssProp: 'color', icon: 'aa', tooltip: 'Contrast for fgColor-default', numOnSwatch: true},
-  {key: 'fgMuted', cssVar: '--fgColor-muted', cssProp: 'color', icon: 'aa', tooltip: 'Contrast for fgColor-muted', numOnSwatch: true},
-  {key: 'borderDefault', cssVar: '--borderColor-default', cssProp: 'color', icon: 'outline-square', tooltip: 'Contrast for borderColor-default', numOnSwatch: false},
-  {key: 'bgDefault', cssVar: '--bgColor-default', cssProp: 'backgroundColor', icon: 'filled-square', tooltip: 'Contrast for bgColor-default', numOnSwatch: true},
-  {key: 'bgMuted', cssVar: '--bgColor-muted', cssProp: 'backgroundColor', icon: 'filled-square', tooltip: 'Contrast for bgColor-muted', numOnSwatch: true},
+  {
+    key: 'fgDefault',
+    cssVar: '--fgColor-default',
+    cssProp: 'color',
+    icon: 'aa',
+    tooltip: 'Contrast for fgColor-default',
+    numOnSwatch: true,
+  },
+  {
+    key: 'fgMuted',
+    cssVar: '--fgColor-muted',
+    cssProp: 'color',
+    icon: 'aa',
+    tooltip: 'Contrast for fgColor-muted',
+    numOnSwatch: true,
+  },
+  {
+    key: 'borderDefault',
+    cssVar: '--borderColor-default',
+    cssProp: 'color',
+    icon: 'outline-square',
+    tooltip: 'Contrast for borderColor-default',
+    numOnSwatch: false,
+  },
+  {
+    key: 'bgDefault',
+    cssVar: '--bgColor-default',
+    cssProp: 'backgroundColor',
+    icon: 'filled-square',
+    tooltip: 'Contrast for bgColor-default',
+    numOnSwatch: true,
+  },
+  {
+    key: 'bgMuted',
+    cssVar: '--bgColor-muted',
+    cssProp: 'backgroundColor',
+    icon: 'filled-square',
+    tooltip: 'Contrast for bgColor-muted',
+    numOnSwatch: true,
+  },
 ]
 
 export type ColorScaleProps = {

--- a/docs/storybook/stories/StorybookComponents/ColorScale/ColorScale.tsx
+++ b/docs/storybook/stories/StorybookComponents/ColorScale/ColorScale.tsx
@@ -1,6 +1,63 @@
 import React from 'react'
-import {toHex, readableColor} from 'color2k'
+import {toHex} from 'color2k'
 import './ColorScale.css'
+
+function linearize(c: number): number {
+  return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+}
+
+function luminance(hex: string): number {
+  const r = parseInt(hex.slice(1, 3), 16) / 255
+  const g = parseInt(hex.slice(3, 5), 16) / 255
+  const b = parseInt(hex.slice(5, 7), 16) / 255
+  return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b)
+}
+
+function contrast(a: string, b: string): number {
+  const la = luminance(a)
+  const lb = luminance(b)
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05)
+}
+
+function fmt(r: number): string {
+  const x = Math.round(r * 10) / 10
+  return x % 1 === 0 ? x.toFixed(0) : x.toFixed(1)
+}
+
+function safeHex(rgb: string): string | null {
+  try {
+    return toHex(rgb)
+  } catch {
+    return null
+  }
+}
+
+const PROBE_STYLE: React.CSSProperties = {
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  width: 1,
+  height: 1,
+  opacity: 0,
+  pointerEvents: 'none',
+}
+
+type ProbeConfig = {
+  key: string
+  cssVar: string
+  cssProp: 'color' | 'backgroundColor'
+  icon: 'aa' | 'outline-square' | 'filled-square'
+  tooltip: string
+  numOnSwatch: boolean
+}
+
+const PROBES: ProbeConfig[] = [
+  {key: 'fgDefault', cssVar: '--fgColor-default', cssProp: 'color', icon: 'aa', tooltip: 'Contrast for fgColor-default', numOnSwatch: true},
+  {key: 'fgMuted', cssVar: '--fgColor-muted', cssProp: 'color', icon: 'aa', tooltip: 'Contrast for fgColor-muted', numOnSwatch: true},
+  {key: 'borderDefault', cssVar: '--borderColor-default', cssProp: 'color', icon: 'outline-square', tooltip: 'Contrast for borderColor-default', numOnSwatch: false},
+  {key: 'bgDefault', cssVar: '--bgColor-default', cssProp: 'backgroundColor', icon: 'filled-square', tooltip: 'Contrast for bgColor-default', numOnSwatch: true},
+  {key: 'bgMuted', cssVar: '--bgColor-muted', cssProp: 'backgroundColor', icon: 'filled-square', tooltip: 'Contrast for bgColor-muted', numOnSwatch: true},
+]
 
 export type ColorScaleProps = {
   color?: string
@@ -8,20 +65,21 @@ export type ColorScaleProps = {
 }
 
 export const ColorScale = ({color, border}: ColorScaleProps) => {
-  const ref = React.useRef<HTMLDivElement | null>(null)
+  const swatchRef = React.useRef<HTMLDivElement>(null)
+  const probeRefs = React.useRef<Record<string, HTMLDivElement | null>>({})
+
   const [hex, setHex] = React.useState<string | null>(null)
-  const [textColor, setTextColor] = React.useState<string>('currentColor')
+  const [probeColors, setProbeColors] = React.useState<Record<string, string | null>>({})
 
   const recalculate = React.useCallback(() => {
     setTimeout(() => {
-      if (ref.current === null) {
-        return
+      if (swatchRef.current) setHex(safeHex(getComputedStyle(swatchRef.current).backgroundColor))
+      const next: Record<string, string | null> = {}
+      for (const {key, cssProp} of PROBES) {
+        const el = probeRefs.current[key]
+        if (el) next[key] = safeHex(getComputedStyle(el)[cssProp])
       }
-      const style = getComputedStyle(ref.current)
-      const rgb = style.getPropertyValue('background-color')
-      const asHex = toHex(rgb)
-      setHex(asHex)
-      setTextColor(asHex ? readableColor(asHex) : 'currentColor')
+      setProbeColors(next)
     }, 0)
   }, [])
 
@@ -30,31 +88,78 @@ export const ColorScale = ({color, border}: ColorScaleProps) => {
   }, [color, recalculate])
 
   React.useEffect(() => {
-    const observer = new MutationObserver(recalculate)
-    observer.observe(document.body, {
+    const obs = new MutationObserver(recalculate)
+    obs.observe(document.body, {
       attributes: true,
       attributeFilter: ['data-color-mode', 'data-light-theme', 'data-dark-theme'],
     })
-    return () => observer.disconnect()
+    return () => obs.disconnect()
   }, [recalculate])
+
+  const vsBlack = hex ? contrast(hex, '#000000') : null
+  const vsWhite = hex ? contrast(hex, '#ffffff') : null
+  const onSwatch = (vsBlack ?? 0) >= (vsWhite ?? 0) ? '#000000' : '#ffffff'
 
   return (
     <div
       className="ColorScale--block"
       style={{
         backgroundColor: `var(--${color})`,
-        color: textColor,
-        border: border ? '1px solid var(--borderColor-default)' : 'none',
+        outline: border ? '1px solid var(--borderColor-default)' : undefined,
       }}
       data-color-scale
-      ref={ref}
+      ref={swatchRef}
     >
-      <p data-token-name>{color}</p>
-      {hex ? <p data-token-name>{hex}</p> : null}
+      {/* Probes — read color/bg values from CSS vars */}
+      {PROBES.map(({key, cssVar, cssProp}) => (
+        <div
+          key={key}
+          ref={el => {
+            probeRefs.current[key] = el
+          }}
+          aria-hidden
+          style={{
+            ...PROBE_STYLE,
+            ...(cssProp === 'color' ? {color: `var(${cssVar})`} : {backgroundColor: `var(${cssVar})`}),
+          }}
+        />
+      ))}
+
+      <p className="cs-name" style={{color: onSwatch}}>
+        {color}
+      </p>
+
+      <div className="cs-row">
+        {PROBES.map(({key, cssVar, icon, tooltip, numOnSwatch}) => {
+          const probeColor = probeColors[key]
+          const ratio = hex && probeColor ? contrast(hex, probeColor) : null
+          if (ratio === null) return null
+          const numColor = numOnSwatch ? onSwatch : `var(${cssVar})`
+          return (
+            <span key={key} className="cs-badge" data-tooltip={tooltip}>
+              {icon === 'aa' ? (
+                <span className="cs-aa" style={{color: `var(${cssVar})`}}>
+                  Aa
+                </span>
+              ) : icon === 'outline-square' ? (
+                <span className="cs-square cs-square--outline" style={{borderColor: `var(${cssVar})`}} />
+              ) : (
+                <span className="cs-square cs-square--filled" style={{backgroundColor: `var(${cssVar})`}} />
+              )}
+              <span className="cs-num" style={{color: numColor}}>
+                {fmt(ratio)}
+              </span>
+            </span>
+          )
+        })}
+        {hex && (
+          <span className="cs-hex" style={{color: onSwatch}}>
+            {hex}
+          </span>
+        )}
+      </div>
     </div>
   )
 }
-
-// export default ColorScale
 
 ColorScale.displayName = 'ColorScale'

--- a/docs/storybook/stories/StorybookComponents/ColorScale/ColorScale.tsx
+++ b/docs/storybook/stories/StorybookComponents/ColorScale/ColorScale.tsx
@@ -65,7 +65,7 @@ export type ColorScaleProps = {
 }
 
 export const ColorScale = ({color, border}: ColorScaleProps) => {
-  const swatchRef = React.useRef<HTMLDivElement>(null)
+  const swatchRef = React.useRef<HTMLDivElement | null>(null)
   const probeRefs = React.useRef<Record<string, HTMLDivElement | null>>({})
 
   const [hex, setHex] = React.useState<string | null>(null)


### PR DESCRIPTION
This pull request significantly improves the `ColorScale` component in Storybook by enhancing its accessibility and usability. The changes add dynamic contrast ratio calculations for various foreground and background color combinations, introduce a new visual badge system for displaying these ratios, and update the component's styling for better clarity and structure.

<img width="794" height="1296" alt="CleanShot 2026-05-08 at 14 51 35@2x" src="https://github.com/user-attachments/assets/8cfbe0a8-0f83-40ea-a70e-99ebf3d1cfac" />
