### PR TITLE
Fix formatting of storybook:install script in package.json

### DIFF
--- a/.changeset/funny-foxes-deliver.md
+++ b/.changeset/funny-foxes-deliver.md
@@ -1,0 +1,5 @@
+---
+"@primer/primitives": patch
+---
+
+Remove postinstall script from package.json

--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
     "prepack": "npm run build",
     "release": "changeset publish",
     "storybook": "npm run build:tokens && cd docs/storybook && npm run storybook",
-    "storybook:install": "cd docs/storybook && npm ci --no-audit --no-fund",
-    "postinstall": "npm run storybook:install"
+    "storybook:install": "cd docs/storybook && npm ci --no-audit --no-fund"
   },
   "prettier": "@github/prettier-config",
   "devDependencies": {


### PR DESCRIPTION
Closes #1386 

Remove the `postinstall` hook as this causes issues when using the package. This is only for local development and should not be included in the published package.