### PR TITLE
fix: update border width and border radius token descriptions

### DIFF
--- a/src/tokens/functional/size/border.json5
+++ b/src/tokens/functional/size/border.json5
@@ -19,7 +19,7 @@
   borderWidth: {
     default: {
       $value: '{borderWidth.thin}',
-      $description: 'Default border width for most UI elements. Alias of borderWidth.thin (1px)',
+      $description: 'Semantic token: preferred default border width for standard component borders. Use this in normal component code unless a specific scale value is required.',
       $type: 'dimension',
       $extensions: {
         'org.primer.figma': {
@@ -30,7 +30,7 @@
     },
     thin: {
       $value: {value: 1, unit: 'px'},
-      $description: 'Standard 1px border width. Use for most borders, dividers, and outlines throughout the interface',
+      $description: 'Scale token: 1px border width. Use when selecting an explicit size from the border-width scale.',
       $type: 'dimension',
       $extensions: {
         'org.primer.figma': {
@@ -41,7 +41,7 @@
     },
     thick: {
       $value: {value: 2, unit: 'px'},
-      $description: 'Thick 2px border for emphasis. Use for focus indicators, selected states, or to emphasize important boundaries',
+      $description: 'Scale token: 2px border width for emphasis or focus states.',
       $type: 'dimension',
       $extensions: {
         'org.primer.figma': {
@@ -56,7 +56,7 @@
     },
     thicker: {
       $value: {value: 4, unit: 'px'},
-      $description: 'Extra thick 4px border for maximum emphasis. Use sparingly for high-contrast focus indicators or critical visual separators',
+      $description: 'Scale token: 4px border width for strong emphasis.',
       $type: 'dimension',
       $extensions: {
         'org.primer.figma': {

--- a/src/tokens/functional/size/radius.json5
+++ b/src/tokens/functional/size/radius.json5
@@ -2,7 +2,7 @@
   borderRadius: {
     small: {
       $value: {value: 3, unit: 'px'},
-      $description: 'Small border radius (3px). Use for small variants of components or small UI elements like badges, tags, or anything below 16px in height',
+      $description: 'Scale token: 3px radius for compact UI elements or small component variants.',
       $type: 'dimension',
       $extensions: {
         'org.primer.figma': {
@@ -20,7 +20,7 @@
     },
     medium: {
       $value: {value: 6, unit: 'px'},
-      $description: 'Medium border radius (6px). The default choice for most buttons, cards, and containers',
+      $description: 'Scale token: 6px radius in the border-radius scale. Use when selecting a specific radius intentionally.',
       $type: 'dimension',
       $extensions: {
         'org.primer.figma': {
@@ -38,7 +38,7 @@
     },
     large: {
       $value: {value: 12, unit: 'px'},
-      $description: 'Large border radius (12px). Use for larger containers, dialogs, or when more visual softness is desired.',
+      $description: 'Scale token: 12px radius for larger surfaces or softer container treatments.',
       $type: 'dimension',
       $extensions: {
         'org.primer.figma': {
@@ -57,7 +57,7 @@
     full: {
       $value: {value: 9999, unit: 'px'},
       $type: 'dimension',
-      $description: 'Use this border radius for pill shaped elements',
+      $description: 'Shape token for fully rounded or pill-shaped elements.',
       $extensions: {
         'org.primer.figma': {
           collection: 'functional/size',
@@ -74,7 +74,7 @@
     },
     default: {
       $value: '{borderRadius.medium}',
-      $description: 'Default border radius for most UI elements. Alias of borderRadius.medium (6px). Use when in doubt',
+      $description: 'Semantic token: preferred default border radius for standard UI components. Use this in normal component code unless a specific radius is intentionally required.',
       $type: 'dimension',
       $extensions: {
         'org.primer.figma': {


### PR DESCRIPTION
## Summary

Updates `$description` fields for border width and border radius tokens to use consistent scale/semantic/shape token language.

### Border width (`src/tokens/functional/size/border.json5`)
- `borderWidth.thin` — Scale token: 1px border width. Use when selecting an explicit size from the border-width scale.
- `borderWidth.thick` — Scale token: 2px border width for emphasis or focus states.
- `borderWidth.thicker` — Scale token: 4px border width for strong emphasis.
- `borderWidth.default` — Semantic token: preferred default border width for standard component borders.

### Border radius (`src/tokens/functional/size/radius.json5`)
- `borderRadius.small` — Scale token: 3px radius for compact UI elements or small component variants.
- `borderRadius.medium` — Scale token: 6px radius in the border-radius scale. Use when selecting a specific radius intentionally.
- `borderRadius.large` — Scale token: 12px radius for larger surfaces or softer container treatments.
- `borderRadius.full` — Shape token for fully rounded or pill-shaped elements.
- `borderRadius.default` — Semantic token: preferred default border radius for standard UI components.