### PR TITLE
add 'Noto Sans Backtick Fix' alias to sans-serif font stacks

### DIFF
--- a/.changeset/noto-sans-backtick-fix-alias.md
+++ b/.changeset/noto-sans-backtick-fix-alias.md
@@ -2,8 +2,4 @@
 '@primer/primitives': minor
 ---
 
-Add `'Noto Sans Backtick Fix'` before `'Noto Sans'` in the `fontStack.system`, `fontStack.sansSerif`, and `fontStack.sansSerifDisplay` tokens.
-
-This is step 1 of a two-step rollout coordinated with `github/github-ui`. The `hx_browsers.scss` file in `github/github-ui` declares an `@font-face` under the family name `'Noto Sans'` that only covers `U+60` (backtick) as a workaround for a rendering bug. Per [CSS Fonts L4 §5.1](https://drafts.csswg.org/css-fonts-4/#font-face-rule), declaring an `@font-face` under `'Noto Sans'` shadows the system-installed Noto Sans for the whole page, causing body text on Linux Firefox to fall through to Helvetica/Arial/Nimbus (see [primer/css#3107](https://github.com/primer/css/issues/3107) and [github/primer#6890](https://github.com/github/primer/issues/6890)).
-
-Adding `'Noto Sans Backtick Fix'` to the stack is a no-op at runtime until `github/github-ui` renames its `@font-face` to match in step 2. Once renamed, the workaround still applies for backticks while `'Noto Sans'` resolves to the system font for the rest of the text.
+Add `'Noto Sans Backtick Fix'` before `'Noto Sans'` in `fontStack.system`, `fontStack.sansSerif`, and `fontStack.sansSerifDisplay`. The new family name is a non-shadowing alias for a consumer-defined `@font-face`, fixing body text falling through to Helvetica/Arial on Linux Firefox (see [primer/css#3107](https://github.com/primer/css/issues/3107), [github/primer#6890](https://github.com/github/primer/issues/6890)).

--- a/.changeset/noto-sans-backtick-fix-alias.md
+++ b/.changeset/noto-sans-backtick-fix-alias.md
@@ -1,0 +1,9 @@
+---
+'@primer/primitives': minor
+---
+
+Add `'Noto Sans Backtick Fix'` before `'Noto Sans'` in the `fontStack.system`, `fontStack.sansSerif`, and `fontStack.sansSerifDisplay` tokens.
+
+This is step 1 of a two-step rollout coordinated with `github/github-ui`. The `hx_browsers.scss` file in `github/github-ui` declares an `@font-face` under the family name `'Noto Sans'` that only covers `U+60` (backtick) as a workaround for a rendering bug. Per [CSS Fonts L4 §5.1](https://drafts.csswg.org/css-fonts-4/#font-face-rule), declaring an `@font-face` under `'Noto Sans'` shadows the system-installed Noto Sans for the whole page, causing body text on Linux Firefox to fall through to Helvetica/Arial/Nimbus (see [primer/css#3107](https://github.com/primer/css/issues/3107) and [github/primer#6890](https://github.com/github/primer/issues/6890)).
+
+Adding `'Noto Sans Backtick Fix'` to the stack is a no-op at runtime until `github/github-ui` renames its `@font-face` to match in step 2. Once renamed, the workaround still applies for backticks while `'Noto Sans'` resolves to the system font for the rest of the text.

--- a/src/tokens/functional/typography/font-stack.json5
+++ b/src/tokens/functional/typography/font-stack.json5
@@ -1,7 +1,7 @@
 {
   fontStack: {
     system: {
-      $value: "'Mona Sans VF', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
+      $value: "'Mona Sans VF', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans Backtick Fix', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
       $type: 'fontFamily',
       $description: 'Mona Sans–first font stack with system fallbacks, optimized for cross-platform rendering. Primary font stack for all UI text where Mona Sans is available.',
       $extensions: {
@@ -12,7 +12,7 @@
       },
     },
     sansSerif: {
-      $value: "'Mona Sans VF', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
+      $value: "'Mona Sans VF', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans Backtick Fix', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
       $type: 'fontFamily',
       $description: 'Sans-serif font stack for body text and general UI elements.',
       $extensions: {
@@ -27,7 +27,7 @@
       },
     },
     sansSerifDisplay: {
-      $value: "'Mona Sans VF', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
+      $value: "'Mona Sans VF', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans Backtick Fix', 'Noto Sans', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'",
       $type: 'fontFamily',
       $description: 'Display font stack for headings and titles. Same as sansSerif but semantically distinct.',
       $extensions: {


### PR DESCRIPTION
## Summary

Adds `'Noto Sans Backtick Fix'` before `'Noto Sans'` in `fontStack.system`, `fontStack.sansSerif`, and `fontStack.sansSerifDisplay`. This is **step 1 of a two-step rollout** with `github/github-ui` to fix body text falling through to Helvetica/Arial/Nimbus on Linux Firefox (primer/css#3107, github/primer#6890).

Root cause: `github/github-ui`'s `hx_browsers.scss` declares an `@font-face` under the family name `'Noto Sans'` that only covers `U+60` (backtick) as a workaround for a Noto Sans backtick rendering bug (github/primer#1531). Per [CSS Fonts L4 §5.1](https://drafts.csswg.org/css-fonts-4/#font-face-rule), declaring an `@font-face` under `'Noto Sans'` shadows the system-installed Noto Sans for the whole page. Every non-backtick character then falls through the stack. On macOS/Windows this is invisible because `-apple-system` / `'Segoe UI'` wins earlier. On Linux Firefox there is no earlier match, so body text lands on Helvetica/Arial/Nimbus.

The fix is to rename the `@font-face` in `hx_browsers.scss` to a non-shadowing name (`'Noto Sans Backtick Fix'`) and reference that name in the stack **before** `'Noto Sans'`. That preserves the backtick workaround while letting `'Noto Sans'` resolve to the system font. This PR ships the stack change; `github/github-ui` will ship the `@font-face` rename in step 2.


## What should reviewers focus on?

- **Rollout ordering.** This PR must merge and release **before** `github/github-ui` renames the `@font-face`. If the github-ui rename ships first, users on old Noto Sans versions would see zero-width backticks regress (github/primer#1531). At runtime, this PR is a **no-op** until step 2 lands: browsers try `'Noto Sans Backtick Fix'`, find no matching face, and skip to `'Noto Sans'` exactly as today.
- **Diff scope.** The only value changes in the compiled outputs should be `--fontStack-system`, `--fontStack-sansSerif`, `--fontStack-sansSerifDisplay` (and their equivalents in each output format, plus composite typography tokens that interpolate them). Any other diff is unexpected — please flag.

## Verification

To verify this PR resolves the underlying bug, I:

1. Deployed [github/github-ui#28664](https://github.com/github/github-ui/pull/28664), which renames the backtick-only `@font-face` in `hx_browsers.scss` from `'Noto Sans'` to `'Noto Sans Backtick Fix'`.
2. Installed this branch's `@primer/primitives` canary version, so `--fontStack-sansSerif` includes `'Noto Sans Backtick Fix'` before `'Noto Sans'`.
3. Simulated Linux font resolution by removing the macOS-specific entries (`-apple-system`, `BlinkMacSystemFont`) from the computed stack, forcing the browser past the platform fallbacks.

**Before (current production page https://github.com/):** the `'Noto Sans'` `@font-face` shadows the system Noto Sans, so every non-backtick character skips it and lands on Helvetica.

<img width="1587" height="368" alt="without fix" src="https://github.com/user-attachments/assets/baf542d1-9bf4-4439-975c-37ed89654bc4" />


**After (this PR + github-ui#28664 — fix applied):** the backtick face is now registered under `'Noto Sans Backtick Fix'`, so `'Noto Sans'` in the stack resolves to the system font and body text renders in Noto Sans as intended.

<img width="1591" height="369" alt="with fix" src="https://github.com/user-attachments/assets/ed6904c9-4c19-4dfb-a036-6b8ac3e7d1fb" />

Same page, same DOM, same computed `font-family` value — only the `@font-face` declaration and the stack alias differ.

## Related issues:

- primer/css#3107 (pending step 2 in github/github-ui)
- github/primer#6890 (pending step 2 in github/github-ui)
- Background: github/primer#1531 (original backtick `@font-face` workaround)
- Spec: [CSS Fonts L4 §5.1 — the @font-face rule](https://drafts.csswg.org/css-fonts-4/#font-face-rule)

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description